### PR TITLE
Adds max-height and scrollbar to project submissions

### DIFF
--- a/app/assets/stylesheets/components/lesson/lesson_content.scss
+++ b/app/assets/stylesheets/components/lesson/lesson_content.scss
@@ -18,7 +18,7 @@
       }
     }
   }
-  
+
   h4 {
     margin-bottom: 10px;
     font-weight: bold;
@@ -62,8 +62,14 @@
   li {
 
     ul {
-      margin-bottom: 0;
+      margin-bottom: 0px;
     }
+  }
+
+  #student-solutions {
+    max-height: 450px;
+    overflow: scroll;
+    margin-bottom: 50px;
   }
 
   ol {
@@ -111,7 +117,7 @@
       color: $grey;
       font-size: 1.125rem;
     }
-    
+
     ul {
       margin: 15px;
     }
@@ -129,5 +135,3 @@
     cursor: pointer;
   }
 }
-
-


### PR DESCRIPTION
It looks like there was a max-height to project submissions a few years ago but I can't find anything on that now.  I find it extremely frustrating to have to scroll through hundreds of project submissions before getting to the next project.

I'm proposing `max-height` and `overflow: scroll` properties are added to the `#student-solutions` div but anything that makes this area shorter (such as a toggle dropdown) would be fantastic.