### PR TITLE
Update users avatar

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -4,6 +4,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   def github
     @user = User.from_omniauth(auth)
+    update_users_avatar if avatar_needs_updated?
 
     if @user.persisted?
       sign_in_and_redirect @user, :event => :authentication
@@ -23,6 +24,18 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   private
+
+  def update_users_avatar
+    @user.update_avatar(github_avatar)
+  end
+
+  def avatar_needs_updated?
+    github_avatar != @user.avatar
+  end
+
+  def github_avatar
+    @github_avatar ||= auth.info.image
+  end
 
   def auth
     request.env['omniauth.auth']

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,8 +40,7 @@ class User < ApplicationRecord
   end
 
   def image(size = 25)
-    #Could use GravatarUrlBuilder and users_helper
-    self.avatar ? self.avatar : "http://www.gravatar.com/avatar/436053b3e050d4156773bc04cfb167fe?s=#{size}"
+    avatar || default_image(size)
   end
 
   def self.from_omniauth(auth)
@@ -53,6 +52,10 @@ class User < ApplicationRecord
       user.avatar = auth.info.image
       user.skip_confirmation!
     end
+  end
+
+  def update_avatar(github_avatar)
+    self.update!(avatar: github_avatar)
   end
 
   def add_omniauth(auth)
@@ -73,6 +76,10 @@ class User < ApplicationRecord
   end
 
   private
+
+  def default_image(size)
+    "http://www.gravatar.com/avatar/436053b3e050d4156773bc04cfb167fe?s=#{size}"
+  end
 
   def ordered_lesson_completions
     lesson_completions.order(created_at: :asc)

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -81,7 +81,8 @@ Before('@omniauth_test') do
     uid: '123545',
     info: {
       name: 'kevin',
-      email: 'kevin@example.com'
+      email: 'kevin@example.com',
+      image: 'http://github.com/fake-avatar'
     }
   )
 

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe OmniauthCallbacksController, type: :controller do
   end
 
   describe 'GET #github' do
-    it 'redirects the user to some page' do
+    it 'redirects the user to the dashboard page' do
       get :github
       expect(response).to redirect_to(dashboard_path)
     end
@@ -54,6 +54,22 @@ RSpec.describe OmniauthCallbacksController, type: :controller do
       it 'redirects to the courses path' do
         get :github
         expect(response).to redirect_to(dashboard_path)
+      end
+
+      context 'and its a legacy user' do
+        let(:user) {
+          FactoryGirl.create(
+            :user,
+            username: 'John',
+            email: 'john@example.com',
+            avatar: nil
+          )
+        }
+
+        it 'sets the users avatar' do
+          expect(user).to receive(:update_avatar).with('http://github.com/fake-avatar')
+          get :github
+        end
       end
     end
 

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -10,6 +10,7 @@ FactoryGirl.define do
     password 'foobar'
     legal_agreement true
     confirmed_at Time.now - 5_000_000
+    avatar 'http://github.com/fake-avatar'
 
     factory :admin do
       admin true

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,10 +8,12 @@ RSpec.describe User do
       legal_agreement: 'true',
       password: 'foobar',
       provider: provider,
-      uid: ''
+      uid: '',
+      avatar: avatar
     )
   }
   let(:provider) { '' }
+  let(:avatar) { 'http://github.com/fake-avatar' }
 
   let(:lesson_completions) {
     [first_lesson_completion, second_lesson_completion]
@@ -108,6 +110,21 @@ RSpec.describe User do
     end
   end
 
+  describe '#image' do
+    it 'returns the users avatar' do
+      expect(user.image).to eql('http://github.com/fake-avatar')
+    end
+
+    context 'when the user does not have an avatar' do
+      let(:avatar) { nil }
+      let(:gravatar) { 'http://www.gravatar.com/avatar/436053b3e050d4156773bc04cfb167fe?s=25' }
+
+      it 'returns the users avatar' do
+        expect(user.image).to eql(gravatar)
+      end
+    end
+  end
+
   describe '.from_omniauth' do
     let(:user) {
       FactoryGirl.create(
@@ -141,7 +158,8 @@ RSpec.describe User do
       double(
         'OmniAuth::AuthHash::InfoHash',
         name: 'kevin',
-        email: 'kevin@example.com'
+        email: 'kevin@example.com',
+        image: 'http://github.com/fake-avatar'
       )
     }
 
@@ -157,6 +175,16 @@ RSpec.describe User do
 
     it 'returns the user' do
       expect(User.from_omniauth(auth)).to eql(user)
+    end
+  end
+
+  describe '#update_avatar' do
+    let(:github_avatar) { 'http://github.com/fake-avatar' }
+    let(:avatar) { nil }
+
+    it 'updates the users avatar' do
+      user.update_avatar(github_avatar)
+      expect(user.avatar).to eql('http://github.com/fake-avatar')
     end
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -71,7 +71,10 @@ RSpec.configure do |config|
   OmniAuth.config.test_mode = true
   OmniAuth.config.mock_auth[:github] = OmniAuth::AuthHash.new(
     provider: 'github',
-    uid: '123'
+    uid: '123',
+    info: {
+      image: 'http://github.com/fake-avatar'
+    }
   )
 
   config.include(Shoulda::Matchers::ActiveModel, type: :model)


### PR DESCRIPTION
This feature serves two purposes:

1. It will set the  avatars of users who have signed up with github before the avatar feature was introduced
2. If the user changes their avatar on github, they just need to sign in to Odin again to update it on our site