### PR TITLE
Add Github edit URL to the lesson pages

### DIFF
--- a/app/assets/stylesheets/components/lesson/lesson_functions.scss
+++ b/app/assets/stylesheets/components/lesson/lesson_functions.scss
@@ -10,4 +10,9 @@
   &__sub-title {
     text-transform: uppercase;
   }
+
+  &__edit-lesson-link {
+    color: $primary;
+    font-size: 1.125rem;
+  }
 }

--- a/app/helpers/lessons_helper.rb
+++ b/app/helpers/lessons_helper.rb
@@ -7,4 +7,8 @@ module LessonsHelper
       'button--secondary'
     end
   end
+
+  def github_edit_url(lesson)
+    github_link("curriculum/edit/master#{lesson.url}")
+  end
 end

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -49,6 +49,14 @@
       <% end %>
     </div>
 
+    <%= link_to github_edit_url(@lesson),
+      target: :_blank,
+      rel: 'noreferrer noopener',
+      class: 'lesson-functions__edit-lesson-link' do %>
+      <span class="fab fa-github mr-1"></span>
+      <span> Improve this lesson on GitHub</span>
+    <% end %>
+
     <%= render 'shared/bottom_cta',
       button: chat_button,
       heading: 'Have a question?',


### PR DESCRIPTION
Fixes https://github.com/TheOdinProject/theodinproject/issues/1095

### Screenshot

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/7039523/79677959-eccdd000-81bb-11ea-885f-65022f4f8ed9.png">

