### PR TITLE
Added social option on navbar

### DIFF
--- a/app/assets/stylesheets/static_pages.css.scss
+++ b/app/assets/stylesheets/static_pages.css.scss
@@ -732,3 +732,55 @@
     margin: 20px 0;
   }
 }
+
+
+/* styles for the chat page */
+
+h1{
+  text-align: center;
+}
+
+
+a.chat-btn{
+  float: left;
+  width: 40%
+}
+
+
+div.chat-actions a:first-child{
+  margin-right: 3%;
+}
+
+div.chat-actions{
+  width: 100%;
+
+}
+
+/* clearfix for the buttons container */
+.clearfix:after { 
+   content: " ";
+   display: block; 
+   height: 0; 
+   clear: both;
+}
+
+@media (max-width: 640px){
+  div.chat-actions{
+  margin: 0;
+  width: 100%;
+  }
+
+  a.chat-btn{
+    float: none;
+    width: 90%;
+    margin-top: 2%;
+
+  }
+}
+
+.clearfix:after { 
+   content: " ";
+   display: block; 
+   height: 0; 
+   clear: both;
+}

--- a/app/assets/stylesheets/static_pages.css.scss
+++ b/app/assets/stylesheets/static_pages.css.scss
@@ -777,10 +777,3 @@ div.chat-actions{
 
   }
 }
-
-.clearfix:after { 
-   content: " ";
-   display: block; 
-   height: 0; 
-   clear: both;
-}

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -13,12 +13,19 @@
             <ul class="nav pull-right nav-links">
               <li class="top-link nav-search"><%= render "shared/search_box" %></li>              
               <li class="top-link"><a href="<%= curriculum_path %>">Curriculum</a></li>
+
+              <li class="dropdown">
+                <a href="#" class="dropdown-toggle" data-toggle="dropdown"> Social <b class="caret"></b></a>
+                  <ul class="dropdown-menu">
+                    <li><%= link_to "Chat", chat_path %></li>
+                    <li><%= link_to "Study Groups", studygroup_path %></li>
+                  </ul>
+
               <% if user_signed_in? %>
                 <li class="dropdown">
                   <a href="#" class="dropdown-toggle" data-toggle="dropdown"><strong><%= current_user.username %> <b class="caret"></b></strong></a>
                   <ul class="dropdown-menu">
                     <li><%= link_to "Forum", forum_path %></li>
-                    <li><%= link_to "Study Groups", studygroup_path %></li>
                     <li><%= link_to "Students", students_path %></li>
                     <li class="divider"></li>
                     <li><%= link_to "Profile", current_user %></li>

--- a/app/views/static_pages/chat.html.erb
+++ b/app/views/static_pages/chat.html.erb
@@ -1,0 +1,25 @@
+<div class="StaticPagesController">
+  <div class="container">
+    <h1>Chat</h1>
+      <p>We use <a href="https://slack.com/">slack</a> to communicate within our community. Please utilize it to meet others working through the Odin Project, get help when you are stuck, share your finished projects or just talk with other like minded individuals who are going through the same journey you are.
+
+
+      <h3> Registering for the chat </h3>
+        <ul>
+        <li>To join the chat you will need an invite, which you can get by clicking the Register button below.</li>
+        <li>Follow the instructions on the invite page.</li>
+        </ul>
+        <p>
+        That's it -- you are now part of the Odin community.
+        Introduce yourself in the #general channel and make sure to have fun!
+      </p>
+
+
+       <p><b>If you are already registered, click the "Join Chat Now" button to enter the chat rooms.<b><p>
+       <div class="chat-actions clear-fix">
+          <%= link_to "Register",  "https://odinproject.herokuapp.com", class: "btn btn-primary btn-large chat-btn"%>
+
+          <%= link_to "Join Chat Now",  "https://odinproject.slack.com", class: "btn btn-success btn-large chat-btn"%>
+      </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ devise_for :users,
   get 'tou' => "static_pages#tou"
   get 'press' => redirect('https://docs.google.com/document/d/1FmjfYvOsQ-syoOCzuvPXv96TCxeJAT9m-Wl7trgNZcE/pub')
   get 'studygroups' => "static_pages#studygroups"
+  get 'chat'=>"static_pages#chat"
 
   #failure route if github information returns invalid
   get '/auth/failure' => 'omniauth_callbacks#failure'


### PR DESCRIPTION
The current method of finding groups on odin is cumbersome as the user has to go into the account dropdown and then into study groups and then scan through the list of meet ups. It's hidden in a sense and I would bet money that some users on TOP haven't even found the list of meetups and groups because you really have to go looking for it.

A social drop down right on the navbar will be immediately visible and will be much more user friendly. with the integration of a slack chat it will make the odin project a much more social experience by bringing together everyone who is working through it.