### PR TITLE
made scrollbar only appear on the solutions list

### DIFF
--- a/app/assets/stylesheets/lessons.scss
+++ b/app/assets/stylesheets/lessons.scss
@@ -39,7 +39,7 @@
   ol>li{
     margin: .5em 0;
   }
-  ul {
+  ul:nth-last-of-type(2) {
     width: 100%;
     max-height: 600px;
     overflow: auto;


### PR DESCRIPTION
as you can see.. this targets the second-to-last ul only.  this should clean up the subtle problems with other lists getting targeted.

this fix depends on "Additional Resources" being a ul, and being after the solution list... which is a situation that doesn't make me very happy, but ideally this whole thing is just a temporary hack to get us by until the redesign.