### PR TITLE
Fix/Bug #960 - Navbar out of alignment

### DIFF
--- a/app/assets/stylesheets/components/navbar_modal.scss
+++ b/app/assets/stylesheets/components/navbar_modal.scss
@@ -59,11 +59,10 @@
       transition: all 0.25s ease;
       background-color: transparent;
       color: $primary;
-      padding: 7.5vh 0;
+      padding: 0;
       height: 5vh;
       font-size: 5vh;
-      line-height: 0;
-      line-height: 0;
+      line-height: 5vh;
 
       &:hover {
         color: $black;


### PR DESCRIPTION
Bug #960 - Navbar out of alignment

Setting the `line-height` and `height` of the `.nav-link` class to the same size (in this case 5vh) seems to have fixed the alignment of the "Community" drop-down menu link.