### PR TITLE
Feature/anchor links

### DIFF
--- a/app/assets/stylesheets/components/lesson/lesson_content.scss
+++ b/app/assets/stylesheets/components/lesson/lesson_content.scss
@@ -1,7 +1,7 @@
 .lesson-content {
   padding-bottom: 60px;
 
-  h3:first-child {
+  h3:nth-child(2) {
     margin-top: 0;
   }
 


### PR DESCRIPTION
The inserted anchor links on the lesson section titles are the first child inside the `<h3>`  causing `margin-top=0`. 

This fix increases the `margin-top` to what it was before the anchor links were added to the site. 