### PR TITLE
added a max-height and scrollbars to student solutions

### DIFF
--- a/app/assets/stylesheets/lessons.scss
+++ b/app/assets/stylesheets/lessons.scss
@@ -4,7 +4,6 @@
 @import "colors";
 @import "mixins";
 
-
 .individual-lesson{
   /* User styles */
   font-size: 1.25em;
@@ -14,7 +13,6 @@
     -moz-appearance: none;
     -webkit-appearance: none;
   }
-
 
   p{
     margin-bottom: 1.2em;
@@ -41,7 +39,6 @@
   ol>li{
     margin: .5em 0;
   }
-  
   ul {
     width: 100%;
     max-height: 600px;
@@ -50,7 +47,6 @@
     text-indent: -2em;
     list-style-position: inside;
   }
-  
   li > ol, li > ul{
     margin-top: 1em;
     margin-bottom: 1em;

--- a/app/assets/stylesheets/lessons.scss
+++ b/app/assets/stylesheets/lessons.scss
@@ -4,6 +4,7 @@
 @import "colors";
 @import "mixins";
 
+
 .individual-lesson{
   /* User styles */
   font-size: 1.25em;
@@ -13,6 +14,7 @@
     -moz-appearance: none;
     -webkit-appearance: none;
   }
+
 
   p{
     margin-bottom: 1.2em;
@@ -39,6 +41,16 @@
   ol>li{
     margin: .5em 0;
   }
+  
+  ul {
+    width: 100%;
+    max-height: 600px;
+    overflow: auto;
+    padding-left: 2em;
+    text-indent: -2em;
+    list-style-position: inside;
+  }
+  
   li > ol, li > ul{
     margin-top: 1em;
     margin-bottom: 1em;


### PR DESCRIPTION
All I've done is add a bit of css to all `ul`s on the main lesson content on lesson pages.  Doing it this way has the downside of potentially adding a scrollbar to other ul's on the lesson pages... but on the few I looked at this didn't happen.  Most lists on the lessons are `ol`s.
The other downside is that I can't _really_ add any other styling (a border might be nice) to the solutions box because it would effect the main content of the lesson

Doing it this way has the upside of being very simple... the alternative is adding html markup to the lesson pages which could be a big pain and hard to maintain.  I'm not opposed to doing it, but this way is much simpler to implement, at least initially.

I've attached a screenshot of what the change looks like on _my_ system.. but note that the scrollbars will look different on different computers.

![1_022](https://cloud.githubusercontent.com/assets/18574792/19736225/04d78b00-9b74-11e6-9739-afaffe703bec.png)
