### PR TITLE
Update styles for focus on links

### DIFF
--- a/app/assets/stylesheets/global.scss
+++ b/app/assets/stylesheets/global.scss
@@ -11,7 +11,7 @@ body {
 a {
   text-decoration: none;
 
-  &:hover {
+  &:hover, &:focus {
     color: $black;
     text-decoration: none;
   }


### PR DESCRIPTION
The link focus styles were defaulting to bootstrap's style which included a color of `#014c8c`. This PR fixes it by updating styles of links on focus state.