### PR TITLE
Tweak lesson completion state styles

### DIFF
--- a/app/assets/stylesheets/components/buttons.scss
+++ b/app/assets/stylesheets/components/buttons.scss
@@ -47,13 +47,15 @@
 
   &--complete {
     background-color: $button-disabled;
+    color: $black;
 
     &:after {
-      content: 'completed!';
+      content: 'Completed!';
     }
 
     &:hover {
       background: $red-danger;
+      color: $white;
 
       &:after {
         content: 'Incomplete';


### PR DESCRIPTION
- Capitalize 'completed' text
- Change color of 'Completed' text to black to improve color contrast ratio
Contrast ratio: [Before](http://webaim.org/resources/contrastchecker/?fcolor=FFFFFF&bcolor=D8D8D8), [After](http://webaim.org/resources/contrastchecker/?fcolor=000000&bcolor=D8D8D8)

Screenshots:

![image](https://user-images.githubusercontent.com/7039523/30254075-828fda9a-9658-11e7-80b5-36ca01ba36fc.png)


![image](https://user-images.githubusercontent.com/7039523/30254078-88ab959a-9658-11e7-9558-80a339b62425.png)
