### PR TITLE
Removed estimated completion date from the user table

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -32,7 +32,6 @@ class UsersController < ApplicationController
         :github,
         :google_plus,
         :learning_goal,
-        :learning_goal_completion_date,
         :uid,
         :provider,
       )

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,14 +10,6 @@ class User < ApplicationRecord
   has_many :completed_lessons, through: :lesson_completions, source: :lesson
   has_many :projects
 
-  def format_completion_date
-    if learning_goal_completion_date
-      learning_goal_completion_date.strftime('%B %Y')
-    else
-      'Click here to set a date!'
-    end
-  end
-
   def completion_status(lesson)
     has_completed?(lesson) ? 'Completed' : 'Incomplete'
   end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -25,10 +25,6 @@
         <div class="goal">
           <%= best_in_place @user, :learning_goal, as: :input, place_holder: "Click me to set a learning goal!"%>
         </div>
-        <div class="spacer"></div>
-        <div class="completion-date">
-          Estimated Completion date: <%= best_in_place @user, :learning_goal_completion_date, as: :date, display_as: :format_completion_date %>
-        </div>
       </div>
     </div>
     <div class="password-card settings-section">

--- a/app/views/users/_profile_card.html.erb
+++ b/app/views/users/_profile_card.html.erb
@@ -20,11 +20,6 @@
                 <%= user.learning_goal || 'Not Specified' %>
               </p>
             </div>
-
-            <p class="completion-date small">
-              Estimated Completion Date:
-              <%= user.learning_goal_completion_date&.strftime('%b %Y') || 'Not Specified' %>
-            </p>
           </div>
         </div>
       </div>

--- a/db/migrate/20170629181228_remove_estimated_completion_date.rb
+++ b/db/migrate/20170629181228_remove_estimated_completion_date.rb
@@ -1,0 +1,5 @@
+class RemoveEstimatedCompletionDate < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :users, :learning_goal_completion_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170615185649) do
+ActiveRecord::Schema.define(version: 20170629181228) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -121,12 +121,12 @@ ActiveRecord::Schema.define(version: 20170615185649) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                         default: "",    null: false
-    t.string   "encrypted_password",            default: "",    null: false
+    t.string   "email",                  default: "",    null: false
+    t.string   "encrypted_password",     default: "",    null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",                 default: 0
+    t.integer  "sign_in_count",          default: 0
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
@@ -142,7 +142,7 @@ ActiveRecord::Schema.define(version: 20170615185649) do
     t.string   "google_plus"
     t.string   "skype"
     t.string   "screenhero"
-    t.boolean  "legal_agreement",               default: false, null: false
+    t.boolean  "legal_agreement",        default: false, null: false
     t.datetime "legal_agree_date"
     t.string   "provider"
     t.string   "uid"
@@ -150,8 +150,7 @@ ActiveRecord::Schema.define(version: 20170615185649) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string   "unconfirmed_email"
-    t.boolean  "admin",                         default: false, null: false
-    t.date     "learning_goal_completion_date"
+    t.boolean  "admin",                  default: false, null: false
     t.string   "avatar"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree


### PR DESCRIPTION
This removes the estimated completion date that the user can set, it was decided that this would do more harm than good with how optimistic a lot of our students are with timeframes 😛 

When this is merged, https://github.com/TheOdinProject/theodinproject/issues/617 can be unblocked