### PR TITLE
Change lesson headings

### DIFF
--- a/app/assets/stylesheets/lessons.scss
+++ b/app/assets/stylesheets/lessons.scss
@@ -24,6 +24,10 @@
     margin-bottom: 1em;
   }
 
+  h2 {
+    text-align: center;
+  }
+
   h2, h3, h4, h5{
     margin-top: 1.5em;
   }

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -32,6 +32,7 @@
       </h3>
     <% end %>
 
+    <h2><%= @lesson.title %></h2>
     <%= convert_markdown_to_html(@lesson.content) %>
 
     <%= render partial: 'chat_link' %>


### PR DESCRIPTION
This changes the lesson title to a h2 and puts it in the lesson view instead of getting it from the lesson content on the curriculum. This will be merged when the lessons on the curriculum are amended to remove the title