### PR TITLE
update seeds for js frameworks project to style it as a project

### DIFF
--- a/db/seeds/06_javascript_course_seeds.rb
+++ b/db/seeds/06_javascript_course_seeds.rb
@@ -330,7 +330,7 @@ create_or_update_lesson(
   description: "Project: Frameworks",
   position: lesson_position,
   section_id: section.id,
-  is_project: false,
+  is_project: true,
   url: "/frameworks/frameworks-project.md",
   repo: 'javascript_curriculum'
 )


### PR DESCRIPTION
The new JS frameworks project isn't listed as a project in the seeds. This is my fix.