### PR TITLE
Fix #lesson-nav appearing on top of scroll down menu

### DIFF
--- a/app/assets/stylesheets/lessons.scss
+++ b/app/assets/stylesheets/lessons.scss
@@ -682,7 +682,7 @@
 @media (max-width: 979px) {
   #lesson-nav{
     position: absolute;
-    z-index: 0;
+    z-index: -1;
     margin-top:10px;
   }
 }


### PR DESCRIPTION
On small screens #lesson-nav appears on top of the scroll down menu.