### PR TITLE
refactored admin flash helper

### DIFF
--- a/app/helpers/admin_flash_helper.rb
+++ b/app/helpers/admin_flash_helper.rb
@@ -7,6 +7,6 @@ module AdminFlashHelper
   private
 
   def admin_flash_cookies
-    cookies.map { |name, _| name.match(/admin_flash_(\d*)/) }.compact
+    cookies.map { |name, _| name.match(/admin_flash_(\d+)/) }.compact
   end
 end

--- a/app/helpers/admin_flash_helper.rb
+++ b/app/helpers/admin_flash_helper.rb
@@ -1,13 +1,12 @@
 module AdminFlashHelper
-  
+
   def disabled_flash_ids_from_cookies
-    disabled_flash_ids = []
-    cookies.each do |name,value| 
-      match = name.match(/admin_flash_(\d*)/)
-      if match 
-        disabled_flash_ids << match[1].to_i
-      end  
-    end
-    disabled_flash_ids
+    admin_flash_cookies.map { |cookie| cookie[1].to_i }
+  end
+
+  private
+
+  def admin_flash_cookies
+    cookies.map { |name, _| name.match(/admin_flash_(\d*)/) }.compact
   end
 end

--- a/spec/helpers/admin_flash_helper_spec.rb
+++ b/spec/helpers/admin_flash_helper_spec.rb
@@ -2,18 +2,17 @@ require 'rails_helper'
 
 describe AdminFlashHelper do
 
-  describe "#disabled_flash_ids_from_cookies" do
+  describe '#disabled_flash_ids_from_cookies' do
+    let(:cookies) {
+      {
+        'admin_flash_10' => 'disabled',
+        'admin_flash_20' => 'disabled',
+        'not_a_flash_15' => 'disabled',
+      }
+    }
 
-    let(:cookies){ {"admin_flash_10" => "disabled","admin_flash_20"=>"disabled","not_a_flash_15"=>"disabled"} }
-
-    it "should grab the flash IDs" do
-      expect(disabled_flash_ids_from_cookies).to include(10)
+    it 'returns the disabled flash ids' do
+      expect(disabled_flash_ids_from_cookies).to eql([10, 20])
     end
-
-    it "should NOT grab an improperly formatted flash ID" do
-      expect(disabled_flash_ids_from_cookies).not_to include(15)
-    end
-
   end
-
 end

--- a/spec/helpers/admin_flash_helper_spec.rb
+++ b/spec/helpers/admin_flash_helper_spec.rb
@@ -8,6 +8,7 @@ describe AdminFlashHelper do
         'admin_flash_10' => 'disabled',
         'admin_flash_20' => 'disabled',
         'not_a_flash_15' => 'disabled',
+        'admin_flash_' => 'disabled',
       }
     }
 


### PR DESCRIPTION
This is a refactor of the admin flash helper, It cleans up the long `disabled_flash_ids_from_cookies`method and the unit tests for this helper.

Fixes https://github.com/TheOdinProject/theodinproject/issues/218
