### PR TITLE
Update progress bar

### DIFF
--- a/app/views/lesson_completions/create.js.erb
+++ b/app/views/lesson_completions/create.js.erb
@@ -1,6 +1,9 @@
 // If it's an individual lesson page, this will run
 $(".lc-end-wrapper").html("<%= escape_javascript(render("shared/complete_lesson.html.erb"))%>");
 
+// Update progress tracking bar
+$('#lc-progress-bar').html("<%= j(render('shared/pt_bar', lesson: @lesson)) %>");
+
 // update checkmarks on individual lesson pages
 if(<%= current_user.completed_lesson?(@lesson) %>){
   $(".lc-completion-indicator").removeClass("hidden");

--- a/features/lesson_completion.feature
+++ b/features/lesson_completion.feature
@@ -16,7 +16,7 @@ Background: Adding data to the database
   | The Best Web Developers |
 
 @javascript
-Scenario: Marking a lesson complete
+Scenario: Marking a lesson complete from the course page
   Given I am logged in
   And I go to the 'Introduction to Web Development' course
   And no lessons are completed
@@ -24,7 +24,7 @@ Scenario: Marking a lesson complete
   Then my progress should be saved
   
 @javascript
-Scenario: Marking a lesson incomplete
+Scenario: Marking a lesson incomplete from the course page
   Given I am logged in
   And I go to the 'Introduction to Web Development' course
   And the lesson 'What a web developer does' is completed
@@ -32,10 +32,21 @@ Scenario: Marking a lesson incomplete
   Then my progress should be declined
 
 @javascript
-Scenario: Marking all the lessons complete
+Scenario: Marking all the lessons complete from the course page
   Given I am logged in
   And I go to the 'Introduction to Web Development' course
   When I mark all the lessons as completed
   Then I should see 'Course Completed!' in the progress bar
   When I go back
   Then I should find the course 'Introduction to Web Development' completed
+  
+@javascript
+Scenario: Marking a lesson complete from the lesson page
+  Given I am logged in
+  And I am in the 'Introduction to Web Development' course page
+  And I go to the 'What a web developer does' lesson page
+  And the lesson is not completed
+  When I click the Mark lesson complete link
+  Then I should see my progress updated
+  When I go to the 'Introduction to Web Development' course page
+  Then I should find the lesson 'What a web developer does' completed

--- a/features/step_definitions/lesson_steps.rb
+++ b/features/step_definitions/lesson_steps.rb
@@ -41,11 +41,21 @@ Given /^no lessons are completed$/ do
   end
 end
 
-And /^the lesson '([^']+)' is completed$/ do |lesson_title|
+Given /^the lesson '([^']+)' is completed$/ do |lesson_title|
   lesson = Lesson.find_by(title: lesson_title)
   within "#lc-id-#{lesson.id}" do
     click_link 'Check to mark lesson completed'
   end
+end
+
+Given(/^the lesson is not completed$/) do
+  puts page.current_path
+  within '.individual-lesson' do
+    expect(page.to have_css('.lc-completion-indicator.hidden'))
+  end
+  puts page.body
+  expect(page).to have_css('.checkbox-container.lc-unchecked')
+  expect(page).not_to have_css('.lc-uncomplete-link')
 end
 
 When /^I mark the lesson '([^']+)'$/ do |lesson_title|
@@ -72,9 +82,13 @@ When /^I go back$/ do
   visit '/courses'
 end
 
+When /^I click the Mark lesson complete link$/ do 
+  click_link '.checkbox-container.lc-unchecked'
+end
+
 Then /^my progress should be saved$/ do
   within "#lc-id-#{@lesson.id}" do
-    expect(page.has_selector? 'a.lc-checkbox.lc-checked').to be true
+    expect(page).to have_css('a.lc-checkbox.lc-checked')
   end
 
   # make sure the percentage completion gets increased
@@ -86,7 +100,7 @@ end
 
 Then /^my progress should be declined$/ do
   within "#lc-id-#{@lesson.id}" do
-    expect(page.has_selector? 'a.lc-checkbox.lc-unchecked').to be true
+    expect(page).to have_css('a.lc-checkbox.lc-unchecked')
   end
 
   # make sure the percentage completion gets increased
@@ -107,7 +121,7 @@ Then /^I should find the course '([^']+)' completed$/ do |course_title|
   selector = ".course-title a[href='/courses/#{course_url_href}']"
 
   within selector do
-    expect(page.has_selector? '.cc-completion-indicator').to be true
-    expect(page.has_selector? '.cc-completion-indicator.hidden').to be false
+    expect(page).to have_css('.cc-completion-indicator')
+    expect(page).not_to have_css('.cc-completion-indicator.hidden')
   end
 end


### PR DESCRIPTION
Fixes #239 
Updates progress bar at the top of the lesson page when it is marked complete or incomplete