### PR TITLE
Tweak signup page

### DIFF
--- a/app/assets/stylesheets/components/login_page.scss
+++ b/app/assets/stylesheets/components/login_page.scss
@@ -48,6 +48,12 @@
     top: 11.1px;
   }
 
+  @media (max-width: 500px) {
+    .input-group .fa {
+      font-size: 22px;
+    }
+  }
+
   .password {
     margin-bottom: 24.3px;
   }
@@ -89,9 +95,14 @@
     text-align: center;
   }
 
+  @media (max-width: 400px) {
+    .omniauth-login .fa {
+      display: none;
+    }
+  }
+
   .github-login-button {
-    display: inline-block;
-    background-color: $text-primary;
+    background: $text-primary;
     padding-top: 14.2px;
     vertical-align: middle;
   }
@@ -121,27 +132,14 @@
     padding: 0 20px;
   }
 
-  .not-signed-up {
-    margin-top: 150px;
-    font-size: 36px;
-    font-weight: 300;
-    letter-spacing: 0.4px;
-    color: $grey;
-  }
-
   .sign-up-button {
-    display: block;
-    width: 100%;
-    max-width: 234px;
-    font-size: 18px;
-    font-weight: bold;
-    letter-spacing: 0.2px;
-    color: $pale-grey;
-    border-radius: 3px;
     border: solid 3px $pale-grey;
+    box-shadow: none;
+    color: $pale-grey;
+    letter-spacing: 0.2px;
+    max-width: 234px;
     padding: 18px;
-    margin: 50px auto 197px auto;
-    clear: right;
+    width: 100%;
   }
 
   .normal-checkbox {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -179,7 +179,7 @@ module ApplicationHelper
     if current_user
       curriculum_button
     else
-      sign_up_button
+      signup_button
     end
   end
 

--- a/app/helpers/button_helper.rb
+++ b/app/helpers/button_helper.rb
@@ -1,6 +1,14 @@
 module ButtonHelper
-  def sign_up_button
+  def signup_button
     link_to 'Sign Up', sign_up_path, class: 'button button--primary'
+  end
+
+  def login_button
+    link_to 'Login', new_session_path(resource_name), class: 'button sign-up-button'
+  end
+
+  def create_new_account_button
+    link_to 'Create new account', new_registration_path(resource_name), class: 'button sign-up-button'
   end
 
   def curriculum_button

--- a/app/views/devise/registrations/_signup_form.html.erb
+++ b/app/views/devise/registrations/_signup_form.html.erb
@@ -1,0 +1,36 @@
+<%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: 'form-horizontal' }) do |f| %>
+
+  <%= f.error_notification %>
+
+  <div class="form-inputs">
+    <div class="input-group">
+      <span class="fa fa-user"></span>
+      <%= f.input :username, label: false, required: true, placeholder: 'Username', input_html: { class: 'login user_username' } %>
+    </div>
+
+    <div class="input-group">
+      <span class="fa fa-envelope"></span>
+      <%= f.input :email, label: false, required: true, placeholder: 'Email', input_html: { class: 'login email' } %>
+    </div>
+
+    <% if f.object.password_required? %>
+      <div class="input-group">
+        <span class="fa fa-lock"></span>
+        <%= f.input :password, required: true, label: false, placeholder: 'Password', input_html: { class: 'login password' } %>
+      </div>
+
+      <div class="input-group">
+        <span class="fa fa-lock"></span>
+        <%= f.input :password_confirmation, required: true, label: false, placeholder: 'Password Confirmation', input_html: { class: 'login password' } %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="tou-caution text-center">
+    <%= link_to 'By signing up, you agree to our terms of use.', terms_of_use_path %>
+  </div>
+
+  <div class="text-center">
+    <%= f.button :submit, 'Sign up', class: 'sign-in-button page-buttons login' %>
+  </div>
+<% end %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,40 +1,21 @@
 <div id="devise-form" class="devise-sign-up gradient">
   <div class="container">
-    <div class="col-lg-5 login-form">
+    <div class="col-lg-6 login-form">
       <h1 class="text-center accent">Sign Up for Free</h1>
       <div class="card-main">
