### PR TITLE
make the welcome email more semantic

### DIFF
--- a/app/views/user_mailer/welcome_email.html.erb
+++ b/app/views/user_mailer/welcome_email.html.erb
@@ -35,62 +35,39 @@
     </div>
 
     <div class="tip-wrapper">
-      <div class="tip">
-        <div class="tip-number">
-          1
-        </div>
-        <div class="tip-content">
-          <h2>
-            Plan out your strategy
-          </h2>
+      <ol class="tips">
+        <li>
+          <h2>Plan out your strategy</h2>
+
           <p>
             Figure out how much time each week you'll be able to devote to learning then browse through our <%= link_to "roadmap of courses", curriculum_url %> and plan your strategy accordingly.  The biggest issue students have is getting distracted (especially since we link to so much juicy content), so staying focused is important.
           </p>
-        </div>
-      </div>
-
-      <div class="tip">
-        <div class="tip-number">
-          2
-        </div>
-        <div class="tip-content">
+        </li>
+        <li>
           <h2>
             Dive into your first course
           </h2>
           <p>
             Get started! If you're brand spanking new to all this, start with <%= link_to @starting_lesson.title, lesson_url(@starting_lesson.course.title_url, @starting_lesson.title_url) %>.  Otherwise, <%= link_to "Web Development 101", course_url("web-development-101") %> is probably your best bet.
           </p>
-        </div>
-      </div>
-
-      <div class="tip">
-        <div class="tip-number">
-          3
-        </div>
-        <div class="tip-content">
+        </li>
+        <li>
           <h2>
             Get help and work with others
           </h2>
           <p>
             You can leave questions in the <%= link_to "forum", forum_url %>.  Join our weekly study group, which is run by other students, at <%= link_to "theodinproject.com/studygroup", studygroup_url %>.  If you fill out your <%= link_to "profile", user_url(@user) %>, it will help others who might want to get in touch with you in the meantime.
           </p>
-        </div>
-      </div>
-
-      <div class="tip">
-        <div class="tip-number">
-          4
-        </div>
-        <div class="tip-content">
+        </li>
+        <li>
           <h2>
             Tell your friends!
           </h2>
           <p>
             If you find the project helpful, please spread the word.  It's always more fun to learn with friends :)
           </p>
-        </div>
-      </div>
-    </div>
+        </li>
+      </ol>
 
     <div class="additional-questions">
       <p>
@@ -123,7 +100,7 @@
       The Odin Project is a free and open-source curriculum for learning web development.  It charts a path through existing resources on the web so anyone in the world can develop a job-ready skillset and a professional portfolio of work without the loneliness and uncertainty of working on their own.
     </p>
   </div>
-  
+
 </div>
 
 <style>
@@ -185,33 +162,18 @@
     font-style: italic;
     color: #666;
   }
-  .tip{
-    position: relative;
-    margin: 2em 0;
-    padding-left: 10px;
-  }
-  .tip-number{
-    font-size: 2em;
-    color: white;
-    font-weight: bold;
-    float: left;
-    text-align: center;
-    width: 1.25em;
-    height: 1.5em;
-    padding-top: .25em;
-    background-color: #f60;
-    /*border: 1px solid black;*/
-  }
-  .tip-content{
+
+  ol.tips li {
     margin-left: 3.5em;
     width: 460px;
     /*margin-top: 1em;*/
     padding-top: .85em;
   }
-  .tip-content h2{
+
+  ol.tips h2 {
     margin-top: 0;
   }
-  .tip-content p{
+  ol.tips p {
     font-size: 1.1em;
     color: #666;
   }


### PR DESCRIPTION
most mail agents will [strip out](http://kb.mailchimp.com/article/css-in-html-email) `<style>` tags.

Here's what the sign up email looked like via gmail ![gmail screenshot](http://screens.launchacademy.com/e35eb949c3a58415b8ce0f5fa8f19629.jpg)

For now, I made the markup a bit more semantic to make it look more attractive short term when this happens. Long term, we should swap out the `<style>` tags for inline styles. With full CSS support, it now looks like this:

![html screenshot](http://screens.launchacademy.com/b5172c5ae06e5266477e63dbdc943bed.jpg)

I'd recommend a mailer layout with inline styles and the use of a tool like [roadie](https://github.com/Mange/roadie) or [premailer](https://github.com/premailer/premailer) (my preference is premailer)
