### PR TITLE
Optimize `CoursesController#index`

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -20,12 +20,11 @@ class CoursesController < ApplicationController
   end
 
   def ordered_courses
-    Course.order(:position).includes(:lessons, sections: [:lessons])
+    Course.order(:position)
   end
 
+  # TODO: remove me and just use current_user everywhere
   def set_user
-    if user_signed_in?
-      @user = User.includes(:lesson_completions).find(current_user.id)
-    end
+    @user = current_user
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -191,15 +191,15 @@ module ApplicationHelper
   end
 
   def percentage_completed_by_user(course, user)
-    CourseProgress.percentage_completed_by_user(course, user)
+    user.progress_for(course).percentage
   end
 
   def course_started_by_user?(course, user)
-    CourseProgress.course_started?(course, user)
+    user.progress_for(course).started?
   end
 
   def course_completed_by_user?(course, user)
-    CourseProgress.course_completed?(course, user)
+    user.progress_for(course).completed?
   end
 
   def next_lesson_to_complete(course, completed_lessons)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -8,21 +8,7 @@ class Course < ApplicationRecord
 
   friendly_id :title, use: [:slugged, :finders]
 
-  def percent_completed_by(user)
-    100 * (1.0 - uncompleted_lessons_count(user) / lessons_count.to_f)
-  end
-
-  def completed_by?(user)
-    percent_completed_by(user) == 100
-  end
-
-  def lessons_count
-    lessons.count
-  end
-
-  private
-
-  def uncompleted_lessons_count(user)
-    (lessons - user.completed_lessons).count
+  def progress_for(user)
+    user.progress_for(self)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,11 @@ class User < ApplicationRecord
   has_many :projects, dependent: :destroy
   has_many :user_providers, dependent: :destroy
 
+  def progress_for(course)
+    @progress ||= Hash.new { |h, c| h[c] = CourseProgress.new(c, self) }
+    @progress[course]
+  end
+
   def has_completed?(lesson)
     completed_lessons.exists?(lesson.id)
   end

--- a/app/services/course_progress.rb
+++ b/app/services/course_progress.rb
@@ -1,51 +1,38 @@
 class CourseProgress
-  attr_reader :course, :user
-  private :course, :user
-
   def initialize(course, user)
     @course = course
     @user = user
   end
 
-  def self.course_started?(course, user)
-    new(course, user).course_started?
+  def started?
+    completed_lessons > 0
   end
 
-  def self.percentage_completed_by_user(course, user)
-    new(course, user).percentage_completed_by_user
+  def completed?
+    pending_lessons == 0
   end
 
-  def self.course_completed?(course, user)
-    new(course, user).course_completed?
-  end
-
-  def course_started?
-    percentage_completed_by_user > 0
-  end
-
-  def percentage_completed_by_user
-    ((100 / number_of_lessons_in_course.to_f) * number_of_lessons_completed).to_i
-  end
-
-  def course_completed?
-    percentage_completed_by_user == 100
+  def percentage
+    (100.0 * completed_lessons / total_lessons).to_i
   end
 
   private
 
-  def number_of_lessons_in_course
-    course_lessons.size
+  attr_reader :course, :user
+
+  def lesson_ids
+    @lesson_ids ||= course.lesson_ids
   end
 
-  def course_lessons
-    course.lessons
+  def total_lessons
+    @total_lessons ||= lesson_ids.size
   end
 
   def completed_lessons
-    user.completed_lessons
+    @completed_lessons ||= user.lesson_completions.where(lesson_id: lesson_ids).size
   end
 
-  def number_of_lessons_completed
-     (course_lessons & completed_lessons).size
-   end
+  def pending_lessons
+    total_lessons - completed_lessons
+  end
 end

--- a/features/step_definitions/lesson_steps.rb
+++ b/features/step_definitions/lesson_steps.rb
@@ -97,7 +97,7 @@ Then(/^my progress should be saved$/) do
 
   # make sure the percentage completion gets increased
   within '.lc-percent-completion' do
