### PR TITLE
Simplify and horizontalize user card on dashboard

### DIFF
--- a/app/assets/stylesheets/components/dashboard.scss
+++ b/app/assets/stylesheets/components/dashboard.scss
@@ -5,19 +5,24 @@
     .user-avatar {
       width:100px;
       height:100px;
-      margin: 0 auto;
-      margin-top: 18px;
+      margin: 0 auto 0 0;
       background-color:#000;
       border-radius:50%;
       overflow: hidden;
+      
+      @include media-breakpoint-down(sm) {
+        margin: 0 auto;
+      }
     }
 
     .user-avatar-img {
       width: 100%;
-      object-fit: contain;
     }
 
     .welcome-text {
+      @include media-breakpoint-down(sm) {
+        text-align: center;
+      }
       color: $text-primary;
       font-size: 24px;
       margin-top: 20px;
@@ -30,13 +35,10 @@
       justify-content: space-between;
 
       @include media-breakpoint-down(sm) {
-        margin-top: 20px;
         text-align: center;
       }
 
       .learning-goal {
-        margin-top: 17px;
-
         a {
           text-decoration: underline;
           color: $grey;
@@ -46,6 +48,10 @@
       .completion-date {
         margin-top: 20px;
       }
+    }
+
+    &.card-main .row {
+      align-items: center;
     }
   }
 

--- a/app/views/users/_profile_card.html.erb
+++ b/app/views/users/_profile_card.html.erb
@@ -3,19 +3,17 @@
     <div class="col-md-10 offset-md-1 col-lg-8 offset-lg-2">
       <div class="card-main profile-card">
         <div class="row">
-          <div class="col-md-5 align-items-center text-center">
+          <div class="col-md-3 align-items-center text-center">
             <div class="user-avatar">
               <%= image_tag @user.image, class: 'user-avatar-img' %>
             </div>
 
-            <p class="welcome-text"> Welcome back <br /> <%=  user.username %>! </p>
           </div>
-
-          <div class="col-sm-1"></div>
-
-          <div class="col-md-6 info">
+          <div class="col-md-4">
+            <p class="welcome-text"><%=  user.username %></p>
+          </div>
+          <div class="col-md-5 info">
             <div class="learning-goal-wrapper">
-              <p class="camel bold learning-goal-title">Learning Goal</p>
               <p class="learning-goal">
                 <%= user.learning_goal || set_learning_goal  %>
               </p>


### PR DESCRIPTION
#646 
On medium screen sizes and up, user cards on the dashboard are thinner/shorter and aligned across. On mobile (sm), they remain centered.