### PR TITLE
Update CodeBuddies link in studygroups page.

### DIFF
--- a/app/views/static_pages/studygroups.html.erb
+++ b/app/views/static_pages/studygroups.html.erb
@@ -24,7 +24,7 @@
           <a href="http://www.meetup.com/Learn-Web-Development/">Our new Meetup group</a> <em>for virtual study groups</em>
         </li>
          <li>
-          <a href="http://bit.ly/1Jt1L1M">CodeBuddies' The Odin Project Study Group - remote study sessions that anyone can schedule</a> <em>Virtual on Google Hangouts with video (and sometimes audio) turned off</em>
+          <a href="https://codebuddies.org/">CodeBuddies - remote study sessions that anyone can schedule</a> <em>Virtual on Google Hangouts with video (and sometimes audio) turned off</em>
         </li>
         <li>
           <em>Add yours here!</em>


### PR DESCRIPTION
I noticed that bit.ly link was pointing to the old CodeBuddies site. I just updated the link to go to the homepage.