-    percent_completed = @course.percent_completed_by(@user).to_i
+    percent_completed = @user.progress_for(@course).percentage
     expect(page).to have_content("#{percent_completed}% Completed")
   end
 end
@@ -109,7 +109,7 @@ Then(/^my progress should be declined$/) do
 
   # make sure the percentage completion gets increased
   within '.lc-percent-completion' do
-    percent_completed = @course.percent_completed_by(@user).to_i
+    percent_completed = @user.progress_for(@course).percentage
     expect(page).to have_content("#{percent_completed}% Completed")
   end
 end

--- a/spec/controllers/courses_controller_spec.rb
+++ b/spec/controllers/courses_controller_spec.rb
@@ -13,8 +13,7 @@ RSpec.describe CoursesController do
 
   describe 'GET index' do
     before do
-      allow(Course).to receive_message_chain(:order, :includes).
-        and_return(courses)
+      allow(Course).to receive(:order).and_return(courses)
     end
 
     it 'assigns @courses' do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -75,47 +75,115 @@ RSpec.describe ApplicationHelper do
     end
   end
 
-  describe '#percentage_completed_by_user' do
-
-    let(:course) { double('Course') }
+  context 'course progress' do
     let(:user) { double('User') }
+    let(:course) { double('Course') }
+    let(:course_progress) { double('CourseProgress') }
 
     before do
-      allow(CourseProgress).to receive(:percentage_completed_by_user).
-        with(course, user).and_return(50)
+      allow(user).to receive(:progress_for).with(course).and_return(course_progress)
     end
 
-    it 'returns 50' do
-      expect(helper.percentage_completed_by_user(course, user)).to eql(50)
+    context 'when user has not started the course' do
+      before do
+        allow(course_progress).to receive_messages(
+          started?: false,
+          completed?: false,
+          percentage: 0
+        )
+      end
+
+      describe '#course_started_by_user?' do
+        it 'returns false' do
+          expect(helper.course_started_by_user?(course, user)).to eq(false)
+        end
+      end
+
+      describe '#course_completed_by_user?' do
+        it 'returns false' do
+          expect(helper.course_completed_by_user?(course, user)).to eq(false)
+        end
+      end
+
+      describe '#percentage_completed_by_user' do
+        it 'returns 0' do
+          expect(helper.percentage_completed_by_user(course, user)).to eql(0)
+        end
+      end
+
+      describe '#modifier_for_badge' do
+        it 'returns the course show progress modifier for the course badge' do
+          expect(helper.modifier_for_badge(course, user)).to eql('progress-circle--show-progress')
+        end
+      end
     end
-  end
 
-  describe '#course_started_by_user' do
+    context 'when user has started the course' do
+      before do
+        allow(course_progress).to receive_messages(
+          started?: true,
+          completed?: false,
+          percentage: 30
+        )
+      end
 
-    let(:course) { double('Course') }
-    let(:user) { double('User') }
+      describe '#course_started_by_user?' do
+        it 'returns true' do
+          expect(helper.course_started_by_user?(course, user)).to eq(true)
+        end
+      end
 
-    before do
-      allow(CourseProgress).to receive(:course_started?).
-        with(course, user).and_return(true)
+      describe '#course_completed_by_user?' do
+        it 'returns false' do
+          expect(helper.course_completed_by_user?(course, user)).to eq(false)
+        end
+      end
+
+      describe '#percentage_completed_by_user' do
+        it 'returns 30' do
+          expect(helper.percentage_completed_by_user(course, user)).to eql(30)
+        end
+      end
+
+      describe '#modifier_for_badge' do
+        it 'returns the course show progress modifier for the course badge' do
+          expect(helper.modifier_for_badge(course, user)).to eql('progress-circle--show-progress')
+        end
+      end
     end
 
-    it 'returns 50' do
-      expect(helper.course_started_by_user?(course, user)).to eql(true)
-    end
-  end
+    context 'when user has completed the course' do
+      before do
+        allow(course_progress).to receive_messages(
+          started?: true,
+          completed?: true,
+          percentage: 100
+        )
+      end
 