-        <%= simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "form-horizontal" } ) do |f| %>
+        <%= render 'signup_form' %>
 
-          <%= f.error_notification %>
-
-          <div class="form-inputs">
-            <div class="input-group">
-              <span class="fa fa-user"></span>
-              <%= f.input :username, label: false, required: true, placeholder: "Username", input_html: { class: "login user_username" } %>
-            </div>
-            <div class="input-group">
-              <span class="fa fa-envelope"></span>
-              <%= f.input :email, label: false, required: true, placeholder: "Email", input_html: { class: "login email" } %>
-            </div>
-            <% if f.object.password_required? %>
-              <div class="input-group">
-                <span class="fa fa-lock"></span>
-                <%= f.input :password, required: true, label: false, placeholder: "Password", input_html: { class: "login password" } %>
-              </div>
-              <div class="input-group">
-                <span class="fa fa-lock"></span>
-                <%= f.input :password_confirmation, required: true, label: false, placeholder: "Password Confirmation", input_html: { class: "login password" }%>
-              </div>
-            <% end %>
-          </div>
-          <div class="tou-caution"><a href="/terms_of_use">By signing up, you agree to our terms of use.</a></div>
-          <%= f.button :submit, "Sign up", class: "sign-in-button page-buttons login" %>
-        <% end %>
         <div class="in-between text-center"><span>OR</span></div>
-        <%= render partial: "shared/github_button", locals: {button_type: "Sign up"} %>
+
+        <%= render 'shared/github_button', button_type: 'Sign up' %>
       </div>
-      <h4 class="not-signed-up text-center">Have an account?</h4>
-      <%= link_to "Login", new_session_path(resource_name), class: "sign-up-button text-center" %>
+
+      <%= render 'shared/bottom_cta',
+        button: login_button,
+        heading: 'Have an account?',
+        sub_heading: ''
+      %>
+
     </div>
   </div>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -30,8 +30,13 @@
           <%= render partial: "shared/github_button", locals: {button_type: "Login"} %>
         </div>
       </div>
-      <h4 class="not-signed-up text-center">Haven't signed up yet?</h4>
-      <%= link_to "Create new account", new_registration_path(resource_name), class: "sign-up-button text-center" %>
+
+      <%= render 'shared/bottom_cta',
+        button: create_new_account_button,
+        heading: 'Haven\'t signed up yet?',
+        sub_heading: ''
+      %>
+
     </div>
   </div>
 </div>

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -29,7 +29,7 @@
       <%= render 'shared/bottom_cta',
         button: gitter_button,
         heading: 'Got questions?',
-        subheading: 'Chat with our friendly Odin community in our Gitter chatrooms'
+        sub_heading: 'Chat with our friendly Odin community in our Gitter chatrooms'
       %>
     </div>
   </div>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -23,7 +23,7 @@
 
   <%= render 'shared/bottom_cta',
       heading: 'Got questions?',
-      subheading: 'Chat with our friendly Odin community in our Gitter chatrooms',
+      sub_heading: 'Chat with our friendly Odin community in our Gitter chatrooms',
       button: gitter_button
   %>
 </div>

--- a/app/views/shared/_bottom_cta.html.erb
+++ b/app/views/shared/_bottom_cta.html.erb
@@ -1,6 +1,6 @@
 <div class="bottom-cta">
   <p class="bottom-cta__heading"><%= heading %></p>
 
-  <p class="bottom-cta__sub-heading"><%= subheading %></p>
+  <p class="bottom-cta__sub-heading"><%= sub_heading %></p>
   <%= button %>
 </div>

