### PR TITLE
Fix Error With Email and Password Sign Up's

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,10 +28,10 @@ gem 'gibbon',                       '~> 3.2.0' # for Mailchimp
 gem 'nokogiri',                     '~> 1.8', '>= 1.8.4'
 gem 'sprockets',                    '~> 3.7.2'
 gem 'skylight'
+gem 'newrelic_rpm',               '~> 3.17'
 
 group :production do
   gem 'rails_12factor',             '~> 0.0.3'
-  gem 'newrelic_rpm',               '~> 3.17'
 end
 
 group :development, :test do

--- a/app/services/mailchimp_subscription.rb
+++ b/app/services/mailchimp_subscription.rb
@@ -16,6 +16,8 @@ class MailchimpSubscription
 
   def create
     mailchimp_list.members.create(body: subscriber_details)
+  rescue Gibbon::MailChimpError => e
+    NewRelic::Agent.notice_error(e)
   end
 
   private

--- a/spec/services/mailchimp_subscription_spec.rb
+++ b/spec/services/mailchimp_subscription_spec.rb
@@ -19,5 +19,23 @@ RSpec.describe MailchimpSubscription do
       MailchimpSubscription.new(options).create
       expect(mailchimp_member_exists?(email, list_id)).to eq(true)
     end
+
+    context 'when an error occurs with mail chimp' do
+      let(:request) { double('Gibbon::Request', ) }
+      let(:mailchimp_list) { double('MailChimp::List', members: members) }
+      let(:members) { double('Members') }
+
+      before do
+        allow(Gibbon::Request).to receive(:new).and_return(request)
+        allow(request).to receive(:lists).and_return(mailchimp_list)
+        allow(members).to receive(:create).and_raise(Gibbon::MailChimpError)
+      end
+
+      it 'sends the error to new relic' do
+        expect(NewRelic::Agent).to receive(:notice_error)
+
+        MailchimpSubscription.new(options).create
+      end
+    end
   end
 end


### PR DESCRIPTION
Users who attempted to sign up with email and password were getting incorrectly
redirected to `/users` instead of to their dashboard. After investigation this was
caused by the Mail Chimp news letter sign up service.

It is currently erroring out when trying to connect to the Mail Chimp.
To stop this issue from affecting users we have wrapped the call to the
Mail Chimp api in a rescue block that will log any occurrences of this error to New Relic
so we have visibility of it.