-  describe '#course_completed_by_user?' do
-    let(:course) { double('Course') }
-    let(:user) { double('User') }
+      describe '#course_started_by_user?' do
+        it 'returns true' do
+          expect(helper.course_started_by_user?(course, user)).to eq(true)
+        end
+      end
 
-    before do
-      allow(CourseProgress).to receive(:course_completed?).
-        with(course, user).and_return(true)
-    end
+      describe '#course_completed_by_user?' do
+        it 'returns true' do
+          expect(helper.course_completed_by_user?(course, user)).to eq(true)
+        end
+      end
 
-    it 'returns true' do
-      expect(helper.course_completed_by_user?(course, user)).to eql(true)
+      describe '#percentage_completed_by_user' do
+        it 'returns 100' do
+          expect(helper.percentage_completed_by_user(course, user)).to eql(100)
+        end
+      end
+
+      describe '#modifier_for_badge' do
+        it 'returns the course completed modifier for the course badge' do
+          expect(helper.modifier_for_badge(course, user)).to eql('progress-circle--completed')
+        end
+      end
     end
   end
 
@@ -137,31 +205,6 @@ RSpec.describe ApplicationHelper do
     it 'returns the next lesson the user has to complete' do
       expect(helper.next_lesson_to_complete(course, lesson_completions)).
         to eql(lesson_to_complete)
-    end
-  end
-
-  describe '#modifier_for_badge' do
-    subject(:modifier_for_badge) { helper.modifier_for_badge(course, user) }
-
-    let(:course) { double('Course') }
-    let(:user) { double('User') }
-    let(:course_completed) { true }
-
-    before do
-      allow(CourseProgress).to receive(:course_completed?).
-        with(course, user).and_return(course_completed)
-    end
-
-    it 'returns the course completed modifier for the course badge' do
-      expect(modifier_for_badge).to eql('progress-circle--completed')
-    end
-
-    context 'when the user has not completed the course' do
-      let(:course_completed) { false }
-
-      it 'returns the course show progress modifier for the course badge' do
-        expect(modifier_for_badge).to eql('progress-circle--show-progress')
-      end
     end
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -14,48 +14,4 @@ RSpec.describe Course do
   it { is_expected.to have_many(:sections) }
   it { is_expected.to have_many(:lessons) }
   it { is_expected.to validate_presence_of(:position) }
-
-  describe '#percent_completed_by' do
-    let(:current_user) { double('User') }
-    let(:lesson) { double('Lesson') }
-
-    before do
-      allow(course).to receive(:lessons).and_return(lessons)
-      allow(current_user).to receive(:completed_lessons).and_return([])
-    end
-
-    context 'when a user has completed no lessons' do
-      it 'returns 0' do
-        expect(course.percent_completed_by(current_user)).to eq(0)
-      end
-    end
-
-    context 'when a user has completed the only lesson' do
-      before do
-        allow(course).to receive(:lessons).and_return([lesson])
-        allow(current_user).to receive(:completed_lessons).and_return([lesson])
-      end
-
-      it 'returns 100' do
-        expect(course.percent_completed_by(current_user)).to eq(100)
-      end
-    end
-
-    context 'when a user has completed one of four lessons' do
-      let(:lesson1) { double('Lesson') }
-      let(:lesson2) { double('Lesson') }
-      let(:lesson3) { double('Lesson') }
-      let(:lesson4) { double('Lesson') }
-      let(:lessons) { [lesson1, lesson2, lesson3, lesson4] }
-
-      before do
-        allow(course).to receive(:lessons).and_return(lessons)
-        allow(current_user).to receive(:completed_lessons).and_return([lesson1])
-      end
-
-      it 'returns 25' do
-        expect(course.percent_completed_by(current_user)).to eq(25)
-      end
-    end
-  end
 end

--- a/spec/services/course_progress_spec.rb
+++ b/spec/services/course_progress_spec.rb
@@ -1,49 +1,58 @@
 require 'rails_helper'
 
