### PR TITLE
Add threading to rake task

### DIFF
--- a/lib/tasks/curriculum.rake
+++ b/lib/tasks/curriculum.rake
@@ -14,30 +14,38 @@ namespace :curriculum do
 
     lessons = Lesson.all
     count = lessons.count
+    threads = []
+    Thread.abort_on_exception = true 
+
     puts "Cycling through #{count} lessons...\n\n\n"
+
     lessons.each_with_index do |lesson,i|
-      puts "Retrieving Lesson #{i+1}/#{count}: #{lesson.title}"
-      response = github.repos.contents.get :path => lesson.url
-      # Decode the gibberish into a real file and render to html
-      decoded_file = Base64.decode64(response["content"])
-      
-      if decoded_file 
-        snippet_end = decoded_file.index("\n")-1 || 03
-        if lesson.content == decoded_file
-          puts "    ...No new content."
+      threads << Thread.new do
+        print "<Retrieving Lesson #{i+1}/#{count}: #{lesson.title}>"
+        response = github.repos.contents.get :path => lesson.url
+        # Decode the gibberish into a real file and render to html
+        decoded_file = Base64.decode64(response["content"])
+
+        if decoded_file
+          snippet_end = decoded_file.index("\n")-1 || 03
+          if lesson.content == decoded_file
+            puts "    ...No new content."
+          else
+            puts "    Adding content: \"#{decoded_file[0..snippet_end]}\""
+            lesson.content = decoded_file
+            lesson.save!
+            # puts "Added content to the lesson..."
+          end
+          puts
         else
-          puts "    Adding content: \"#{decoded_file[0..snippet_end]}\""
-          lesson.content = decoded_file
-          lesson.save!
-          # puts "Added content to the lesson..."
+          puts "\n\n\n\n\n\n FAILED TO ADD CONTENT TO THE LESSON!!!\n\n\n\n\n\n"
+          raise "Failed to add content to the lesson (tried to add `nil`)!"
         end
-        puts
-      else
-        puts "\n\n\n\n\n\n FAILED TO ADD CONTENT TO THE LESSON!!!\n\n\n\n\n\n"
-        raise "Failed to add content to the lesson (tried to add `nil`)!"
       end
     end
-    
+
+    threads.map(&:join)
+
     puts "\nChecking for any nils or blanks in the database"
     Lesson.all.each do |l|
       print "."


### PR DESCRIPTION
There is a bug for me where the same lessons are being updated even when it has not changed. It is really weird...

Anyway this will significantly reduce the time it takes to update content however there are a few caveats you should be aware of 

1. I tried lowering number of threads but database error is thrown
2. Occasionally errors will be thrown but rerunning rake task usually solves it
3. Output is well.. ugly lol

In my opinion I would be tentative to add this into production but I use it in my development environment.

