### PR TITLE
Update connect text on the home page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -147,7 +147,7 @@ module ApplicationHelper
       {
         image: 'img-connect.svg',
         subtitle: 'Connect',
-        description: 'You’re not alone. Learn together by pairing up on projects with other students.'
+        description: 'You’re not alone. Learn and get help from our friendly community.'
       }
     ]
   end


### PR DESCRIPTION
This small change updates the connect text on the how it works section of the homepage to focus on the community instead of pairing.