### PR TITLE
Change Course Buttons to Resume on Dashboard

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -41,6 +41,6 @@ class UsersController < ApplicationController
   end
 
   def user
-    User.includes(:lesson_completions).find(current_user.id)
+    User.includes(lesson_completions: [lesson: [:course]]).find(current_user.id)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -204,6 +204,10 @@ module ApplicationHelper
     CourseProgress.course_completed?(course, user)
   end
 
+  def next_lesson_to_complete(course, lesson_completions)
+    NextLessonToComplete.new(course, lesson_completions).lesson
+  end
+
   private
 
   def custom_flash(flash_type)

--- a/app/services/course_progress.rb
+++ b/app/services/course_progress.rb
@@ -24,7 +24,7 @@ class CourseProgress
   end
 
   def percentage_completed_by_user
-    ((100 / number_of_lessons.to_f) * number_of_lessons_completed).to_i
+    ((100 / number_of_lessons_in_course.to_f) * number_of_lessons_completed).to_i
   end
 
   def course_completed?
@@ -33,11 +33,11 @@ class CourseProgress
 
   private
 
-  def number_of_lessons
-    lessons.size
+  def number_of_lessons_in_course
+    course_lessons.size
   end
 
-  def lessons
+  def course_lessons
     course.lessons
   end
 
@@ -46,6 +46,6 @@ class CourseProgress
   end
 
   def number_of_lessons_completed
-     (lessons & completed_lessons ).size
+     (course_lessons & completed_lessons).size
    end
 end

--- a/app/services/next_lesson.rb
+++ b/app/services/next_lesson.rb
@@ -1,0 +1,41 @@
+class NextLesson
+  attr_reader :course, :lesson_completions
+  private :course, :lesson_completions
+
+  def initialize(course, lesson_completions)
+    @course = course
+    @lesson_completions = lesson_completions
+  end
+
+  def lesson_to_complete
+    course.lessons.find do |lesson|
+      lesson.position == next_lesson_to_complete_position
+    end
+  end
+
+  private
+
+  def completed_lessons_in_course
+    lesson_completions.select do |lesson_completion|
+      lesson_completion.lesson.course.id == course.id
+    end
+  end
+
+  def completed_lessons_by_date
+    completed_lessons_in_course.sort_by(&:created_at)
+  end
+
+  def last_lesson_completed
+    completed_lessons_by_date.last
+  end
+
+  def next_lesson_to_complete_position
+    last_lesson_completed.lesson.position + 1
+  end
+end
+
+
+
+# pass in the course and the completed lessons
+# extract all completed lessons from the course
+# I could go for the section id

--- a/app/views/users/_course_buttons.html.erb
+++ b/app/views/users/_course_buttons.html.erb
@@ -1,0 +1,9 @@
+<div class="col-12 col-md-3 course-progress-wrapper">
+  <% if course_completed_by_user?(course, user) %>
+    <span class="completed-text pale-grey bold text-uppercase">Completed</span>
+  <% elsif course_started_by_user?(course, user) && !course_completed_by_user?(course, user) %>
+    <%= link_to 'Resume', lesson_path(next_lesson_to_complete(course, user.lesson_completions)), class: ' button button--primary' %>
+  <% else %>
+    <%= link_to 'Start', course_path(course), class: 'button button--primary' %>
+  <% end %>
+</div>

--- a/app/views/users/_skill_progress.html.erb
+++ b/app/views/users/_skill_progress.html.erb
@@ -20,13 +20,7 @@
           </p>
         </div>
 
-        <div class="col-12 col-md-3 course-progress-wrapper">
-          <% if course_completed_by_user?(course, @user) %>
-            <span class="completed-text pale-grey bold text-uppercase">Completed</span>
-          <% else %>
-            <%= link_to 'Start', course_path(course), class: 'button button--primary' %>
-          <% end %>
-        </div>
+        <%= render 'users/course_buttons', course: course, user: user %>
       </div>
     </div>
   </div>

--- a/spec/services/next_lesson_spec.rb
+++ b/spec/services/next_lesson_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe NextLesson, :type => :service do
+  subject { NextLesson.new(course, lesson_completions) }
+
+  let(:course) { double('Course', lessons: lessons, id: 1) }
+  let(:lessons) { [lesson, next_lesson] }
+  let(:lesson) { double('Lesson', position: 1) }
+  let(:next_lesson) { double('Lesson', position: 2) }
+  let(:lesson_completions) { [lesson_completion] }
+  let(:lesson_completion) {
+    double(
+      'LessonCompletion',
+      lesson: lesson,
+      created_at: '10-11-2017'
+    )
+  }
+
+  before do
+    allow(lesson).to receive(:course).and_return(course)
+  end
+
+
+  describe '#lesson' do
+    it 'returns the next lesson to complete' do
+      expect(subject.lesson_to_complete).to eql(next_lesson)
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/TheOdinProject/theodinproject/issues/724
If the user has started a course it will now allow them to go straight to the next lesson in they are on in a course.