### PR TITLE
Fix progress bar circles appearing on top of other elements

### DIFF
--- a/app/assets/stylesheets/lessons.scss
+++ b/app/assets/stylesheets/lessons.scss
@@ -441,7 +441,7 @@
     text-align: center;
     font-size: 10px;
     color: $mid_gray;
-    z-index: 100;
+    z-index: 1;
     &:hover{
       background-color: white!important;
       border-width: 6px;
@@ -507,7 +507,7 @@
     font-size: 10px;
     color: $mid_gray;
     background-color: white;
-    z-index: 100;
+    z-index: 1;
     &:hover{
       background-color: white!important;
       border-width: 6px;


### PR DESCRIPTION
Fix lc-end-circle and lc-active-circle appearing on top of breadcrumbs and scroll-effect-alert.