### PR TITLE
Fix Side Nav Bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'acts_as_votable'
 gem 'kramdown'
 gem 'toastr-rails'
 gem 'gibbon',                       '~> 3.2.0' # for Mailchimp
-gem 'nokogiri',                     '~> 1.8', '>= 1.8.2'
+gem 'nokogiri',                     '~> 1.8', '>= 1.8.4'
 gem 'sprockets',                    '~> 3.7.2'
 gem 'skylight'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,7 +205,7 @@ GEM
     multipart-post (2.0.0)
     newrelic_rpm (3.18.1.330)
     nio4r (2.1.0)
-    nokogiri (1.8.2)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     oauth2 (1.4.0)
       faraday (>= 0.8, < 0.13)
@@ -414,7 +414,7 @@ DEPENDENCIES
   kramdown
   letter_opener (~> 1.4)
   newrelic_rpm (~> 3.17)
-  nokogiri (~> 1.8, >= 1.8.2)
+  nokogiri (~> 1.8, >= 1.8.4)
   octokit (~> 4.6)
   omniauth-github (~> 1.1.2)
   omniauth-google-oauth2 (~> 0.5.1)

--- a/app/assets/javascripts/lessons.js
+++ b/app/assets/javascripts/lessons.js
@@ -38,7 +38,7 @@ function getInnerText(heading) {
 }
 
 function isCommonHeading(heading) {
-  return LESSON_HEADINGS.indexOf(heading) !== LESSON_HEADINGS.length - 1;
+  return LESSON_HEADINGS.indexOf(heading) >  -1;
 }
 
 function getLessonHeadings() {


### PR DESCRIPTION
The side nav was rendering links to all headings on lessons instead of white
listed headings only.

This also updates Nokogiri to fix a security warning Jenkins was complaining about.