### PR TITLE
Moved guides into docs

### DIFF
--- a/doc/linux_setup.md
+++ b/doc/linux_setup.md
@@ -1,0 +1,72 @@
+## Setup ruby
+In case you don't have the version of ruby that the TheOdinProject uses, install it with rvm:
+```
+$ rvm install ruby-2.0.0-p353
+$ rvm use ruby-2.0.0-p353
+```
+
+#### Bundler
+If you needed to install the ruby version specified previously, then you're going to need to install bundler all over again, run the following commands for that:
+```
+$ sudo apt-get install bundler
+$ gem install bundler
+$ gem install bundle
+```
+
+## Setup postgres
+Skip this is you have already installed and setup a user for postgresql.
+First, we add the repository and then install postgresql and it's dependencies:
+```
+$ sudo sh -c "echo 'deb http://apt.postgresql.org/pub/repos/apt/ precise-pgdg main' > /etc/apt/sources.list.d/pgdg.list"
+$ wget --quiet -O - http://apt.postgresql.org/pub/repos/apt/ACCC4CF8.asc | sudo apt-key add -
+$ sudo apt-get update
+$ sudo apt-get install postgresql-common
+$ sudo apt-get install postgresql-9.3 libpq-dev
+```
+Next we need to create our role, run the following:
+```
+$ sudo -u postgres createuser yourusername -s
+$ sudo -i -u postgres psql
+# Check that the user was created with:
+postgres=# \du
+# If you want to add a password to the role you created, run:
+postgres=# \password yourusername
+# Type \q to quit
+```
+
+## Gems
+Okay, first we need to install some dependencies that the gem `capybara-webkit` has and then install the actual gem(we also install the postgres gem here):
+```
+$ sudo apt-get install qt4-dev-tools libqt4-dev libqt4-core libqt4-gui
+$ gem install pg -v '0.17.1'
+$ gem install capybara-webkit -v '1.1.1'
+```
+
+Now we need to pull down TOP's repository. To do this, go ahead an `fork` [TOP](https://github.com/TheOdinProject/theodinproject.git) repository. On your terminal run:
+```
+git clone https://github.com/YOUR_USERNAME_HERE/theodinproject.git
+# Once git finishes cloning, cd into the project directory with
+cd theodinproject
+```
+With all that taken care of, run `bundle` and everything should be green.
+```
+$ bundle install
+```
+
+Once bundle finishes, go to `config/database.yml` and write your username and password(only if you added a password) of postgresql for the development and the test database(leave the production alone), next we create and migrate the database:
+```
+$ rake db:create
+$ rake db:migrate
+```
+
+Finally set up the test database
+```
+$ rake db:test:prepare
+```
+
+Get the server up and running with:
+```
+$ rails s
+```
+
+Go to your browser and voila!

--- a/doc/mac_setup.md
+++ b/doc/mac_setup.md
@@ -1,0 +1,69 @@
+**This guide assumes that you have already installed homebrew, rvm and rails after going through the installations project [here](http://www.theodinproject.com/web-development-101/installations)**
+
+##Installing Postgresql:
+before installing postgres make sure that homebrew is up to date
+```
+$ brew update
+$ brew doctor
+```
+
+Now install postgresql
+```
+$ brew install postgresql
+```
+
+Initalize a new database once brew install is finished.
+```
+$ initdb /usr/local/var/postgres
+```
+
+Install lunchy to start and stop your postgres databases easily from the command line:
+```
+$ gem install lunchy
+```
+
+The commands for starting and stopping postgresql with lunchy are:
+```
+$ lunchy start postgres
+$ lunchy stop postgres
+```
+
+create a new database for the odin project site:
+```
+$ createdb theodinproject
+```
+
+Thats it for postgresql, next we will install all of the gems that are needed.
+
+##Installing Gems and Migrating the Database
+change into the project directory
+```
+$ cd theodinproject
+```
+
+run bundle install
+```
+$ bundle install
+```
+
+If a error occurs with the capybara gem install run this command to fix:
+```
+$ brew install qt
+```
+
+Once bundle has finished installing everything its time to get the database set up.
+
+create the database and migrate it
+```
+$ rake db:create:all
+$ rake db:migrate
+```
+
+Finally create the test database
+```
+$ rake db:test:prepare
+```
+
+This will allow you to run the specs.
+
+and thats it, run ```$ rails s``` and go to localhost:3000 in your browser to test that the site is running.


### PR DESCRIPTION
This puts the guides under odin ownership instead of as gists of two different people. I also added a step to prepare the test database to both guides which was overlooked before.

Ticket for this PR:
https://trello.com/c/amDQiPhN/22-move-main-site-set-up-guides-over-to-be-odin-as-readme-s