### PR TITLE
Fix mobile responsive bug

### DIFF
--- a/app/assets/stylesheets/components/login_page.scss
+++ b/app/assets/stylesheets/components/login_page.scss
@@ -3,20 +3,21 @@
   overflow: hidden;
 
   .card {
-    width: 435px;
+    max-width: 435px;
+    width: 100%;
     @include box-shadow(0 2px 4px 0 rgba(0, 0, 0, 0.3));
     padding: 50px 55px;
     margin: 75px auto 0 auto;
   }
   .login {
-    width: 323px;
+    width: 100%;
     background-color: $pale-grey-bg;
     font-family: $body-fonts;
   }
 
   .email, .password, .user_username {
+    width: 100%;
     height: 54.3px;
-    margin-left: -30px;
     padding-left: 60px;
     margin-bottom: 20px;
     border: none;
@@ -24,6 +25,9 @@
     line-height: 1.88;
     letter-spacing: 0.2px;
     color: $pale-grey;
+    .controls {
+      margin-left: -60px;
+    }
   }
 
   .input-group .fa-user {
@@ -72,7 +76,8 @@
   }
 
   .page-buttons {
-    width: 325px;
+    width: 100%;
+    max-width: 325px;
     height: 60.4px;
     border-radius: 3px;
     box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.5);
@@ -123,7 +128,8 @@
 
   .sign-up-button {
     display: block;
-    width: 234px;
+    width: 100%;
+    max-width: 234px;
     font-size: 18px;
     font-weight: bold;
     letter-spacing: 0.2px;

--- a/app/assets/stylesheets/global.scss
+++ b/app/assets/stylesheets/global.scss
@@ -1,6 +1,7 @@
 html {
   height: 100%;
   font-size: 100%;
+  overflow-x: hidden;
 }
 
 body {


### PR DESCRIPTION
Not sure if it closes #505 

Was not able to replicate the resizing of icons, but I did find that a right whitespace on mobile when you scrolled right, this was displaying for all the pages, This keeps the page in view only. Also noticed both signup card and login card was offset from view, instead of giving the various buttons and fields strict widths, this allows for good responsiveness.

![](https://media.giphy.com/media/13XW2MJE0XCoM0/giphy.gif)