### PR TITLE
Fix: Google Omniauth Username Validation Error

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
   acts_as_voter
 
   validates_uniqueness_of :email
-  validates :username, length: { in: 4..20 }
+  validates :username, length: { in: 4..100 }
   validates :learning_goal, length: { maximum: 1700 }
 
   has_many :lesson_completions, foreign_key: :student_id

--- a/spec/helpers/button_helper_spec.rb
+++ b/spec/helpers/button_helper_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ButtonHelper do
     }
 
     before do
-      allow(helper).to receive(:chat_link).and_return('https://discord.gg/hvqVr6d')
+      allow(helper).to receive(:chat_link).and_return('https://discord.gg/V75WSQG')
     end
 
     it 'returns a chat button' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe User do
       .and_return(lesson_completions)
   end
 
-  it { is_expected.to validate_length_of(:username).is_at_least(4).is_at_most(20) }
+  it { is_expected.to validate_length_of(:username).is_at_least(4).is_at_most(100) }
   it { is_expected.to validate_length_of(:learning_goal).is_at_most(1700) }
   it { is_expected.to have_many(:lesson_completions) }
   it { is_expected.to have_many(:completed_lessons) }


### PR DESCRIPTION
Because:
* We use the users name on their Google account to populate their username on TOP. Some Users have large names on their google account however.

This Commit:
* Increases the username max character limit to 100.

We should come up with a better solution for this long term, but this quick fix will resolve the issue for now.