### PR TITLE
Turn off Project Submission feature in production

### DIFF
--- a/app/features/project_submission_feature.rb
+++ b/app/features/project_submission_feature.rb
@@ -1,0 +1,5 @@
+class ProjectSubmissionFeature
+  def self.enabled?
+    false
+  end
+end

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -21,7 +21,10 @@
       <div class="lesson-button-group">
         <%= render 'lesson_buttons', lesson: @lesson, course: @lesson.course, user: @user %>
       </div>
-      <%= render 'submissions' if @projects %>
+
+      <% if @projects && ProjectSubmissionFeature.enabled? %>
+        <%= render 'submissions' %>
+      <% end %>
     </div>
 
     <%= render 'shared/bottom_cta',

--- a/spec/features/project_submission_feature_spec.rb
+++ b/spec/features/project_submission_feature_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe ProjectSubmissionFeature do
+  describe '.enabled?' do
+    it 'returns false' do
+      expect(ProjectSubmissionFeature.enabled?).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
This turns off the project submission feature so the redesign can go out.