### PR TITLE
Tweak about page

### DIFF
--- a/app/assets/stylesheets/components/about.scss
+++ b/app/assets/stylesheets/components/about.scss
@@ -4,8 +4,10 @@
     margin-bottom: 70px;
   }
 
-  .row {
-    padding-bottom: 60px
+  @include media-breakpoint-up(sm) {
+    .row {
+      padding-bottom: 60px;
+    }
   }
 
   .intro {
@@ -62,29 +64,27 @@
   .contact {
     .odin-logo {
       text-align: center;
-      height: 300px;
+      min-height: 300px;
+      align-self: flex-end;
+
       @include media-breakpoint-up(lg) {
         text-align: right;
       }
+
       @media(max-width: 360px) {
-          height: 210px;
-        }
+        height: 210px;
+      }
+
       img {
-        position: absolute;
-        left: -9000px;
-        right: -9000px;
-        margin: -60px auto 0 auto;
         height: auto;
         width: 100%;
-      @media(max-width: 576px) {
-          margin-top: -60px;
-          height: auto;
-          width: 100%;
+
+        @include media-breakpoint-only(md) {
+          transform: scale(1.5);
         }
-      @media(max-width: 480px) {
-          margin-top: -40px;
-          height: auto;
-          width: 120%;
+
+        @include media-breakpoint-only(lg) {
+          transform: scale(1.3);
         }
       }
     }
@@ -97,8 +97,15 @@
         margin-top: 30px;
       }
 
+      &__heading {
+        margin-bottom: 1em;
+      }
+
       &__sub-heading {
         padding-bottom: 4.375rem;
+        a {
+          text-decoration: underline;
+        }
       }
     }
   }

--- a/app/views/static_pages/about.html.erb
+++ b/app/views/static_pages/about.html.erb
@@ -49,6 +49,7 @@
 ] %>
 
 <%= title('About') %>
+
 <div class="StaticPagesController">
   <div id="about">
     <div class="container">
@@ -64,11 +65,11 @@
     </div>
 
     <div class="contribute">
-        <%= render 'shared/bottom_cta',
-            button: contribute_button,
-            heading: 'Help the Odin Project stay current and meaningful to all future students, please contribute',
-            subheading: ''
-        %>
+      <%= render 'shared/bottom_cta',
+        button: contribute_button,
+        heading: 'Help the Odin Project stay current and meaningful to all future students, please contribute',
+        subheading: ''
+      %>
     </div>
   </div>
 </div>

--- a/app/views/static_pages/about/_contact.html.erb
+++ b/app/views/static_pages/about/_contact.html.erb
@@ -1,12 +1,12 @@
 <div class="row contact">
-  <div class="col-sm-6 odin-logo">
+  <div class="col-md-6 odin-logo">
     <%= image_tag 'about_page/odin-wink.gif', alt: 'Odin logo', class: 'img-responsive' %>
   </div>
 
-  <div class="col-sm-6 col-lg-5 contact-details">
-      <h1 class="accent">
+  <div class="col-md-6 col-lg-5 contact-details">
+      <h2 class="accent contact-details__heading">
         Want to contact us?
-      </h1>
+      </h2>
 
       <p class="contact-details__sub-heading">
         Connect with our friendly community on gitter, a chat and networking platform or <a href="mailto:contact@theodinproject.com">send us an email</a>


### PR DESCRIPTION
Tasks done:

- Underline 'send us an email'
- Update 'Want to contact us' to a h2 and add a bottom margin of `1em`
-  Remove `60px` of padding bottom on 'Want to contact us' heading on mobile view
- Align 'Chat on gitter' button with the image, fix image being too small on 1020px and 768px