### PR TITLE
Replace 'View Curriculum' with 'Get Started'

### DIFF
--- a/app/views/static_pages/home/_curriculum.html.erb
+++ b/app/views/static_pages/home/_curriculum.html.erb
@@ -22,7 +22,7 @@
     </div> <!-- /.row -->
 
     <div class="text-center">
-      <%= link_to 'View Curriculum', courses_path,
+      <%= link_to 'Get Started', courses_path,
         class: 'button button--secondary' %>
     </div> <!-- /.row -->
   </div> <!-- /.container -->


### PR DESCRIPTION
Issue #[10452](https://github.com/TheOdinProject/curriculum/issues/10452)

I changed button to say "Get Started" instead of "view curriculum".