### PR TITLE
fix #1021 issue, removed fixed height to cause profile card to not st…

### DIFF
--- a/app/assets/stylesheets/components/dashboard/profile_card.scss
+++ b/app/assets/stylesheets/components/dashboard/profile_card.scss
@@ -11,7 +11,6 @@
 
   &__image {
     width: 100px;
-    height: 100px;
     background-color:#fff;
     border-radius:50%;
     margin-right: 2rem;


### PR DESCRIPTION
Fix #1021 issue
Removed fixed height to cause profile card to not stretch image (See screenshot below: green circle with "B" inside).

Profile card image will decrease in total size, but in my opinion this is a more aesthetic display of the image.

![Screen Shot 2019-11-19 at 11 49 16 am](https://user-images.githubusercontent.com/39540028/69107854-af58ff80-0ac2-11ea-98ab-4ee46c0080f9.png)