+class LessonCompletions
+  def initialize(completed_lessons)
+    @completed_lessons = completed_lessons
+  end
+
+  def where(lesson_id:)
+    @completed_lessons.find_all { |lesson| lesson_id.include?(lesson) }
+  end
+end
+
 RSpec.describe CourseProgress do
   subject { CourseProgress.new(course, user) }
 
-  let(:course) { double('Course', lessons: lessons) }
-  let(:lessons) { [lesson, other_lesson_in_course] }
-  let(:lesson) { double('Lesson') }
-  let(:other_lesson_in_course) { double('Lesson') }
-  let(:user) { double('User', completed_lessons: completed_lessons) }
-  let(:completed_lessons) { [lesson] }
+  let(:lessons) { [1,2,3,4,5,6,7,8,9,10] }
+  let(:course) { double('Course', lesson_ids: lessons) }
+  let(:user) { double('User', lesson_completions: LessonCompletions.new(completed_lessons)) }
 
+  context 'when user has not started the course' do
+    let(:completed_lessons) { [] }
 
-  describe '#course_started?' do
-    it 'returns true' do
-      expect(subject.course_started?).to eql(true)
-    end
+    it { is_expected.not_to be_started }
+    it { is_expected.not_to be_completed }
 
-    context 'when user has not started the course' do
-      let(:lesson_from_other_course) { double('Lesson') }
-      let(:completed_lessons) { [lesson_from_other_course] }
-
-      it 'returns false' do
-        expect(subject.course_started?).to eql(false)
+    describe '#percentage' do
+      it 'should be at 0%' do
+        expect(subject.percentage).to eq(0)
       end
     end
   end
 
-  describe '#percentage_completed_by_user' do
-    it 'returns 50' do
-      expect(subject.percentage_completed_by_user).to eql(50)
-    end
-  end
+  context 'when user has started the course' do
+    let(:completed_lessons) { [1,2,3] }
 
-  describe '#course_completed?' do
-    it 'returns false' do
-      expect(subject.course_completed?).to eql(false)
-    end
+    it { is_expected.to be_started }
+    it { is_expected.not_to be_completed }
 
-    context 'when user has completed all lessons in the course' do
-      let(:completed_lessons) { [lesson, other_lesson_in_course] }
-
-      it 'returns true' do
-        expect(subject.course_completed?).to eql(true)
+    describe '#percentage' do
+      it 'should be at 30%' do
+        expect(subject.percentage).to eq(30)
       end
     end
   end
 
+  context 'when user has completed the course' do
+    let(:completed_lessons) { lessons }
+
+    it { is_expected.to be_started }
+    it { is_expected.to be_completed }
+
+    describe '#percentage' do
+      it 'should be at 100%' do
+        expect(subject.percentage).to eq(100)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is a follow up to #888 (I also work at Tilde/Skylight).

