### PR TITLE
Refactor Auth Form to Make it Generic

### DIFF
--- a/app/assets/javascripts/form_validations.js
+++ b/app/assets/javascripts/form_validations.js
@@ -27,11 +27,11 @@ var constraints = {
 };
 
 document.addEventListener('turbolinks:load', function() {
-  var form = document.querySelector('form.new_user');
+  var form = document.querySelector('.form');
   if (!form) return;
-  var inputs = document.querySelectorAll('.auth-form__element');
+  var inputs = document.querySelectorAll('.form__element');
 
-  inputs.forEach(function(item) {    
+  inputs.forEach(function(item) {
     item.addEventListener("change", function(ev) {
       var errors = validate(form, constraints, { fullMessages: false }) || {};
       showErrorsForInput(this, errors[this.name]);
@@ -50,7 +50,7 @@ function showErrorsForInput(input, errors) {
     errorDiv.parentNode.removeChild(errorDiv);
     return;
   }
-  
+
   errorWrapper.classList.add('field_with_errors');
   errorDiv.innerHTML = errors;
 }
@@ -76,7 +76,7 @@ function findErrorDiv(input) {
 
 function createErrorDiv(input, inputParent) {
   var divName = document.createElement('div');
-  divName.classList.add('auth-form__error-message', 'push-down', input.id);
+  divName.classList.add('form__error-message', 'push-down', input.id);
   inputParent.parentNode.insertBefore(divName, inputParent.nextSibling);
   return divName;
 }

--- a/app/assets/stylesheets/components/form/form.scss
+++ b/app/assets/stylesheets/components/form/form.scss
@@ -1,4 +1,4 @@
-.auth-form {
+.form {
 
   &__section {
     margin-bottom: 20px;
@@ -62,7 +62,7 @@
   &__check-box {
     display: none;
 
-    &:checked + .auth-form__check-box-label:before {
+    &:checked + .form__check-box-label:before {
       content: '\f00c';
       color: #4a4a4a;
       font-size: 1rem;

--- a/app/assets/stylesheets/components/form/form_divider.scss
+++ b/app/assets/stylesheets/components/form/form_divider.scss
@@ -1,4 +1,4 @@
-.auth-form-divider {
+.form-divider {
   margin: 1.875rem 0;
   font-size: 0.8em;
   letter-spacing: 0.2px;

--- a/app/views/devise/registrations/_form.html.erb
+++ b/app/views/devise/registrations/_form.html.erb
@@ -1,49 +1,49 @@
 <div class="card-main">
-  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), class: 'auth-form') do |form| %>
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: 'form' }) do |form| %>
 
-    <div class="auth-form__section">
-      <span class="fa fa-user auth-form__icon"></span>
-      <%= form.text_field :username, required: true, placeholder: 'Username', class: 'auth-form__element' %>
+    <div class="form__section">
+      <span class="fa fa-user form__icon"></span>
+      <%= form.text_field :username, required: true, placeholder: 'Username', class: 'form__element' %>
     </div>
     <% if resource.errors[:username].present? %>
-      <div class="auth-form__error-message push-down user_username"> <%=resource.errors[:username].first %></div>
+      <div class="form__error-message push-down user_username"> <%=resource.errors[:username].first %></div>
     <% end %>
 
-    <div class="auth-form__section">
-      <span class="fa fa-envelope auth-form__icon"></span>
-      <%= form.email_field :email, required: true, placeholder: 'Email', class: 'auth-form__element login email'%>
+    <div class="form__section">
+      <span class="fa fa-envelope form__icon"></span>
+      <%= form.email_field :email, required: true, placeholder: 'Email', class: 'form__element login email'%>
     </div>
     <% if resource.errors[:email].present? %>
-      <div class="auth-form__error-message push-down user_email"> <%=resource.errors[:email].first %></div>
+      <div class="form__error-message push-down user_email"> <%=resource.errors[:email].first %></div>
     <% end %>
 
-    <div class="auth-form__section">
-      <span class="fa fa-lock auth-form__icon"></span>
-      <%= form.password_field :password, required: true, placeholder: 'Password', class: 'auth-form__element login password' %>
+    <div class="form__section">
+      <span class="fa fa-lock form__icon"></span>
+      <%= form.password_field :password, required: true, placeholder: 'Password', class: 'form__element login password' %>
     </div>
     <% if resource.errors[:password].present? %>
-      <div class="auth-form__error-message push-down user_password"> <%=resource.errors[:password].first %></div>
+      <div class="form__error-message push-down user_password"> <%=resource.errors[:password].first %></div>
     <% end %>
 
-    <div class="auth-form__section">
-      <span class="fa fa-lock auth-form__icon"></span>
-      <%= form.password_field :password_confirmation, required: true, placeholder: 'Password Confirmation', class: 'auth-form__element login password' %>
+    <div class="form__section">
+      <span class="fa fa-lock form__icon"></span>
+      <%= form.password_field :password_confirmation, required: true, placeholder: 'Password Confirmation', class: 'form__element login password' %>
     </div>
     <% if resource.errors[:password_confirmation].present? %>
-      <div class="auth-form__error-message push-down user_password_confirmation"> <%=resource.errors[:password_confirmation].first %></div>
+      <div class="form__error-message push-down user_password_confirmation"> <%=resource.errors[:password_confirmation].first %></div>
     <% end %>
 
-    <div class="auth-form__section">
-      <%= link_to 'By signing up, you agree to our terms of use.', terms_of_use_path, class: 'auth-form__link' %>
+    <div class="form__section">
+      <%= link_to 'By signing up, you agree to our terms of use.', terms_of_use_path, class: 'form__link' %>
     </div>
 
-    <div class="auth-form__button-section">
+    <div class="form__button-section">
       <%= form.submit 'Sign up', class: 'button button--primary full-width' %>
     </div>
   <% end %>
 
-  <div class="auth-form-divider text-center">
-    <span class="auth-form-divider__text">OR SIGN UP WITH</span>
+  <div class="form-divider text-center">
+    <span class="form-divider__text">OR SIGN UP WITH</span>
   </div>
 
   <%= render 'shared/omniauth_buttons' %>

--- a/app/views/devise/sessions/_form.html.erb
+++ b/app/views/devise/sessions/_form.html.erb
@@ -1,31 +1,31 @@
 <div class="card-main">
-  <%= form_for(resource, as: resource_name, url: session_path(resource_name), class: "auth-form") do |form| %>
+  <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "form" }) do |form| %>
 
-    <div class="auth-form__section">
-      <span class="fa fa-envelope auth-form__icon"></span>
-      <%= form.email_field :email, required: false, autofocus: true, placeholder: "Email Address", class: 'auth-form__element' %>
+    <div class="form__section">
+      <span class="fa fa-envelope form__icon"></span>
+      <%= form.email_field :email, required: false, autofocus: true, placeholder: "Email Address", class: 'form__element' %>
     </div>
 
-    <div class="auth-form__section">
-      <span class="fa fa-lock auth-form__icon"></span>
-      <%= form.password_field :password, required: false, placeholder:  "Password", class: 'auth-form__element' %>
+    <div class="form__section">
+      <span class="fa fa-lock form__icon"></span>
+      <%= form.password_field :password, required: false, placeholder:  "Password", class: 'form__element' %>
     </div>
 
 
-    <div class="auth-form__link-section">
-      <%= form.check_box :remember_me, checked: true, class: 'auth-form__check-box', id: 'remember_me' %>
-      <label for="remember_me" class="auth-form__check-box-label auth-form__link-section__item">Remember Me</label>
+    <div class="form__link-section">
+      <%= form.check_box :remember_me, checked: true, class: 'form__check-box', id: 'remember_me' %>
+      <label for="remember_me" class="form__check-box-label form__link-section__item">Remember Me</label>
 
-      <%= link_to "Forgot your password?", new_password_path( resource_name), class: "auth-form__link-section__item auth-form__link" %>
+      <%= link_to "Forgot your password?", new_password_path( resource_name), class: "form__link-section__item form__link" %>
     </div>
 
-    <div class="auth-form__button-section">
+    <div class="form__button-section">
       <%= form.submit "Login", class: "button button--primary full-width" %>
     </div>
   <% end %>
 
-  <div class="auth-form-divider text-center">
-    <span class="auth-form-divider__text">OR SIGN UP WITH</span>
+  <div class="form-divider text-center">
+    <span class="form-divider__text">OR SIGN UP WITH</span>
   </div>
 
   <div class="text-center">


### PR DESCRIPTION
This refactors the naming of the auth form so is more generic and therefore can be used throughout the site. This will also allow the form validations to work with any form that follows the same structure.