### PR TITLE
Fix chat link on Contributing page

### DIFF
--- a/app/views/static_pages/contributing.html.erb
+++ b/app/views/static_pages/contributing.html.erb
@@ -31,7 +31,7 @@
         Instructions on setting up your local development environment can be found in the <a href="https://github.com/TheOdinProject/theodinproject">GitHub repo</a>.
       </p>
       <p>
-        <em>NOTE: When choosing an issue to work on, please check out the <strong>#contributing</strong> channel on <a href'https://gitter.im/TheOdinProject/Contributing'>our Gitter chat</a>, and let everyone know what you are working on.  This is important, as somebody else may have already done some work on the issue - in which case they would probably love to have your help!</em>
+        <em>NOTE: When choosing an issue to work on, please check out the <strong>#contributing</strong> channel on <a href="https://gitter.im/TheOdinProject/Contributing">our Gitter chat</a>, and let everyone know what you are working on.  This is important, as somebody else may have already done some work on the issue - in which case they would probably love to have your help!</em>
       </p>
 
       <h3>Reasons to get involved</h3>
@@ -43,7 +43,7 @@
         </p>
         <ul>
           <li>
-            <span class='highlight'>Flexibility--</span>
+            <span class="highlight">Flexibility--</span>
             You can work on your own time. It's not 9 to 5 so you can get involved when it's convenient for you.</li>
           <li>
             <span class="highlight">Exposure--</span>


### PR DESCRIPTION
I noticed the link to the Gitter chat on the Contributing page wasn't working so I just made a quick fix.