### PR TITLE
Fix issue with navigation on lesson pages

### DIFF
--- a/app/assets/javascripts/lessons.js
+++ b/app/assets/javascripts/lessons.js
@@ -38,7 +38,7 @@ function getInnerText(heading) {
 }
 
 function isCommonHeading(heading) {
-  return LESSON_HEADINGS.indexOf(heading) !== -1;
+  return LESSON_HEADINGS.indexOf(heading) !== LESSON_HEADINGS.length - 1;
 }
 
 function getLessonHeadings() {


### PR DESCRIPTION
Turns out it wasnt an issue with turbo links. It turns out that isCommonHeading was always returning false so it would only ever have 1 item in the lessonHeadings array.