### PR TITLE
Fix/fixed navbar out of alignment

### DIFF
--- a/app/assets/stylesheets/components/navbar_modal.scss
+++ b/app/assets/stylesheets/components/navbar_modal.scss
@@ -60,6 +60,7 @@
       background-color: transparent;
       color: $primary;
       padding: 5vh 0;
+      height: 5vh;
       font-size: 5vh;
       line-height: 0;
       line-height: 0;

--- a/app/assets/stylesheets/components/navbar_modal.scss
+++ b/app/assets/stylesheets/components/navbar_modal.scss
@@ -59,8 +59,7 @@
       transition: all 0.25s ease;
       background-color: transparent;
       color: $primary;
-      padding: 7.5vh 0;
-      height: 5vh;
+      padding: 5vh 0;
       font-size: 5vh;
       line-height: 0;
       line-height: 0;


### PR DESCRIPTION
Fixed the navbar out of alignment issue  #960. Reducing the padding of the navbar area to 5vh from 7.5vh seems to resolve it. Mobile menu still looks okay. Would this be breaking any other menu items?

![tablet](https://user-images.githubusercontent.com/19766717/51430105-db69d280-1bca-11e9-95df-9c223295a7bb.png)
![mobile](https://user-images.githubusercontent.com/19766717/51430107-dc9aff80-1bca-11e9-8c0f-7a9dfb5cb5d6.png)
