### PR TITLE
Added redirection route for deprecated external links

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,8 @@ Rails.application.routes.draw do
   resources :users, only: [:show, :update]
   get 'dashboard' => 'users#show', as: :dashboard
 
+  # Deprecated Route to Introduction to Web Development from external links
+  get '/courses/introduction-to-web-development' => redirect('/courses/web-development-101')
   resources :courses, only: %i(index show) do
     resources :lessons, only: :show
   end


### PR DESCRIPTION
Fixes #788 
I tried putting it at the bottom next to the other deprecated links, but it wasn't worked
I think it has to do with entering the /courses/ scope or something
This does work though