### PR TITLE
Change to Read Only Permission with Github Oauth

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -215,7 +215,7 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   require 'omniauth-github'
-  config.omniauth :github, ENV["GITHUB_APP_ID"], ENV["GITHUB_SECRET"], :scope => 'user,public_repo'
+  config.omniauth :github, ENV["GITHUB_APP_ID"], ENV["GITHUB_SECRET"], :scope => ''
   config.omniauth :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_CLIENT_SECRET'], name: 'google', verify_iss: false
 
   # ==> Warden configuration


### PR DESCRIPTION
When we implemented Github oauth we must have copy and pasted the
instructions straight from the read me of the github-omniauth gem.

The example included a scope which requested full read and write
permission to the user's profile and repos on Github. We don't need
any of that and it creeps a lot of users out when prompted to review
permissions upon signing up.

This removes those permissions so we only request read only access to
the users profile on Github and nothing else.