### PR TITLE
Course Badge Component

### DIFF
--- a/app/assets/stylesheets/components/course-badge.scss
+++ b/app/assets/stylesheets/components/course-badge.scss
@@ -1,0 +1,5 @@
+.course-badge {
+  @include box-shadow(0 5px 16px 0 rgba(0, 0, 0, 0.1));
+  @include border-radius(50%);
+  padding: 10px;
+}

--- a/app/views/courses/_course_overview.html.erb
+++ b/app/views/courses/_course_overview.html.erb
@@ -1,9 +1,7 @@
 <div class="row course-badge-title-wrapper align-items-center">
   <%= link_to course, class: 'col-md-8 col-lg-8' do %>
     <div class="course-badge-title align-items-center">
-      <div class="course-badge">
-        <%= image_tag course.badge, alt: "#{course.title} badge", class: 'course-badge-img' %>
-      </div>
+      <%= render 'shared/course_badge', course: course %>
 
       <div class="course-title text-uppercase">
         <h2 class="font-weight-bold"><%= course.title %></h2>

--- a/app/views/shared/_course_badge.html.erb
+++ b/app/views/shared/_course_badge.html.erb
@@ -1,0 +1,3 @@
+<div class="course-badge">
+  <%= image_tag course.badge, alt: "#{course.title} badge", class: 'course-badge-img' %>
+</div>


### PR DESCRIPTION
Resolves step one on https://github.com/TheOdinProject/theodinproject/issues/707

* Turns a badge for a course into a component
* New Raised style for the badge

This completes step 1 of the progress indicators for courses.

<img width="829" alt="screen shot 2017-09-03 at 20 36 50" src="https://user-images.githubusercontent.com/7963776/30006111-c50ec9fa-90e8-11e7-8e14-08ff6bfee5c2.png">
