### PR TITLE
Redirect signed in users to the dashboard

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,11 +23,8 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_in_path_for(_resource)
-    if current_user.confirmed_at.nil?
-      flash[:warning] = render_to_string partial: 'layouts/confirm_email'
-    end
-
-    after_sign_in_redirect_path
+    set_confirm_email_flash unless current_user.confirmed?
+    dashboard_path
   end
 
   def not_found_error
@@ -35,6 +32,10 @@ class ApplicationController < ActionController::Base
   end
 
   private
+
+  def set_confirm_email_flash
+    flash[:warning] = render_to_string partial: 'layouts/confirm_email'
+  end
 
   def configure_permitted_parameters
     devise_parameter_sanitizer

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -5,10 +5,6 @@ class RegistrationsController < Devise::RegistrationsController
     dashboard_path
   end
 
-  def after_update_path_for(_resource)
-    courses_path
-  end
-
   def update_resource(resource, params)
     if current_user.provider == 'github'
       params.delete('current_password')

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -2,7 +2,7 @@ class RegistrationsController < Devise::RegistrationsController
   private
 
   def after_sign_up_path_for(_resource)
-    session[:previous_url] || courses_path(ref: 'signup', newuser: 'true')
+    dashboard_path
   end
 
   def after_update_path_for(_resource)

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,4 +1,6 @@
 class StaticPagesController < ApplicationController
+  before_action :redirect_if_logged_in, only: :home
+
   def home
     @navbar = false
     @is_home_page = true
@@ -39,6 +41,10 @@ class StaticPagesController < ApplicationController
   end
 
   private
+
+  def redirect_if_logged_in
+    redirect_to dashboard_path if current_user
+  end
 
   def user_identifier
     current_user_email || 'Anonymous'

--- a/app/views/layouts/_confirm_email.html.erb
+++ b/app/views/layouts/_confirm_email.html.erb
@@ -1,2 +1,2 @@
-<p> Please confirm your email address.  </p> <br>
+<p class="mb-1"> Please confirm your email address.</p>
 <%= link_to "Didn't receive confirmation instructions, or need them again?", confirm_email_path %>

--- a/spec/controllers/static_pages_controller_spec.rb
+++ b/spec/controllers/static_pages_controller_spec.rb
@@ -2,9 +2,28 @@ require 'rails_helper'
 
 RSpec.describe StaticPagesController do
   describe 'GET home' do
-    it 'renders the home page' do
-      get :home
-      expect(response).to render_template(:home)
+    context 'guest user' do
+      before do
+        allow(controller).to receive(:current_user).and_return(nil)
+      end
+
+      it 'renders the home page' do
+        get :home
+        expect(response).to render_template(:home)
+      end
+    end
+
+    context 'signed in user' do
+      let(:user) { double('User') }
+
+      before do
+        allow(controller).to receive(:current_user).and_return(user)
+      end
+
+      it 'redirects to the dashboard' do
+        get :home
+        expect(response).to redirect_to(dashboard_path)
+      end
     end
 
     it 'assigns @navbar' do


### PR DESCRIPTION
I didn't modify the `after_update_path_for` method because we're using `best_in_place` to perform in-place edits. Do we need that method? Is it fine to remove the `after_update_path_for` method?

/cc @KevinMulhern 