### PR TITLE
Fix Unique Validation Errors Being Raised On Lesson Completions

### DIFF
--- a/app/views/lessons/_lesson_completion_state.html.erb
+++ b/app/views/lessons/_lesson_completion_state.html.erb
@@ -1,9 +1,9 @@
 <% if lesson_completed?(user, lesson) %>
-  <%= link_to lesson_completions_path(lesson), method: :delete, remote: true, class: 'button button--complete lesson-button-group__item lesson-button lesson-button--complete', title: 'Mark lesson incomplete' do %>
+  <%= link_to lesson_completions_path(lesson), method: :delete, remote: true, class: 'button button--complete lesson-button-group__item lesson-button lesson-button--complete', title: 'Mark lesson incomplete', data: { disable_with: "submitting" } do %>
     <i class="lesson-button__icon far fa-check-circle" aria-hidden="true"></i>
   <% end %>
 <% else %>
-  <%= link_to lesson_completions_path(lesson), remote: true, method: :post, class: 'button button--primary lesson-button-group__item lesson-button', title: 'Mark lesson complete' do %>
+  <%= link_to lesson_completions_path(lesson), remote: true, method: :post, class: 'button button--primary lesson-button-group__item lesson-button', title: 'Mark lesson complete', data: { disable_with: "submitting" } do %>
     <i class="lesson-button__icon far fa-check-circle" aria-hidden="true"></i>Complete
   <% end %>
 <% end %>


### PR DESCRIPTION
Because:
* although this does not impact users it makes a lot of noise in our NewRelic error logs.

This Commit:
* Adds a data-disable-with attribute to the lesson completion buttons so users cannot double click them.