### PR TITLE
add FB pixel

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,5 +11,6 @@
     <%= render 'shared/footer' %>
     <%= render 'shared/sidecar' %>
     <%= render 'shared/ga' %>
+    <%= render 'shared/fb' %>
   </body>
 </html>

--- a/app/views/shared/_fb.html.erb
+++ b/app/views/shared/_fb.html.erb
@@ -1,0 +1,18 @@
+<% if current_page?(controller: 'static_pages', action: 'home') && Rails.env.production? %>
+<!-- FB pixel -->
+<script>
+    !function(f,b,e,v,n,t,s)
+    {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+    n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+    if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+    n.queue=[];t=b.createElement(e);t.async=!0;
+    t.src=v;s=b.getElementsByTagName(e)[0];
+    s.parentNode.insertBefore(t,s)}(window,document,'script',
+    'https://connect.facebook.net/en_US/fbevents.js');
+    fbq('init', '204929933721168'); 
+    fbq('track', 'PageView');
+</script>
+<noscript>
+    <img height="1" width="1" src="https://www.facebook.com/tr?id=204929933721168&ev=PageView&noscript=1"/>
+</noscript>
+<% end %>


### PR DESCRIPTION
Per conversation between @KevinMulhern and @adamelevenson, I was asked to add a FB pixel to the home page for tracking.

Please let me know if this is an acceptable way to do it. I based it off of the pattern I saw already in this codebase for Google Analytics.

I had looked into the [Rack Tracker](https://github.com/railslove/rack-tracker) gem for this, but decided against it once I saw the `_ga` partial. But do let me know if you think using Rack Tracker is a cleaner way to do it.

Thanks!