### PR TITLE
Index lesson_completions on student_id

### DIFF
--- a/db/migrate/20180413180306_add_student_index_to_lesson_completions.rb
+++ b/db/migrate/20180413180306_add_student_index_to_lesson_completions.rb
@@ -1,0 +1,5 @@
+class AddStudentIndexToLessonCompletions < ActiveRecord::Migration[5.0]
+  def change
+    add_index :lesson_completions, :student_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180411225308) do
+ActiveRecord::Schema.define(version: 20180413180306) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,6 +51,7 @@ ActiveRecord::Schema.define(version: 20180411225308) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["lesson_id", "student_id"], name: "index_lesson_completions_on_lesson_id_and_student_id", unique: true, using: :btree
+    t.index ["student_id"], name: "index_lesson_completions_on_student_id", using: :btree
   end
 
   create_table "lessons", force: :cascade do |t|


### PR DESCRIPTION
In exploring performance data on [Odin Project's Skylight page](https://oss.skylight.io/app/applications/g0gJSNnzYAws/recent/6h/endpoints), I noticed that this query was not optimized:

```sql
SELECT "lesson_completions".* FROM "lesson_completions" WHERE "lesson_completions"."student_id" = ?
```

While the query itself isn't currently super slow, we noticed that it occurs on every endpoint (You can see it on the Skylight event sequence as "SELECT FROM lesson_completions"), and we noted that as the lesson_completions table grows the query might start to have a bigger impact on performance.

Despite the fact that the [compound index](https://github.com/TheOdinProject/theodinproject/blob/master/db/schema.rb#L53) does provide some benefit if it is only partially used, [Postgres documentation](https://www.postgresql.org/docs/9.6/static/indexes-bitmap-scans.html) suggests single-column indexes are generally faster (and the query planner is very effective at combining indexes, so they recommend using single-column indexes by default).

We populated the `lesson_completions` table with 250,000 rows and ran benchmarks on `UsersController#show` and `CoursesController#index` using Skylight in development mode and `explain`.

## Before:

![image](https://user-images.githubusercontent.com/14152574/38760173-c2f81c30-3f2e-11e8-89f7-36aa83d0937f.png)

```shell
# User.find(200).lesson_completions.explain

D, [2018-04-13T11:04:30.082675 #63023] DEBUG -- :   LessonCompletion Load (31.9ms)  SELECT "lesson_completions".* FROM "lesson_completions" WHERE "lesson_completions"."student_id" = $1  [["student_id", 200]]
 => EXPLAIN for: SELECT "lesson_completions".* FROM "lesson_completions" WHERE "lesson_completions"."student_id" = $1 [["student_id", 200]]
                              QUERY PLAN
-----------------------------------------------------------------------
 Seq Scan on lesson_completions  (cost=0.00..4749.30 rows=51 width=28)
   Filter: (student_id = 200)
(2 rows)
```

Note that Postgres appears to be doing a sequential scan on lesson_completions here.

## After:

![image](https://user-images.githubusercontent.com/14152574/38760180-d0d28d90-3f2e-11e8-9472-442bf19bf6b4.png)

```
# User.find(200).lesson_completions.explain

 D, [2018-04-13T11:06:32.344059 #63023] DEBUG -- :   LessonCompletion Load (0.7ms)  SELECT "lesson_completions".* FROM "lesson_completions" WHERE "lesson_completions"."student_id" = $1  [["student_id", 200]]

 => EXPLAIN for: SELECT "lesson_completions".* FROM "lesson_completions" WHERE "lesson_completions"."student_id" = $1 [["student_id", 200]]
                                                    QUERY PLAN
-------------------------------------------------------------------------------------------------------------------
 Index Scan using index_lesson_completions_on_student_id on lesson_completions  (cost=0.42..9.29 rows=50 width=28)
   Index Cond: (student_id = 200)
(2 rows)
```

And here we're doing an index scan using the new index.

## Notes

We also looked at the lessons table, which looks like a significant source of slow queries on production. Because of the small size of this table, Postgres's query analyzer tends to think that seq scans will be fast than using indexes, so in our tests, altering the indexes on that table had no effect (but we also weren't experiencing the same long query times that are evident in production, so perhaps that database is configured somewhat differently).

CAVEAT: I work at Tilde on Skylight

paired with @zvkemp

