### PR TITLE
use kramdown for rendering markdown

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gem 'turbolinks'
 gem 'jquery-rails',                 '~> 4.2.1'
 gem 'devise',                       '~> 4.2.0' # Managing environment variables
 gem 'rack-timeout',                 '~> 0.4'
-gem 'redcarpet',                    '~> 3.3'  # to render the curriculum's .md files as html
 gem 'kaminari',                     '~> 1.0', '>= 1.0.1'
 gem 'pg',                           '~> 0.19'
 gem 'premailer-rails',              '~> 1.9'
@@ -24,6 +23,7 @@ gem 'sass-rails',                   '~> 5.0'
 gem 'rack-attack'
 gem 'tether-rails' # dependency for bootstrap tooltips
 gem 'acts_as_votable'
+gem 'kramdown'
 
 group :production do
   gem 'rails_12factor',             '~> 0.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,6 +173,7 @@ GEM
       activerecord
       kaminari-core (= 1.0.1)
     kaminari-core (1.0.1)
+    kramdown (1.15.0)
     launchy (2.4.3)
       addressable (~> 2.3)
     letter_opener (1.4.1)
@@ -276,7 +277,6 @@ GEM
     rainbow (2.2.2)
       rake
     rake (11.3.0)
-    redcarpet (3.4.0)
     reek (4.7.1)
       codeclimate-engine-rb (~> 0.4.0)
       parser (>= 2.4.0.0, < 2.5)
@@ -393,6 +393,7 @@ DEPENDENCIES
   github_api (~> 0.14)
   jquery-rails (~> 4.2.1)
   kaminari (~> 1.0, >= 1.0.1)
+  kramdown
   letter_opener (~> 1.4)
   newrelic_rpm (~> 3.17)
   octokit (~> 4.6)
@@ -409,7 +410,6 @@ DEPENDENCIES
   rails-controller-testing (~> 1.0)
   rails_12factor (~> 0.0.3)
   rake (~> 11.3)
-  redcarpet (~> 3.3)
   reek
   rspec-rails (~> 3.5)
   rubocop

--- a/app/assets/stylesheets/components/lesson/lesson_content.scss
+++ b/app/assets/stylesheets/components/lesson/lesson_content.scss
@@ -64,7 +64,7 @@
     word-wrap: break-word;
   }
 
-  &__assignment {
+  &__panel {
     background-color: $white-smoke;
     padding: 2em 1.5em;
     margin: 20px 0 50px 0;

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -55,7 +55,11 @@ class Lesson < ApplicationRecord
   end
 
   def github_response
-    Octokit.contents('theodinproject/curriculum', path: url)
+    Octokit.contents(
+      'theodinproject/curriculum',
+      path: url,
+      ref: 'feature/redesign-structure'
+    )
   end
 
   def failed_to_import_message

--- a/app/services/markdown_converter.rb
+++ b/app/services/markdown_converter.rb
@@ -7,20 +7,12 @@ class MarkdownConverter
   end
 
   def as_html
-    markdown_converter.render(markdown).html_safe
+    converted_markdown.html_safe
   end
 
   private
 
-  def markdown_converter
-    Redcarpet::Markdown.new(renderer, extensions = markdown_extensions)
-  end
-
-  def renderer
-    Redcarpet::Render::HTML
-  end
-
-  def markdown_extensions
-    { :fenced_code_blocks => true }
+  def converted_markdown
+    Kramdown::Document.new(markdown).to_html
   end
 end

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -8,7 +8,7 @@
       </div>
 
       <div class="lesson-content">
-        <%= convert_markdown_to_html(@lesson.content) %>
+        <%= Kramdown::Document.new(@lesson.content).to_html.html_safe %>
       </div>
     </div>
 </div>

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Lesson do
 
       before do
         allow(Octokit).to receive(:contents)
-          .with('theodinproject/curriculum', path: '/README.md')
+          .with('theodinproject/curriculum', path: '/README.md', ref: 'feature/redesign-structure' )
           .and_raise(Octokit::Error)
 
         allow(lesson).to receive(:errors).and_return('there was a problem')

--- a/spec/services/markdown_converter_spec.rb
+++ b/spec/services/markdown_converter_spec.rb
@@ -4,16 +4,16 @@ RSpec.describe MarkdownConverter, type: :service do
   subject(:markdown_converter) { MarkdownConverter.new(markdown) }
 
   let(:markdown) { 'Some markdown' }
-  let(:redcarpet_markdown) { double('Redcarpet::Markdown') }
-  let(:markdown_extensions) { { fenced_code_blocks: true } }
+  let(:kramdown) {
+    double(
+      'Kramdown::Document',
+      to_html: "<p>Some markdown</p>"
+     )
+   }
 
   before do
-    allow(Redcarpet::Markdown).to receive(:new)
-      .with(Redcarpet::Render::HTML, extentions = markdown_extensions)
-      .and_return(redcarpet_markdown)
-
-    allow(redcarpet_markdown).to receive(:render).with(markdown)
-      .and_return('<p>Some markdown</p>')
+    allow(Kramdown::Document).to receive(:new).with(markdown).
+      and_return(kramdown)
   end
 
   describe '#as_html' do


### PR DESCRIPTION
We are switching to Kramdown for rendering markdown to html as it allows markdown to be wrapped in block level html elements.