### PR TITLE
Update frameworks project title and title url in seeds

### DIFF
--- a/db/seeds/06_javascript_course_seeds.rb
+++ b/db/seeds/06_javascript_course_seeds.rb
@@ -325,8 +325,8 @@ create_or_update_lesson(
 
 lesson_position += 1
 create_or_update_lesson(
-  title: "Project: Frameworks",
-  title_url: "Project: Frameworks".parameterize,
+  title: "Frameworks",
+  title_url: "Frameworks".parameterize,
   description: "Project: Frameworks",
   position: lesson_position,
   section_id: section.id,


### PR DESCRIPTION
Removes the 'Project: ' prefix from the `title` and `title_url` fields for 'Frameworks' project as we don't want the title to prefixed by double  'Project:'

ie. The lesson has been marked as a `project` and a project lesson has a [`title`](https://github.com/TheOdinProject/theodinproject/blob/seeds-update/app/decorators/lesson_decorator.rb#L4) method which returns the lesson title prefixed by 'Project' anyway.