### PR TITLE
Remove Phantom from Travis Config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,6 @@ rvm:
   - 2.5.0
 services:
   - postgresql
-install:
-  - mkdir travis-phantomjs
-  - wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
-  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -C $PWD/travis-phantomjs
-  - export PATH=$PWD/travis-phantomjs:$PATH
 before_script:
   - bundle install
   - psql -c 'create database theodinproject_test;' -U postgres


### PR DESCRIPTION
We no longer use phantom so this can be removed from the Travis config