### PR TITLE
Add Node Badge to home page

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -175,6 +175,10 @@ module ApplicationHelper
         badge_alt_text: 'ruby on rails badge',
         title: 'Ruby on Rails'
       },
+      { badge_image_url: 'badge-nodejs.svg',
+        badge_alt_text: 'nodejs badge',
+        title: 'NodeJS'
+      },
       { badge_image_url: 'badge-getting-hired.svg',
         badge_alt_text: 'getting hired badge',
         title: 'Getting Hired'


### PR DESCRIPTION
This adds the node badge to the available_courses helper which displays
all the badges on the home page.