### PR TITLE
fixed lesson-nav overlaying navbar on mobile view

### DIFF
--- a/app/assets/stylesheets/lessons.scss
+++ b/app/assets/stylesheets/lessons.scss
@@ -690,7 +690,7 @@
 
 @media (max-width: 979px) {
   #lesson-nav{
-    position: absolute;
+    position: relative;
     margin-top:10px;
   }
 }


### PR DESCRIPTION
Some list items are being covered by lesson nav..
Also tested on real mobile
![overlay](https://user-images.githubusercontent.com/12657290/27763950-8b6d45a0-5ec0-11e7-9402-5b48d3f00731.png)
