### PR TITLE
Fix Unique Validation Errors for Lesson Completions

### DIFF
--- a/app/assets/javascripts/analytics.js.erb
+++ b/app/assets/javascripts/analytics.js.erb
@@ -92,5 +92,19 @@ document.addEventListener("turbolinks:load", function () {
       adId = $(e.target).parents('.ad').data('ad-id');
       _gaq.push(['_trackEvent', 'ad', 'click', adId, 1])
     });
+
+    $('[title="Mark lesson complete"]').on('click', function(e) {
+      _gaq.push(['_trackEvent', 'lesson_completion', 'mark_completed', window.location.href, 1]);
+    });
+
+    // Fire an event whenever a user marks a lesson  uncompleted on the individual lesson page
+    $('[title="Mark lesson incomplete"]').on('click', function(e) {
+      _gaq.push(['_trackEvent', 'lesson_completion', 'mark_not_completed', window.location.href, 1]);
+    });
+
+    // Fire an event when a user clicks on the next lesson navigation link in the individual lesson page
+    $('[title^="Move on to"]').on('click', function(e) {
+      _gaq.push(['_trackEvent', 'lesson_navigation', 'click_next_lesson_link', 'lesson_page', 1]);
+    });
   });
 });

--- a/app/controllers/lesson_completions_controller.rb
+++ b/app/controllers/lesson_completions_controller.rb
@@ -4,7 +4,7 @@ class LessonCompletionsController < ApplicationController
   before_action :set_user
 
   def create
-    new_lesson_completion.save
+    LessonCompletion.create!(student_id: current_user.id, lesson_id: lesson.id)
   end
 
   def destroy
@@ -22,13 +22,9 @@ class LessonCompletionsController < ApplicationController
   end
 
   def set_user
-      @user = User.includes(:lesson_completions).find(current_user.id)
+    @user = User.includes(:lesson_completions).find(current_user.id)
   end
-
-  def new_lesson_completion
-    LessonCompletion.new(student_id: current_user.id, lesson_id: @lesson.id)
-  end
-
+  
   def lookup_lesson
     @lesson = LessonDecorator.new(lesson)
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
 
     <%= render 'shared/footer' %>
     <%= render 'shared/sidecar' %>
-    <%= javascript_include_tag 'application', async: true %>
     <%= render 'shared/ga' %>
+    <%= javascript_include_tag 'application', async: Rails.env.production? %>
   </body>
 </html>

--- a/app/views/lessons/_lesson_buttons.html.erb
+++ b/app/views/lessons/_lesson_buttons.html.erb
@@ -13,21 +13,3 @@
       class: "button #{next_lesson_button_state(lesson)} lesson-button-group__item lesson-button"
   %>
 <% end %>
-
-
-<script>
-  // Fire an event whenever a user marks a lesson completed on the individual lesson page
-  $('[title="Mark lesson complete"]').on('click', function(e) {
-    _gaq.push(['_trackEvent', 'lesson_completion', 'mark_completed', window.location.href, 1]);
-  });
-
-  // Fire an event whenever a user marks a lesson  uncompleted on the individual lesson page
-  $('[title="Mark lesson incomplete"]').on('click', function(e) {
-    _gaq.push(['_trackEvent', 'lesson_completion', 'mark_not_completed', window.location.href, 1]);
-  });
-
-  // Fire an event when a user clicks on the next lesson navigation link in the individual lesson page
-  $('[title^="Move on to"]').on('click', function(e) {
-    _gaq.push(['_trackEvent', 'lesson_navigation', 'click_next_lesson_link', 'lesson_page', 1]);
-  });
-</script>

--- a/app/views/lessons/_lesson_completion_state.html.erb
+++ b/app/views/lessons/_lesson_completion_state.html.erb
@@ -1,9 +1,9 @@
 <% if lesson_completed?(user, lesson) %>
-  <%= link_to lesson_completions_path(lesson), method: :delete, remote: true, class: 'button button--complete lesson-button-group__item lesson-button lesson-button--complete', title: 'Mark lesson incomplete' do %>
+  <%= link_to lesson_completions_path(lesson), method: :delete, remote: true, class: 'button button--complete lesson-button-group__item lesson-button lesson-button--complete', title: 'Mark lesson incomplete', data: { disable_with: 'Loading' } do %>
     <i class="lesson-button__icon fa fa-check-circle-o" aria-hidden="true"></i>
   <% end %>
 <% else %>
-  <%= link_to lesson_completions_path(lesson), remote: true, method: :post, class: 'button button--primary lesson-button-group__item lesson-button', title: 'Mark lesson complete' do %>
+  <%= link_to lesson_completions_path(lesson), remote: true, method: :post, class: 'button button--primary lesson-button-group__item lesson-button', title: 'Mark lesson complete', data: { disable_with: 'Loading' } do %>
     <i class="lesson-button__icon fa fa-check-circle-o" aria-hidden="true"></i>Complete
   <% end %>
 <% end %>


### PR DESCRIPTION
We have been seeing quite a few unique validation errors in New Relic. After investigating I believe this is happening due to users clicking the complete lesson button multiple times in a short period of time.

This disables the complete and un-complete button until the ajax request for the lesson completions button is completed.

This error has occurred 65 times over the past 7 days:
<img width="1220" alt="screen shot 2018-03-11 at 02 52 48" src="https://user-images.githubusercontent.com/7963776/37249046-78fc1cc4-24d7-11e8-894c-6c218e46a68c.png">


This also includes a small fix for JS errors with jquery not being found with the lesson buttons ga tracking.

That was caused by the application.js files being recently moved to the bottom of the page so jquery was loaded after the script for the ga tracking.

