### PR TITLE
Chore: Bump Puma

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,8 @@ source 'https://rubygems.org'
 ruby '~> 2.6'
 
 gem 'rails',                      '~> 5.2'
-gem 'puma',                       '~> 4.3.1'
+
+gem 'puma'
 gem 'turbolinks'
 gem 'jquery-rails',               '~> 4.3.1'
 gem 'devise',                     '>= 4.7.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,7 +219,7 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     newrelic_rpm (3.18.1.330)
-    nio4r (2.3.1)
+    nio4r (2.5.2)
     nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
     oauth2 (1.4.1)
@@ -264,7 +264,7 @@ GEM
       method_source (~> 0.9.0)
     psych (3.1.0)
     public_suffix (3.0.3)
-    puma (4.3.1)
+    puma (4.3.3)
       nio4r (~> 2.0)
     rack (2.0.8)
     rack-attack (5.4.2)
@@ -461,7 +461,7 @@ DEPENDENCIES
   pg (~> 0.19)
   premailer-rails (~> 1.9)
   pry (~> 0.12.2)
-  puma (~> 4.3.1)
+  puma
   rack-attack
   rack-timeout (~> 0.4)
   rails (~> 5.2)


### PR DESCRIPTION
Because:
* The current version of puma we are running is a security rick.

This Commit:
* Bumps Puma to the latest version.
* Removes the version constraint for Puma in the Gemfile. The Gemfile.lock should be the source of truth for what versions we are running.