### PR TITLE
Complete redesign requests for success stories page

### DIFF
--- a/app/assets/stylesheets/components/success_stories.scss
+++ b/app/assets/stylesheets/components/success_stories.scss
@@ -99,6 +99,7 @@
     min-height: 400px;
     margin: 0 auto;
     margin-top: 100px;
+    margin-bottom: 6em;
     display: flex;
     flex-wrap: wrap;
     }
@@ -134,8 +135,12 @@
           }
         }
 
-        .success-content {
-          flex: 1
+        .success-content-full {
+          flex: 1;
+
+          .student-name {
+            margin-bottom: 20px;
+          }
         }
     }
 
@@ -149,13 +154,13 @@
   }
 
   .success-stories-sign-up {
-    margin-top: 50px;
     font-size: 2.2em;
     font-weight: light;
     width: 100%;
     text-align: center;
     letter-spacing: 0.4px;
     color: rgba(74, 74, 74, 0.7);
+    margin-bottom: 3.6em;
 
     .signup-button {
       text-decoration: none;

--- a/app/assets/stylesheets/components/success_stories.scss
+++ b/app/assets/stylesheets/components/success_stories.scss
@@ -97,9 +97,7 @@
     color: $text-primary;
     max-width: 1280px;
     min-height: 400px;
-    margin: 0 auto;
-    margin-top: 100px;
-    margin-bottom: 6em;
+    margin: 100px auto 6em;
     display: flex;
     flex-wrap: wrap;
     }

--- a/app/views/static_pages/success_stories.html.erb
+++ b/app/views/static_pages/success_stories.html.erb
@@ -17,7 +17,7 @@
       <div class="success-story-full">
         <div class="photo"> <%= image_tag story[:student_avatar_url] %></div>
         <div class="success-content-full">
-          <p><%= story[:student_name] %></p>
+          <p class="student-name"><%= story[:student_name] %></p>
           <p><%= story[:story_content] %></p>
         </div>
         <div class="completed-course">


### PR DESCRIPTION
#418 Redesign: Success Stories Page

CHANGES:
- Removed margin-top from class .success-stories-sign-up.
- Added `margin-bottom: 6em;` to .success-stories-page .success-stories-container. NOTE: I did not add the margin-bottom to the .success-stories-container embedded in .success-stories, only the one embedded in .success-stories-page.
- Added `margin-bottom: 3.6em;` to .success-stories-page .success-stories-sign-up to increase the spacing between the "Sign Up" button and the footer matching the spacing between the container and the "Start learning for free now" text.
- The p tag enclosing the student's name now has the class `student-name`. That class has `margin-bottom: 20px;`.

FIXES:
- Class `.success-content-full` was in the CSS but referred to as `.success-content` in the view. I changed the class in the view to `.success-content-full`.
- The CSS for `.success-content-full` was missing a semicolon. I threw it in there.