### PR TITLE
Update Ruby on Rails track description

### DIFF
--- a/db/seeds/tracks/full_stack_rails.rb
+++ b/db/seeds/tracks/full_stack_rails.rb
@@ -3,7 +3,7 @@
 
 track = create_or_update_track(
   title: "Full Stack Ruby on Rails",
-  description: "This track takes you through our entire curriculum. You'll learn everything you need to know to create beautiful responsive websites from scratch. This is our default track. If you do not know where to start, select this track.",
+  description: "This track takes you through our entire Ruby on Rails curriculum. You'll learn everything you need to know to create beautiful responsive websites from scratch. This is our default track. If you do not know where to start, select this track.",
   position: 1,
   default: true,
 )


### PR DESCRIPTION
The original wording stated that the Ruby on Rails track takes a student
though the entire curriculum. With NodeJS as an option this is not
longer correct. This clarifies the track as specific to Ruby on Rails