### PR TITLE
Exclude migration files from reek

### DIFF
--- a/config.reek
+++ b/config.reek
@@ -1,2 +1,4 @@
 IrresponsibleModule:
   enabled: false
+exclude_paths:
+  - db/migrate


### PR DESCRIPTION
This removes the migration files from being evaluated by reek.