### PR TITLE
Redirect if a non-existent user is being searched

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,16 +5,11 @@ class UsersController < ApplicationController
   before_action :check_current_user, :only => [:edit, :update]
 
   def show
-    handle_nil_user if @user.nil?
   end
 
   def edit
-    if @user
-      @edit = true
-      render :show
-    else
-      handle_nil_user
-    end
+    @edit = true
+    render :show
   end
 
   # NOTE: This is actually done by Devise's RegistrationsController
@@ -76,11 +71,10 @@ class UsersController < ApplicationController
 
   private
     def set_user
-      @user = User.find_by_id(params[:id])
-    end
-
-    def handle_nil_user
-      flash[:error] = "There was no user by that name"
-      redirect_to :back
+      begin
+        @user = User.find(params[:id])
+      rescue ActiveRecord::RecordNotFound
+        redirect_to root_url, :flash => {error: "Invalid user ID"}
+      end
     end
 end

--- a/app/helpers/bootstrap_flash_helper.rb
+++ b/app/helpers/bootstrap_flash_helper.rb
@@ -7,8 +7,9 @@ module BootstrapFlashHelper
     flash.each do |type, message|
       # Skip empty messages, e.g. for devise messages set to nothing in a locale file.
       next if message.blank?
-      type = :success if type.to_sym == :notice
-      type = :error   if type.to_sym == :alert
+      type = type.to_sym
+      type = :success if type == :notice
+      type = :error   if type == :alert
       next unless ALERT_TYPES.include?(type)
       Array(message).each do |msg|
         text = content_tag(:div,

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -46,6 +46,12 @@ describe UsersController do
       assert_response 200
     end
 
+    it "GET #show with invalid id is redirected" do
+      get :show, :id => "invalid"
+      expect(response).to redirect_to root_url
+      expect(flash[:error]).to eql("Invalid user ID")
+    end
+
     describe "messing with other users' things" do
 
       it "GET #edit is unauthorized" do


### PR DESCRIPTION
Fixes #166 

## Steps done
- Remove the `handle_nil_user` method
- Rescue the exception in `set_user` method and redirect the user to `users_url`
- Add tests to check the behaviour of GET users#show with a controller spec
- Refactor the code in `bootstrap_help` method