### PR TITLE
Fix Factory Bot Depreciation Warnings

### DIFF
--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -7,12 +7,12 @@ FactoryBot.define do
       "foo#{n}@bar.com"
     end
 
-    password 'foobar'
-    confirmed_at Time.now - 5_000_000
-    avatar 'http://github.com/fake-avatar'
+    password { 'foobar' }
+    confirmed_at { Time.now - 5_000_000 }
+    avatar { 'http://github.com/fake-avatar' }
 
     factory :admin do
-      admin true
+      admin { true }
     end
   end
 
@@ -23,9 +23,9 @@ FactoryBot.define do
     sequence :position do |n|
       n
     end
-    url 'http://www.bogus.com/subpage/whatever.git'
+    url { 'http://www.bogus.com/subpage/whatever.git' }
     association :section
-    content 'content'
+    content { 'content' }
   end
 
   factory :section do
@@ -50,8 +50,8 @@ FactoryBot.define do
   end
 
   factory :project do
-    repo_url 'https://github.com/user/repo'
-    live_preview 'http://mysite.com'
+    repo_url { 'https://github.com/user/repo' }
+    live_preview { 'http://mysite.com' }
     user
   end
 end


### PR DESCRIPTION
Factory Bot is flagging up depreciation warnings when we run the unit tests.This Resolves them.