### PR TITLE
feat(contributing): fix position problem on 'Reasons to get involved'

### DIFF
--- a/app/assets/stylesheets/static_pages.css.scss
+++ b/app/assets/stylesheets/static_pages.css.scss
@@ -526,9 +526,13 @@
 }
 
 
-.contributing{
+.contributing {
 
   @extend .individual-lesson;
+  .container {
+    // quick hack to override `position relative` inherited from .invididual-lesson
+    position: static;
+  }
 
   .star{
     padding:15px;


### PR DESCRIPTION
This fixes the issue when you navigate to `/contribute` and click on `reasons to get involved!` link.
