### PR TITLE
Ease Username Size Validations

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
   acts_as_voter
 
   validates_uniqueness_of :email
-  validates :username, length: { in: 4..20 }
+  validates :username, length: { in: 2..40 }
   validates :learning_goal, length: { maximum: 1700 }
 
   has_many :lesson_completions, foreign_key: :student_id

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe User do
       .and_return(lesson_completions)
   end
 
-  it { is_expected.to validate_length_of(:username).is_at_least(4).is_at_most(20) }
+  it { is_expected.to validate_length_of(:username).is_at_least(2).is_at_most(40) }
   it { is_expected.to validate_length_of(:learning_goal).is_at_most(1700) }
   it { is_expected.to have_many(:lesson_completions) }
   it { is_expected.to have_many(:completed_lessons) }


### PR DESCRIPTION
We see quite a few validation errors day from username validation failures when users
try to sign in through google or github omniauth.

Increasing the range of valid username sizes should reduce frequency of these errors
significantly.
<img width="1208" alt="screen shot 2019-01-16 at 17 58 19" src="https://user-images.githubusercontent.com/7963776/51269119-8c991e80-19b9-11e9-8ca5-a40c122684f2.png">
