### PR TITLE
Excludes punctuation from header anchor links

### DIFF
--- a/app/assets/javascripts/lessons.js
+++ b/app/assets/javascripts/lessons.js
@@ -10,7 +10,7 @@ function getElements(selector) {
 }
 
 function kebabCase(text) {
-  return text.toLowerCase().match(/\w+/g).join('-');
+  return text.toLowerCase().replace(/[^\w\d -]/, '').split(' ').join('-');
 }
 
 function setTargetForExternalLinks() {


### PR DESCRIPTION
For #903.

When Markdown is parsed, the header text is turned to lowercase, and any characters other than alphanumeric character, spaces, and hyphens are removed. Spaces are then replaced with hyphens to form the anchor.