--- a/app/views/shared/_github_button.html.erb
+++ b/app/views/shared/_github_button.html.erb
@@ -1,14 +1,10 @@
-<!-- <div class="row"> -->
-  <%- if @user.password_required? %>
-    <!-- <div class="social-wrapper"> -->
-      <%- resource_class.omniauth_providers.each do |provider| %>
-        <%= link_to omniauth_authorize_path(resource_name, provider), class: 'github-login-button page-buttons login btn' do %>
-          <i class="fa fa-<%= provider%> providers-button"></i>
-          <%= button_type %> with <%= provider.to_s.titleize %>
-        <% end %>
-
-      <% end -%>
-
-    <!-- </div> -->
-  <% end -%>
-<!-- </div> -->
+<% if @user.password_required? %>
+  <% resource_class.omniauth_providers.each do |provider| %>
+    <div class="omniauth-login text-center">
+      <%= link_to omniauth_authorize_path(resource_name, provider), class: 'github-login-button page-buttons login btn' do %>
+        <i class="fa fa-<%= provider%> providers-button"></i>
+        <%= button_type %> with <%= provider.to_s.titleize %>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/static_pages/about.html.erb
+++ b/app/views/static_pages/about.html.erb
@@ -67,7 +67,7 @@
         <%= render 'shared/bottom_cta',
             button: contribute_button,
             heading: 'Help the Odin Project stay current and meaningful to all future students, please contribute',
-            subheading: ''
+            sub_heading: ''
         %>
     </div>
   </div>

--- a/app/views/static_pages/contributing/_hall_of_fame.erb
+++ b/app/views/static_pages/contributing/_hall_of_fame.erb
@@ -134,6 +134,6 @@
   <%= render 'shared/bottom_cta',
     button: gitter_button,
     heading: 'Got questions?',
-    subheading: 'Chat with our friendly Odin community in our Gitter chatrooms'
+    sub_heading: 'Chat with our friendly Odin community in our Gitter chatrooms'
   %>
 </div

--- a/app/views/static_pages/faq.html.erb
+++ b/app/views/static_pages/faq.html.erb
@@ -10,7 +10,7 @@
     <%= render 'shared/bottom_cta',
       button: gitter_button,
       heading: 'Got questions?',
-      subheading: 'Chat with our friendly Odin community in our Gitter chatrooms'
+      sub_heading: 'Chat with our friendly Odin community in our Gitter chatrooms'
     %>
   </div> <!--  /.container -->
 </div> <!-- /.StaticPagesController -->

--- a/app/views/static_pages/home/_success_stories.html.erb
+++ b/app/views/static_pages/home/_success_stories.html.erb
@@ -34,7 +34,7 @@
   <%= render 'shared/bottom_cta',
     button: sign_in_or_view_curriculum_button,
     heading: 'Start learning for free now!',
-    subheading: ''
+    sub_heading: ''
   %>
 
 </div> <!-- /.success-stories -->

--- a/app/views/static_pages/success_stories.html.erb
+++ b/app/views/static_pages/success_stories.html.erb
@@ -26,9 +26,9 @@
       </div>
 
       <%= render 'shared/bottom_cta',
-          button: sign_up_button,
+          button: signup_button,
           heading: 'Start learning for free now!',
-          subheading: ''
+          sub_heading: ''
       %>
     </div>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -12,6 +12,6 @@
   <%= render 'shared/bottom_cta',
       button: gitter_button,
       heading: 'Got questions?',
-      subheading: 'Chat with our friendly Odin community in our Gitter chatrooms'
+      sub_heading: 'Chat with our friendly Odin community in our Gitter chatrooms'
   %>
 </div>

--- a/spec/helpers/button_helper_spec.rb
+++ b/spec/helpers/button_helper_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe ButtonHelper do
-  describe '#sign_up_button' do
-    let(:sign_up_button) {
+  describe '#signup_button' do
+    let(:signup_button) {
       '<a class="button button--primary" href="/sign_up">Sign Up</a>'
     }
 
     it 'returns a sign up button' do
-      expect(helper.sign_up_button).to eq(sign_up_button)
+      expect(helper.signup_button).to eq(signup_button)
     end
   end
 


### PR DESCRIPTION
Tasks done:
- Use the `bottom_cta` component for the ‘Have an account’ section
- Change column size to 6 in signup page
- Reduce the size of the icons within the input fields on mobile view
- Remove github icon from 'Sign up with Github' button in mobile view