### PR TITLE
Remove click event listener

### DIFF
--- a/app/assets/javascripts/navbar.js
+++ b/app/assets/javascripts/navbar.js
@@ -10,15 +10,4 @@ document.addEventListener('DOMContentLoaded', function() {
     logoImg.classList.toggle('expanded')
     logo.classList.toggle('expanded')
   })
-
-  // Collapses the navbar if a click is made outside it
-  document.addEventListener('click', function(event) {
-    var navbar = document.querySelector('.navbar-collapse')
-    var collapseButton = document.querySelector('.navbar-toggler-icon + .close')
-
-    var navbarOpened = navbar.classList.contains('show')
-    var linkClicked = event.target.tagName.toLowerCase() === 'a'
-
-    if (navbarOpened && !linkClicked) collapseButton.click()
-  })
 })


### PR DESCRIPTION
Since we have a full-screen navbar implemented, there is no need to watch for a click event to collapse the navbar if the click was made outside the navbar.