### PR TITLE
Update sprockets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'kramdown'
 gem 'toastr-rails'
 gem 'gibbon',                       '~> 3.2.0' # for Mailchimp
 gem 'nokogiri',                     '~> 1.8', '>= 1.8.2'
+gem 'sprockets',                    '~> 3.7.2'
 gem 'skylight'
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,7 +248,7 @@ GEM
       actionmailer (>= 3, < 6)
       premailer (~> 1.7, >= 1.7.9)
     puma (3.11.2)
-    rack (2.0.4)
+    rack (2.0.5)
     rack-attack (5.0.1)
       rack
     rack-test (0.6.3)
@@ -341,7 +341,7 @@ GEM
     simplecov-html (0.10.1)
     skylight (1.5.0)
       activesupport (>= 3.0.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.0)
@@ -436,6 +436,7 @@ DEPENDENCIES
   shoulda-matchers (~> 3.1)
   simplecov
   skylight
+  sprockets (~> 3.7.2)
   tether-rails
   toastr-rails
   turbolinks
@@ -448,4 +449,4 @@ RUBY VERSION
    ruby 2.5.0p0
 
 BUNDLED WITH
-   1.16.1
+   1.16.2


### PR DESCRIPTION
We weren't affected by the vulnerability as we had `config.assets.compile` set to `false` in `config/environments/production.rb` but thought it would be better to update sprockets.

/cc @KevinMulhern 