### PR TITLE
Fix/install details further dropdown styling

### DIFF
--- a/app/assets/stylesheets/components/lesson/lesson_content.scss
+++ b/app/assets/stylesheets/components/lesson/lesson_content.scss
@@ -117,8 +117,10 @@
 
   details .dropDown-header {
     font-size: 1.5em;
+    margin-bottom: 1em;
     font-weight: bold;
     color: $text-primary;
+    cursor: pointer;
   }
 }
 

--- a/app/assets/stylesheets/components/lesson/lesson_content.scss
+++ b/app/assets/stylesheets/components/lesson/lesson_content.scss
@@ -117,15 +117,10 @@
 
   details .dropDown-header {
     font-size: 1.5em;
-<<<<<<< HEAD
     margin-bottom: 1em;
     font-weight: bold;
     color: $text-primary;
     cursor: pointer;
-=======
-    font-weight: bold;
-    color: $text-primary;
->>>>>>> fc74d81abbf0585b616f30dfa2086027e61b4b5b
   }
 }
 

--- a/app/assets/stylesheets/components/lesson/lesson_content.scss
+++ b/app/assets/stylesheets/components/lesson/lesson_content.scss
@@ -115,4 +115,11 @@
     margin-bottom: 30px;
   }
 
+  details .dropDown-header {
+    font-size: 1.5em;
+    font-weight: bold;
+    color: $text-primary;
+  }
 }
+
+


### PR DESCRIPTION
It was brought to my attention that the dropdowns in the install fest needed additional styling to draw attention to the fact they can, in fact, be dropped down. 

A cursor change and increasing the bottom margin of both should help them stand out even more. 