### PR TITLE
Add active admin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'nokogiri',                     '~> 1.8', '>= 1.8.4'
 gem 'sprockets',                    '~> 3.7.2'
 gem 'skylight'
 gem 'newrelic_rpm',               '~> 3.17'
+gem 'activeadmin'
 
 group :production do
   gem 'rails_12factor',             '~> 0.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,18 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    activeadmin (1.4.3)
+      arbre (>= 1.1.1)
+      coffee-rails
+      formtastic (~> 3.1)
+      formtastic_i18n
+      inherited_resources (>= 1.9.0)
+      jquery-rails (>= 4.2.0)
+      kaminari (>= 0.15)
+      railties (>= 4.2, < 5.3)
+      ransack (>= 1.8.7)
+      sass (~> 3.1)
+      sprockets (< 4.1)
     activejob (5.0.7.1)
       activesupport (= 5.0.7.1)
       globalid (>= 0.3.6)
@@ -41,6 +53,8 @@ GEM
     acts_as_votable (0.11.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    arbre (1.1.1)
+      activesupport (>= 3.0.0)
     arel (7.1.4)
     ast (2.4.0)
     autoprefixer-rails (9.1.4)
@@ -74,6 +88,13 @@ GEM
     coderay (1.1.2)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
+    coffee-rails (4.2.2)
+      coffee-script (>= 2.2.0)
+      railties (>= 4.0.0)
+    coffee-script (2.4.1)
+      coffee-script-source
+      execjs
+    coffee-script-source (1.12.2)
     concurrent-ruby (1.1.3)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -120,6 +141,9 @@ GEM
     ffi (1.9.25)
     font-awesome-rails (4.7.0.4)
       railties (>= 3.2, < 6.0)
+    formtastic (3.1.5)
+      actionpack (>= 3.2.13)
+    formtastic_i18n (0.6.0)
     friendly_id (5.2.4)
       activerecord (>= 4.0.0)
     get_process_mem (0.2.2)
@@ -134,6 +158,9 @@ GEM
       oauth2 (~> 1.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
+    has_scope (0.7.2)
+      actionpack (>= 4.1)
+      activesupport (>= 4.1)
     hashdiff (0.3.7)
     hashie (3.5.7)
     heapy (0.1.4)
@@ -141,6 +168,11 @@ GEM
     i18n (1.1.1)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
+    inherited_resources (1.9.0)
+      actionpack (>= 4.2, < 5.3)
+      has_scope (~> 0.6)
+      railties (>= 4.2, < 5.3)
+      responders
     jaro_winkler (1.5.1)
     jaro_winkler (1.5.1-x86_64-darwin-17)
     jquery-rails (4.2.2)
@@ -261,6 +293,11 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (3.0.0)
     rake (11.3.0)
+    ransack (2.1.1)
+      actionpack (>= 5.0)
+      activerecord (>= 5.0)
+      activesupport (>= 5.0)
+      i18n
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -371,6 +408,7 @@ PLATFORMS
   x86_64-darwin-17
 
 DEPENDENCIES
+  activeadmin
   acts_as_votable
   better_errors (~> 2.4)
   binding_of_caller (~> 0.8)

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -1,0 +1,33 @@
+ActiveAdmin.register_page "Dashboard" do
+
+  menu priority: 1, label: proc{ I18n.t("active_admin.dashboard") }
+
+  content title: proc{ I18n.t("active_admin.dashboard") } do
+    div class: "blank_slate_container", id: "dashboard_default_message" do
+      span class: "blank_slate" do
+        span I18n.t("active_admin.dashboard_welcome.welcome")
+        small I18n.t("active_admin.dashboard_welcome.call_to_action")
+      end
+    end
+
+    # Here is an example of a simple dashboard with columns and panels.
+    #
+    # columns do
+    #   column do
+    #     panel "Recent Posts" do
+    #       ul do
+    #         Post.recent(5).map do |post|
+    #           li link_to(post.title, admin_post_path(post))
+    #         end
+    #       end
+    #     end
+    #   end
+
+    #   column do
+    #     panel "Info" do
+    #       para "Welcome to ActiveAdmin."
+    #     end
+    #   end
+    # end
+  end # content
+end

--- a/app/assets/javascripts/active_admin.js.coffee
+++ b/app/assets/javascripts/active_admin.js.coffee
@@ -1,0 +1,1 @@
+#= require active_admin/base

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -1,0 +1,17 @@
+// SASS variable overrides must be declared before loading up Active Admin's styles.
+//
+// To view the variables that Active Admin provides, take a look at
+// `app/assets/stylesheets/active_admin/mixins/_variables.scss` in the
+// Active Admin source.
+//
+// For example, to change the sidebar width:
+// $sidebar-width: 242px;
+
+// Active Admin's got SASS!
+@import "active_admin/mixins";
+@import "active_admin/base";
+
+// Overriding any non-variable SASS must be done after the fact.
+// For example, to change the default status-tag color:
+//
+//   .status_tag { background: #6090DB; }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,6 +14,12 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def authenticate_admin_user!
+    unless current_user && current_user.admin?
+      redirect_to root_path
+    end
+  end
+
   def after_sign_out_path_for(_resource_or_scope)
     home_path(ref: 'logout')
   end

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -1,0 +1,293 @@
+ActiveAdmin.setup do |config|
+  # == Site Title
+  #
+  # Set the title that is displayed on the main layout
+  # for each of the active admin pages.
+  #
+  config.site_title = "Theodinproject"
+
+  # Set the link url for the title. For example, to take
+  # users to your main site. Defaults to no link.
+  #
+  # config.site_title_link = "/"
+
+  # Set an optional image to be displayed for the header
+  # instead of a string (overrides :site_title)
+  #
+  # Note: Aim for an image that's 21px high so it fits in the header.
+  #
+  # config.site_title_image = "logo.png"
+
+  # == Default Namespace
+  #
+  # Set the default namespace each administration resource
+  # will be added to.
+  #
+  # eg:
+  #   config.default_namespace = :hello_world
+  #
+  # This will create resources in the HelloWorld module and
+  # will namespace routes to /hello_world/*
+  #
+  # To set no namespace by default, use:
+  #   config.default_namespace = false
+  #
+  # Default:
+  # config.default_namespace = :admin
+  #
+  # You can customize the settings for each namespace by using
+  # a namespace block. For example, to change the site title
+  # within a namespace:
+  #
+  #   config.namespace :admin do |admin|
+  #     admin.site_title = "Custom Admin Title"
+  #   end
+  #
+  # This will ONLY change the title for the admin section. Other
+  # namespaces will continue to use the main "site_title" configuration.
+
+  # == User Authentication
+  #
+  # Active Admin will automatically call an authentication
+  # method in a before filter of all controller actions to
+  # ensure that there is a currently logged in admin user.
+  #
+  # This setting changes the method which Active Admin calls
+  # within the application controller.
+  config.authentication_method = :authenticate_admin_user!
+
+  # == User Authorization
+  #
+  # Active Admin will automatically call an authorization
+  # method in a before filter of all controller actions to
+  # ensure that there is a user with proper rights. You can use
+  # CanCanAdapter or make your own. Please refer to documentation.
+  # config.authorization_adapter = ActiveAdmin::CanCanAdapter
+
+  # In case you prefer Pundit over other solutions you can here pass
+  # the name of default policy class. This policy will be used in every
+  # case when Pundit is unable to find suitable policy.
+  # config.pundit_default_policy = "MyDefaultPunditPolicy"
+
+  # You can customize your CanCan Ability class name here.
+  # config.cancan_ability_class = "Ability"
+
+  # You can specify a method to be called on unauthorized access.
+  # This is necessary in order to prevent a redirect loop which happens
+  # because, by default, user gets redirected to Dashboard. If user
+  # doesn't have access to Dashboard, he'll end up in a redirect loop.
+  # Method provided here should be defined in application_controller.rb.
+  # config.on_unauthorized_access = :access_denied
+
+  # == Current User
+  #
+  # Active Admin will associate actions with the current
+  # user performing them.
+  #
+  # This setting changes the method which Active Admin calls
+  # (within the application controller) to return the currently logged in user.
+  # config.current_user_method = :current_admin_user
+
+  # == Logging Out
+  #
+  # Active Admin displays a logout link on each screen. These
+  # settings configure the location and method used for the link.
+  #
+  # This setting changes the path where the link points to. If it's
+  # a string, the strings is used as the path. If it's a Symbol, we
+  # will call the method to return the path.
+  #
+  # Default:
+  config.logout_link_path = :destroy_admin_user_session_path
+
+  # This setting changes the http method used when rendering the
+  # link. For example :get, :delete, :put, etc..
+  #
+  # Default:
+  # config.logout_link_method = :get
+
+  # == Root
+  #
+  # Set the action to call for the root path. You can set different
+  # roots for each namespace.
+  #
+  # Default:
+  # config.root_to = 'dashboard#index'
+
+  # == Admin Comments
+  #
+  # This allows your users to comment on any resource registered with Active Admin.
+  #
+  # You can completely disable comments:
+  # config.comments = false
+  #
+  # You can change the name under which comments are registered:
+  # config.comments_registration_name = 'AdminComment'
+  #
+  # You can change the order for the comments and you can change the column
+  # to be used for ordering:
+  # config.comments_order = 'created_at ASC'
+  #
+  # You can disable the menu item for the comments index page:
+  # config.comments_menu = false
+  #
+  # You can customize the comment menu:
+  # config.comments_menu = { parent: 'Admin', priority: 1 }
+
+  # == Batch Actions
+  #
+  # Enable and disable Batch Actions
+  #
+  config.batch_actions = true
+
+  # == Controller Filters
+  #
+  # You can add before, after and around filters to all of your
+  # Active Admin resources and pages from here.
+  #
+  # config.before_action :do_something_awesome
+
+  # == Localize Date/Time Format
+  #
+  # Set the localize format to display dates and times.
+  # To understand how to localize your app with I18n, read more at
+  # https://github.com/svenfuchs/i18n/blob/master/lib%2Fi18n%2Fbackend%2Fbase.rb#L52
+  #
+  config.localize_format = :long
+
+  # == Setting a Favicon
+  #
+  # config.favicon = 'favicon.ico'
+
+  # == Meta Tags
+  #
+  # Add additional meta tags to the head element of active admin pages.
+  #
+  # Add tags to all pages logged in users see:
+  #   config.meta_tags = { author: 'My Company' }
+
+  # By default, sign up/sign in/recover password pages are excluded
+  # from showing up in search engine results by adding a robots meta
+  # tag. You can reset the hash of meta tags included in logged out
+  # pages:
+  #   config.meta_tags_for_logged_out_pages = {}
+
+  # == Removing Breadcrumbs
+  #
+  # Breadcrumbs are enabled by default. You can customize them for individual
+  # resources or you can disable them globally from here.
+  #
+  # config.breadcrumb = false
+
+  # == Create Another Checkbox
+  #
+  # Create another checkbox is disabled by default. You can customize it for individual
+  # resources or you can enable them globally from here.
+  #
+  # config.create_another = true
+
+  # == Register Stylesheets & Javascripts
+  #
+  # We recommend using the built in Active Admin layout and loading
+  # up your own stylesheets / javascripts to customize the look
+  # and feel.
+  #
+  # To load a stylesheet:
+  #   config.register_stylesheet 'my_stylesheet.css'
+  #
+  # You can provide an options hash for more control, which is passed along to stylesheet_link_tag():
+  #   config.register_stylesheet 'my_print_stylesheet.css', media: :print
+  #
+  # To load a javascript file:
+  #   config.register_javascript 'my_javascript.js'
+
+  # == CSV options
+  #
+  # Set the CSV builder separator
+  # config.csv_options = { col_sep: ';' }
+  #
+  # Force the use of quotes
+  # config.csv_options = { force_quotes: true }
+
+  # == Menu System
+  #
+  # You can add a navigation menu to be used in your application, or configure a provided menu
+  #
+  # To change the default utility navigation to show a link to your website & a logout btn
+  #
+  #   config.namespace :admin do |admin|
+  #     admin.build_menu :utility_navigation do |menu|
+  #       menu.add label: "My Great Website", url: "http://www.mygreatwebsite.com", html_options: { target: :blank }
+  #       admin.add_logout_button_to_menu menu
+  #     end
+  #   end
+  #
+  # If you wanted to add a static menu item to the default menu provided:
+  #
+  #   config.namespace :admin do |admin|
+  #     admin.build_menu :default do |menu|
+  #       menu.add label: "My Great Website", url: "http://www.mygreatwebsite.com", html_options: { target: :blank }
+  #     end
+  #   end
+
+  # == Download Links
+  #
+  # You can disable download links on resource listing pages,
+  # or customize the formats shown per namespace/globally
+  #
+  # To disable/customize for the :admin namespace:
+  #
+  #   config.namespace :admin do |admin|
+  #
+  #     # Disable the links entirely
+  #     admin.download_links = false
+  #
+  #     # Only show XML & PDF options
+  #     admin.download_links = [:xml, :pdf]
+  #
+  #     # Enable/disable the links based on block
+  #     #   (for example, with cancan)
+  #     admin.download_links = proc { can?(:view_download_links) }
+  #
+  #   end
+
+  # == Pagination
+  #
+  # Pagination is enabled by default for all resources.
+  # You can control the default per page count for all resources here.
+  #
+  # config.default_per_page = 30
+  #
+  # You can control the max per page count too.
+  #
+  # config.max_per_page = 10_000
+
+  # == Filters
+  #
+  # By default the index screen includes a "Filters" sidebar on the right
+  # hand side with a filter for each attribute of the registered model.
+  # You can enable or disable them for all resources here.
+  #
+  # config.filters = true
+  #
+  # By default the filters include associations in a select, which means
+  # that every record will be loaded for each association.
+  # You can enabled or disable the inclusion
+  # of those filters by default here.
+  #
+  # config.include_default_association_filters = true
+
+  # == Footer
+  #
+  # By default, the footer shows the current Active Admin version. You can
+  # override the content of the footer here.
+  #
+  # config.footer = 'my custom footer text'
+
+  # == Sorting
+  #
+  # By default ActiveAdmin::OrderClause is used for sorting logic
+  # You can inherit it with own class and inject it for all resources
+  #
+  # config.order_clause = MyOrderClause
+end

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -86,7 +86,7 @@ ActiveAdmin.setup do |config|
   #
   # This setting changes the method which Active Admin calls
   # (within the application controller) to return the currently logged in user.
-  # config.current_user_method = :current_admin_user
+  config.current_user_method = :current_user
 
   # == Logging Out
   #
@@ -98,13 +98,13 @@ ActiveAdmin.setup do |config|
   # will call the method to return the path.
   #
   # Default:
-  config.logout_link_path = :destroy_admin_user_session_path
+  config.logout_link_path = :destroy_user_session_path
 
   # This setting changes the http method used when rendering the
   # link. For example :get, :delete, :put, etc..
   #
   # Default:
-  # config.logout_link_method = :get
+  config.logout_link_method = :delete
 
   # == Root
   #

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  ActiveAdmin.routes(self)
   root 'static_pages#home'
 
   devise_for :users, controllers: {

--- a/db/migrate/20190204213636_create_active_admin_comments.rb
+++ b/db/migrate/20190204213636_create_active_admin_comments.rb
@@ -1,0 +1,17 @@
+class CreateActiveAdminComments < ActiveRecord::Migration::Current
+  def self.up
+    create_table :active_admin_comments do |t|
+      t.string :namespace
+      t.text   :body
+      t.references :resource, polymorphic: true
+      t.references :author, polymorphic: true
+      t.timestamps
+    end
+    add_index :active_admin_comments, [:namespace]
+
+  end
+
+  def self.down
+    drop_table :active_admin_comments
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180712020424) do
+ActiveRecord::Schema.define(version: 20190204213636) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_admin_comments", force: :cascade do |t|
+    t.string   "namespace"
+    t.text     "body"
+    t.string   "resource_type"
+    t.integer  "resource_id"
+    t.string   "author_type"
+    t.integer  "author_id"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+    t.index ["author_type", "author_id"], name: "index_active_admin_comments_on_author_type_and_author_id", using: :btree
+    t.index ["namespace"], name: "index_active_admin_comments_on_namespace", using: :btree
+    t.index ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource_type_and_resource_id", using: :btree
+  end
 
   create_table "admin_flashes", force: :cascade do |t|
     t.datetime "created_at"


### PR DESCRIPTION
Adds base functionality for activeadmin.

This makes use of the existing user model and utilises the existing admin flag for users.

For now unauthorised users who try to access the /admin path have been routed to root_path, we can modify this or add a flash as necessary.

Once merged and accepted as working ok we can start the process of registering the required models that admins will be able to access.