### PR TITLE
Fix for issue #920: Added class names to summary tag in installfest.

### DIFF
--- a/app/assets/stylesheets/components/lesson/lesson_content.scss
+++ b/app/assets/stylesheets/components/lesson/lesson_content.scss
@@ -115,4 +115,11 @@
     margin-bottom: 30px;
   }
 
+  details .dropDown-header {
+    font-size: 1.5em;
+    font-weight: bold;
+    color: $text-primary;
+  }
 }
+
+


### PR DESCRIPTION
Per #920 slight styling change to the Summary tags in dropdowns. 

Increased font size and weight, as well as changing the colour back to the primary text colour, increases visibility and causes the heading of each detail drawer to stand out.

This goes along with a curriculum pull request. https://github.com/TheOdinProject/curriculum/pull/8075