### PR TITLE
Change hover style for nav-item and excluded divider from functionality

### DIFF
--- a/app/assets/stylesheets/components/navbar.scss
+++ b/app/assets/stylesheets/components/navbar.scss
@@ -51,16 +51,22 @@
       display: none;
     }
 
-    .nav-link {
-      color: #676767;
-      text-decoration: none;
-      letter-spacing: 0.2px;
-      line-height: 88px;
-      font-size: 1.1em;
+    .nav-item {
+      display: flex;
+      justify-content: center;
+      align-content: center;
+      flex-direction: column;
 
-      &:hover {
-        color: $black;
-        font-weight: bold;
+      .nav-link {
+        color: #676767;
+        text-decoration: none;
+        letter-spacing: 0.2px;
+        font-size: 1.1em;
+        border-bottom: 2px solid transparent;
+
+        &:hover {
+          border-bottom: 2px solid $primary;
+        }
       }
     }
 

--- a/app/assets/stylesheets/components/navbar.scss
+++ b/app/assets/stylesheets/components/navbar.scss
@@ -65,7 +65,8 @@
         border-bottom: 2px solid transparent;
 
         &:hover {
-          border-bottom: 2px solid $primary;
+          color: $black;
+          border-bottom: 2px solid $black;
         }
       }
     }


### PR DESCRIPTION
**Included:** Excluded the divider in navbar from getting the hover functionality. Also, this makes the link area compressed in height as it was filling up a huge chuck outside the text.

![](https://media.giphy.com/media/l41lI4bYmcsPJX9Go/giphy.gif)