### PR TITLE
Chore: Remove Advanced Associations Project

### DIFF
--- a/db/seeds/04_rails_course_seeds.rb
+++ b/db/seeds/04_rails_course_seeds.rb
@@ -312,18 +312,6 @@ create_or_update_lesson(
 
 lesson_position += 1
 create_or_update_lesson(
-  title: "Advanced Associations",
-  title_url: "Advanced Associations".parameterize,
-  description: "Exercise those association muscles to finish up the tutorial like a pro.",
-  position: lesson_position,
-  section_id: section.id,
-  is_project: true,
-  url: "/rails_programming/advanced_forms_and_activerecord/project_associations_2.md",
-  repo: 'curriculum'
-)
-
-lesson_position += 1
-create_or_update_lesson(
   title: "Advanced Forms",
   title_url: "Advanced Forms".parameterize,
   description: "Take what you know about forms and put rocket boosters on it.  Don't be afraid to make a form for anything.",


### PR DESCRIPTION
Because:
* This was missed when removing the ror tutorial.