### PR TITLE
Adds rel='noreferrer' to external links

### DIFF
--- a/app/assets/javascripts/lessons.js
+++ b/app/assets/javascripts/lessons.js
@@ -16,6 +16,7 @@ function kebabCase(text) {
 function setTargetForExternalLinks() {
   getElements('.lesson-content a[href^=http]').forEach(function(externalLink) {
     externalLink.setAttribute('target', '_blank');
+    externalLink.setAttribute('rel', 'noreferrer');
   });
 }
 

--- a/app/helpers/button_helper.rb
+++ b/app/helpers/button_helper.rb
@@ -20,7 +20,8 @@ module ButtonHelper
       'Open Gitter',
       chat_link,
       class: 'button button--secondary',
-      target: '_blank'
+      target: '_blank',
+      rel: 'noreferrer'
     )
   end
 

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -12,7 +12,7 @@
     <div class="footer-links-container">
       <%= link_to "About", about_path, class: "footer-link" %>
       <%= link_to "FAQ", faq_path, class: "footer-link" %>
-      <%= link_to "Blog", medium_blog_path, target: "_blank", class: "footer-link" %>
+      <%= link_to "Blog", medium_blog_path, target: "_blank", rel: "noreferrer", class: "footer-link" %>
     </div>
     <div class="footer-links-container">
       <%= link_to "Success Stories", success_stories_path, class: "footer-link" %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -23,12 +23,12 @@
           </a>
           <ul class="dropdown-menu dropdown-menu-right menu-options pb-0">
             <li>
-              <%= link_to forum_link, class: 'drop-down-link accent', target: '_blank', rel: 'noopener noreferrer' do %>
+              <%= link_to forum_link, class: 'drop-down-link accent', target: '_blank', rel: 'noreferrer' do %>
                 <span class="drop-down-logo fa fa-users mt-2"></span>Forum
               <% end %>
             </li>
             <li>
-              <%= link_to chat_link, class: 'drop-down-link accent', target: '_blank', rel: 'noopener noreferrer' do %>
+              <%= link_to chat_link, class: 'drop-down-link accent', target: '_blank', rel: 'noreferrer' do %>
                 <span class="drop-down-logo fa fa-comment mt-2"></span>Chat
               <% end %>
             </li>
@@ -50,12 +50,12 @@
           </a>
           <ul class="dropdown-menu dropdown-menu-right menu-options pb-0">
             <li>
-              <%= link_to forum_link, class: "drop-down-link accent", target: '_blank', rel: 'noopener noreferrer' do %>
+              <%= link_to forum_link, class: "drop-down-link accent", target: '_blank', rel: 'noreferrer' do %>
                 <span class="drop-down-logo fa fa-users mt-2"></span>Forum
               <% end %>
             </li>
             <li>
-              <%= link_to chat_link, class: 'drop-down-link accent', target: '_blank', rel: 'noopener noreferrer' do %>
+              <%= link_to chat_link, class: 'drop-down-link accent', target: '_blank', rel: 'noreferrer' do %>
                 <span class="drop-down-logo fa fa-comment mt-2"></span>Chat
               <% end %>
             </li>

--- a/app/views/shared/_navbar_modal.html.erb
+++ b/app/views/shared/_navbar_modal.html.erb
@@ -23,7 +23,7 @@
             <%= link_to 'Forum', forum_link, class: 'nav-link' %>
           </li>
           <li class="nav-item">
-            <%= link_to 'Chat', chat_link, class: 'nav-link gitter-chat-link', target: '_blank' %>
+            <%= link_to 'Chat', chat_link, class: 'nav-link gitter-chat-link', target: '_blank', rel: 'noreferrer' %>
           </li>
 
           <div class="dropdown-divider"></div>
@@ -46,7 +46,7 @@
             </a>
             <div class="collapse" id="collapseCommunity">
               <%= link_to 'Forum', forum_link, class: 'nav-link' %>
-              <%= link_to 'Chat', chat_link, class: 'nav-link gitter-chat-link', target: '_blank' %>
+              <%= link_to 'Chat', chat_link, class: 'nav-link gitter-chat-link', target: '_blank', rel: 'noreferrer' %>
             </div>
           </li>
 

--- a/app/views/static_pages/about.html.erb
+++ b/app/views/static_pages/about.html.erb
@@ -60,9 +60,9 @@
             Connect with our friendly community on gitter, a chat and networking platform or <a href="mailto:contact@theodinproject.com">send us an email</a>
           </p>
 
-          <%= link_to 'Chat on Gitter', chat_link, class: 'button button--secondary', target: '_blank' %>
+          <%= link_to 'Chat on Gitter', chat_link, class: 'button button--secondary', target: '_blank', rel: 'noreferrer' %>
         </div>
-      </div> <!-- /.contact -->
+      </div>
     </div>
 
     <div class="contribute">

--- a/app/views/static_pages/contributing/_contributing_options.html.erb
+++ b/app/views/static_pages/contributing/_contributing_options.html.erb
@@ -24,7 +24,7 @@
             <h3 class="contributing-card__title"><%= contribution[:title] %></h3>
             <p class="contributing-card__description"><%= contribution[:description] %></p>
             <div class="contributing-card__button">
-              <%= link_to 'View on GitHub', github_link(contribution[:path]), class: 'button button--primary', target: '_blank' %>
+              <%= link_to 'View on GitHub', github_link(contribution[:path]), class: 'button button--primary', target: '_blank', rel: 'noreferrer' %>
             </div>
           </div>
         </div>

--- a/app/views/static_pages/contributing/_hall_of_fame.erb
+++ b/app/views/static_pages/contributing/_hall_of_fame.erb
@@ -119,7 +119,7 @@
     <div class="row">
       <% members.each do |member| %>
         <div class="col-lg-2 col-md-3 col-sm-4 col-xs-6 hall-of-fame__member">
-          <%= link_to(member[:github_url], target: "_blank") do %>
+          <%= link_to(member[:github_url], target: "_blank", rel: "noreferrer") do %>
             <%= image_tag(member[:image], alt: member[:name], class: 'img-fluid') %>
           <% end %>
         </div>
@@ -128,7 +128,7 @@
   </div>
 
   <div class="hall-of-fame__view-all">
-    <%= link_to 'View All Contributors', github_link('theodinproject/graphs/contributors'), class: 'camel-link mb-5', target: '_blank'%>
+    <%= link_to 'View All Contributors', github_link('theodinproject/graphs/contributors'), class: 'camel-link mb-5', target: '_blank', rel: 'noreferrer' %>
   </div>
 
   <%= render 'shared/bottom_cta',

--- a/spec/helpers/button_helper_spec.rb
+++ b/spec/helpers/button_helper_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ButtonHelper do
 
   describe '#gitter_button' do
     let(:gitter_button) {
-      '<a class="button button--secondary" target="_blank" href="https://gitter.im/TheOdinProject/theodinproject">Open Gitter</a>'
+      '<a class="button button--secondary" target="_blank" rel="noreferrer" href="https://gitter.im/TheOdinProject/theodinproject">Open Gitter</a>'
     }
 
     before do


### PR DESCRIPTION
This PR fixes a vulnerability on links with `target` attribute set to `_blank`.

For more info, check [this](https://developers.google.com/web/tools/lighthouse/audits/noopener) out.