### PR TITLE
Fix/fixed navbar alignment

### DIFF
--- a/app/assets/stylesheets/components/navbar.scss
+++ b/app/assets/stylesheets/components/navbar.scss
@@ -213,6 +213,12 @@
           text-shadow: 0px 0px 8px rgba(204, 149, 67, .5);
         }
       }
+      //overriding bootstrap dropdown-toggle vertical align for tablet mode
+      .nav-link.dropdown-toggle::after{
+        vertical-align: baseline;
+        position: relative;
+        top:-0.255em;
+      }
       .divider {
         display: none;
       }

--- a/app/assets/stylesheets/components/navbar.scss
+++ b/app/assets/stylesheets/components/navbar.scss
@@ -215,7 +215,7 @@
       }
       //overriding bootstrap dropdown-toggle vertical align for tablet mode
       .nav-link.dropdown-toggle::after{
-        vertical-align: baseline;
+        vertical-align: baseline !important;
         position: relative;
         top:-0.255em;
       }


### PR DESCRIPTION
For issue#960 [https://github.com/TheOdinProject/theodinproject/issues/960](Navbar out of alignment).
Override vertical-align for bootstrap's dropdown-toggle in tablet mode and replace it with a top offset using relative positioning.