### PR TITLE
Add Rubocop Performance

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,4 @@
+require: rubocop-performance
 Documentation:
   Enabled: false
 Style/FrozenStringLiteralComment:

--- a/Gemfile
+++ b/Gemfile
@@ -59,4 +59,5 @@ group :development do
   gem 'derailed'
   gem 'reek'
   gem 'rubocop', require: false
+  gem 'rubocop-performance', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -348,6 +348,8 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.6)
+    rubocop-performance (1.1.0)
+      rubocop (>= 0.67.0)
     ruby-progressbar (1.10.0)
     safe_yaml (1.0.5)
     sass (3.7.4)
@@ -468,6 +470,7 @@ DEPENDENCIES
   reek
   rspec-rails (~> 3.5)
   rubocop
+  rubocop-performance
   sass-rails (~> 5.0)
   shoulda-matchers (~> 3.1)
   simplecov


### PR DESCRIPTION
The rubocop post-install message now states performance cops will be
removed in Rubocop 0.68 and are now maintained in the Rubocop
Performance Gem. This adds the gem and requires the file in the rubocop
yml