### PR TITLE
Update lesson content importer exception handling

### DIFF
--- a/app/services/lesson_content_importer.rb
+++ b/app/services/lesson_content_importer.rb
@@ -11,9 +11,11 @@ class LessonContentImporter
   end
 
   def import
-    lesson.update(content: content_converted_to_html) if content_needs_updated?
-  rescue Octokit::Error => errors
-    failed_to_import_message
+    lesson.update!(content: content_converted_to_html) if content_needs_updated?
+  rescue Octokit::Error => error
+    log_error(error.message)
+  rescue ActiveRecord::RecordInvalid => error
+    log_error(error.record.errors.full_messages)
   end
 
   private
@@ -34,8 +36,8 @@ class LessonContentImporter
     Octokit.contents(repo, path: lesson.url)
   end
 
-  def failed_to_import_message
-    Rails.logger.error "Failed to import \"#{lesson.title}\" content: #{lesson.errors}"
+  def log_error(message)
+    Rails.logger.error "Failed to import '#{lesson.title}' message: #{message}"
     false
   end
 


### PR DESCRIPTION
Previously, when lesson content import failed, we were logging the `lesson.errors` object.

The PR updates it to log the exception message.