### PR TITLE
Edit home page so that curriculum button shows track options

### DIFF
--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -3,7 +3,7 @@
     <header>
       <h1 class="accent hero__main-heading"> Your Career in Web Development Starts Here </h1>
       <p class="secondary hero__sub-heading"> Our full stack curriculum is free and supported by a passionate open source community.</p>
-        <%= link_to 'View Full Curriculum', courses_path,  class: 'button button--primary' %>
+        <%= link_to 'View Full Curriculum', tracks_path,  class: 'button button--primary' %>
     </header>
     <%= image_tag 'home-isometric.svg', class: 'hero__image', alt: 'home-page-banner' %>
   </div>


### PR DESCRIPTION
The button on the homepage to View Full Curriculum currently still only
goes to the default RoR track. It should now go to the tracks path to
mirror the behaviour of the Curriculum link in the navigation menu