Currently, a [significant amount of time](https://oss.skylight.io/app/applications/g0gJSNnzYAws/1523662560/6h/endpoints/CoursesController%23index?responseType=html) (up to 40%!) is spent in loading and initialize the lesson objects:

<img width="1312" alt="skylight" src="https://user-images.githubusercontent.com/55829/38764836-35b265be-3f6b-11e8-80bb-3640c8ed00c1.png">

We originally suspected a missing index, but as @gitKrystan and @zvkemp pointed out, this wasn't the case. Turns out, the reason it is slow is because the lessons have a big `content` field, making them very expensive to load:

1. The database has to read a lot into memory
2. The database has to send back a big result
3. The Ruby driver has to parse/process the big payload
4. The `content` field need to be loaded/copied into big Ruby strings
5. Having these big strings in memory increases memory usage/GC pressure

Therefore, it is a good idea to avoid loading the lesson objects unless they are absolutely needed to display the content, which is probably only needed in `LessonsController#show`.

In the case of `CoursesController#index`, the lesson objects are only loaded to render the badges. This PR demonstrates a way to refactor the relevant code to avoid
needing to load the lessons object.

The focus here is `CoursesController#index`, but a lot of other endpoints can benefit from this optimization (you can find them on Skylight). I'll leave that as an exercise to interested readers 😉

I ran a synthetic benchmark locally:

* I ran `rails server -e production`locally, while sending data to a fresh Skylight app
* I used `ab` to send 1000 requests to `/courses`, before and after the patch, with and without logging in

The results look quite promising, ranging from 11-40% improvement:

<img width="1296" alt="skylight" src="https://user-images.githubusercontent.com/55829/38764891-4808f63c-3f6c-11e8-87d0-61d32ac8eb0b.png">

I would expect to see a bigger improvement on the actual production environment:

1. The synthetic benchmark access the same data/endpoint repeatedly in a short amount of time, making it a best case scenario for the database (things are already in working memory, etc)
2. The database and web server is on the same computer, eliminating time to send those big blobs across the network 
3. My database only has the seed data (and a few rows of `lesson_completions` for a single user)
4. For the same reason as (1), the Rails app probably has much lower GC pressure than production

* * *

If this patch is accepted, I have some follow up suggestions for others who are interested in doing performance work:

1. Do the same work to avoid the need to load the lessons object for other endpoints (`CoursesController#show`, etc).
2. Remove `@user` and consistently use `current_user` everywhere. As far as I can tell, this was only added to force an eager load on `lesson_completions`. I believe this is no longer necessary (and in fact it is now doing an extra/redundant query).
3. Refactor: merge `NextLesson` into `CourseProgress#next_lesson` to remove some duplication and take advantage of better caching.
4. Consider [denormalizing](https://en.wikipedia.org/wiki/Denormalization) `lessons`, i.e. add a `course_id` column, an index on the column, and `belongs_to :course` to the `lessons` table/model (and possibly `lesson_completions` as well). It is not rare that we want to get a list of lessons associated with a course (which I had to do a few times here), but since the only way to do that is to go through `sections` today, fetching the lessons for a course requires a somewhat expensive `JOIN`. Having the `course_id` on the lessons object would help eliminate that cost.

* * *

Finally, it is also worth noting: the "logged in" scenario is not as optimized as it could be. If you look at Skylight or the logs, you will see something like this:

```
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8] Started GET "/courses" for 127.0.0.1 at 2018-04-13 21:30:07 -0700
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8] Processing by CoursesController#index as HTML
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Parameters: {}
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   User Load (1.6ms)  SELECT  "users".* FROM "users" ORDER BY "users"."id" ASC LIMIT $1  [["LIMIT", 1]]
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Course Load (0.8ms)  SELECT "courses".* FROM "courses" ORDER BY "courses"."position" ASC
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Rendering layouts/application.html.erb
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Rendering courses/index.html.erb within layouts/application
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]    (1.1ms)  SELECT "lessons".id FROM "lessons" INNER JOIN "sections" ON "lessons"."section_id" = "sections"."id" WHERE "sections"."course_id" = $1 ORDER BY "lessons"."position" ASC, "sections"."position" ASC  [["course_id", 1]]
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]    (0.7ms)  SELECT COUNT(*) FROM "lesson_completions" WHERE "lesson_completions"."student_id" = $1 AND "lesson_completions"."lesson_id" IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35)  [["student_id", 1]]
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Rendered shared/_course_badge.html.erb (0.7ms)
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]    (0.9ms)  SELECT COUNT(*) FROM "lessons" INNER JOIN "sections" ON "lessons"."section_id" = "sections"."id" WHERE "sections"."course_id" = $1  [["course_id", 1]]
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Rendered courses/_course_card.html.erb (99.0ms)
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]    (0.6ms)  SELECT "lessons".id FROM "lessons" INNER JOIN "sections" ON "lessons"."section_id" = "sections"."id" WHERE "sections"."course_id" = $1 ORDER BY "lessons"."position" ASC, "sections"."position" ASC  [["course_id", 2]]
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]    (0.4ms)  SELECT COUNT(*) FROM "lesson_completions" WHERE "lesson_completions"."student_id" = $1 AND "lesson_completions"."lesson_id" IN (36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57)  [["student_id", 1]]
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Rendered shared/_course_badge.html.erb (0.2ms)
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]    (0.5ms)  SELECT COUNT(*) FROM "lessons" INNER JOIN "sections" ON "lessons"."section_id" = "sections"."id" WHERE "sections"."course_id" = $1  [["course_id", 2]]
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Rendered courses/_course_card.html.erb (4.2ms)
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]    (0.5ms)  SELECT "lessons".id FROM "lessons" INNER JOIN "sections" ON "lessons"."section_id" = "sections"."id" WHERE "sections"."course_id" = $1 ORDER BY "lessons"."position" ASC, "sections"."position" ASC  [["course_id", 3]]
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]    (0.4ms)  SELECT COUNT(*) FROM "lesson_completions" WHERE "lesson_completions"."student_id" = $1 AND "lesson_completions"."lesson_id" IN (58, 59, 60)  [["student_id", 1]]
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Rendered shared/_course_badge.html.erb (0.1ms)
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]    (0.5ms)  SELECT COUNT(*) FROM "lessons" INNER JOIN "sections" ON "lessons"."section_id" = "sections"."id" WHERE "sections"."course_id" = $1  [["course_id", 3]]
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Rendered courses/_course_card.html.erb (3.8ms)
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]    (0.7ms)  SELECT "lessons".id FROM "lessons" INNER JOIN "sections" ON "lessons"."section_id" = "sections"."id" WHERE "sections"."course_id" = $1 ORDER BY "lessons"."position" ASC, "sections"."position" ASC  [["course_id", 4]]
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]    (0.5ms)  SELECT COUNT(*) FROM "lesson_completions" WHERE "lesson_completions"."student_id" = $1 AND "lesson_completions"."lesson_id" IN (61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93)  [["student_id", 1]]
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Rendered shared/_course_badge.html.erb (0.1ms)
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]    (0.6ms)  SELECT COUNT(*) FROM "lessons" INNER JOIN "sections" ON "lessons"."section_id" = "sections"."id" WHERE "sections"."course_id" = $1  [["course_id", 4]]
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Rendered courses/_course_card.html.erb (6.6ms)
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]    (0.6ms)  SELECT "lessons".id FROM "lessons" INNER JOIN "sections" ON "lessons"."section_id" = "sections"."id" WHERE "sections"."course_id" = $1 ORDER BY "lessons"."position" ASC, "sections"."position" ASC  [["course_id", 5]]
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]    (0.4ms)  SELECT COUNT(*) FROM "lesson_completions" WHERE "lesson_completions"."student_id" = $1 AND "lesson_completions"."lesson_id" IN (94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122)  [["student_id", 1]]
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Rendered shared/_course_badge.html.erb (0.5ms)
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]    (0.7ms)  SELECT COUNT(*) FROM "lessons" INNER JOIN "sections" ON "lessons"."section_id" = "sections"."id" WHERE "sections"."course_id" = $1  [["course_id", 5]]
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Rendered courses/_course_card.html.erb (6.8ms)
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]    (1.9ms)  SELECT "lessons".id FROM "lessons" INNER JOIN "sections" ON "lessons"."section_id" = "sections"."id" WHERE "sections"."course_id" = $1 ORDER BY "lessons"."position" ASC, "sections"."position" ASC  [["course_id", 6]]
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]    (0.8ms)  SELECT COUNT(*) FROM "lesson_completions" WHERE "lesson_completions"."student_id" = $1 AND "lesson_completions"."lesson_id" IN (123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151)  [["student_id", 1]]
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Rendered shared/_course_badge.html.erb (0.2ms)
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]    (0.8ms)  SELECT COUNT(*) FROM "lessons" INNER JOIN "sections" ON "lessons"."section_id" = "sections"."id" WHERE "sections"."course_id" = $1  [["course_id", 6]]
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Rendered courses/_course_card.html.erb (10.7ms)
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]    (0.7ms)  SELECT "lessons".id FROM "lessons" INNER JOIN "sections" ON "lessons"."section_id" = "sections"."id" WHERE "sections"."course_id" = $1 ORDER BY "lessons"."position" ASC, "sections"."position" ASC  [["course_id", 7]]
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]    (0.4ms)  SELECT COUNT(*) FROM "lesson_completions" WHERE "lesson_completions"."student_id" = $1 AND "lesson_completions"."lesson_id" IN (152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165)  [["student_id", 1]]
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Rendered shared/_course_badge.html.erb (0.2ms)
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]    (0.6ms)  SELECT COUNT(*) FROM "lessons" INNER JOIN "sections" ON "lessons"."section_id" = "sections"."id" WHERE "sections"."course_id" = $1  [["course_id", 7]]
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Rendered courses/_course_card.html.erb (12.4ms)
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Rendered courses/index.html.erb within layouts/application (188.0ms)
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Rendered shared/_head.html.erb (1.3ms)
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Rendered shared/_logo.html.erb (0.7ms)
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Rendered shared/_navbar_modal.html.erb (3.6ms)
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Rendered shared/_logo.html.erb (0.5ms)
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Rendered shared/_user_dropdown.html.erb (1.3ms)
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Rendered shared/_navbar.html.erb (10.0ms)
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   AdminFlash Load (1.2ms)  SELECT "admin_flashes".* FROM "admin_flashes" WHERE (expires >= '2018-04-14 04:30:07.958909') ORDER BY created_at desc
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Rendered shared/_admin_flash.html.erb (4.7ms)
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Rendered shared/_navbar_and_flashes.html.erb (18.4ms)
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Rendered shared/_logo.html.erb (0.3ms)
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Rendered shared/_footer.html.erb (2.0ms)
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Rendered shared/_sidecar.html.erb (0.3ms)
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Rendered shared/_ga.html.erb (0.2ms)
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Rendered layouts/application.html.erb (217.4ms)
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8] Completed 200 OK in 304ms (Views: 200.5ms | ActiveRecord: 44.9ms)
```

As you can see, to render each of the courses, three queries are needed:

```
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]    (1.1ms)  SELECT "lessons".id FROM "lessons" INNER JOIN "sections" ON "lessons"."section_id" = "sections"."id" WHERE "sections"."course_id" = $1 ORDER BY "lessons"."position" ASC, "sections"."position" ASC  [["course_id", 1]]
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]    (0.7ms)  SELECT COUNT(*) FROM "lesson_completions" WHERE "lesson_completions"."student_id" = $1 AND "lesson_completions"."lesson_id" IN (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35)  [["student_id", 1]]
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Rendered shared/_course_badge.html.erb (0.7ms)
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]    (0.9ms)  SELECT COUNT(*) FROM "lessons" INNER JOIN "sections" ON "lessons"."section_id" = "sections"."id" WHERE "sections"."course_id" = $1  [["course_id", 1]]
[9ba5c805-806c-4ff5-9d5e-48fa283a2be8]   Rendered courses/_course_card.html.erb (99.0ms)
```

The first two are necessary to render the progress badge, as you need to know the number of completed lessons and the total number of lessons for a given course to calculate the percentage. (By the way, the first query is the complex `JOIN` that could be eliminated by denormalization.)

However, the third query should not be necessary: it is used to render the count (e.g. 53 lessons) [here](https://github.com/TheOdinProject/theodinproject/blob/18ee7845e671a671f7d9a16a86a91fd641987ec3/app/views/courses/_course_card.html.erb#L22). This is unnecessary because we already fetched all the lesson_ids for the course in the first query, so we can just count that result.

In my opinion, this is a bug/missing feature in Rails, so I opened https://github.com/rails/rails/issues/32569. Assuming the rest of the team agrees with me, it would make a pretty good first PR if someone is interested in contributing to Rails.