### PR TITLE
fix lesson nav bullets with some CSS.

### DIFF
--- a/app/assets/stylesheets/components/lesson/_navigation.scss
+++ b/app/assets/stylesheets/components/lesson/_navigation.scss
@@ -24,6 +24,7 @@
   &__title {
     color: $grey;
     display: inline-block;
+    flex: 1;
     font-size: 13px;
     letter-spacing: 0.2px;
     margin-left: 10px;


### PR DESCRIPTION
fixes this:
![image](https://user-images.githubusercontent.com/18574792/42575436-167e1af6-84e6-11e8-99f6-36635eede220.png)

and makes it look like this:
![image](https://user-images.githubusercontent.com/18574792/42575441-1c0c131a-84e6-11e8-8d13-587e3ca20c36.png)