### PR TITLE
Chore: Add Friendly Id's to Tracks and Migrate DB on Release

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+release: bin/rails db:migrate
 web: bundle exec puma -C config/puma.rb

--- a/app/controllers/tracks_controller.rb
+++ b/app/controllers/tracks_controller.rb
@@ -1,6 +1,6 @@
 class TracksController < ApplicationController
   def show
-    @track = Track.find(params[:id])
+    @track = Track.friendly.find(params[:id])
     @courses = decorated_courses
     @user = current_user
   end

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -1,4 +1,6 @@
 class Track < ApplicationRecord
+  extend FriendlyId
+
   has_many :users
   has_many :track_courses, -> { order(:position) }, dependent: :delete_all
   has_many :courses, through: :track_courses
@@ -6,6 +8,8 @@ class Track < ApplicationRecord
   validates :title, presence: true
   validates :description, presence: true
   validates :position, presence: true
+
+  friendly_id :title, use: [:slugged, :finders]
 
   scope :default, -> { find_by(default: true) }
 end

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -15,7 +15,7 @@
       <!-- Full Width Navbar -->
       <ul class="navbar-nav ml-auto hidden-md-down">
         <li class="nav-item <%= active_class(courses_path) %>">
-          <%= link_to 'My courses', track_path(current_user.track_id, ref: 'homenav'), class: 'nav-link' %>
+          <%= link_to 'My Courses', track_path(current_user.track), class: 'nav-link' %>
         </li>
         <li class="nav-item dropdown js-dropdown">
           <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/db/migrate/20200423213901_add_slug_to_tracks.rb
+++ b/db/migrate/20200423213901_add_slug_to_tracks.rb
@@ -1,0 +1,6 @@
+class AddSlugToTracks < ActiveRecord::Migration[6.0]
+  def change
+    add_column :tracks, :slug, :string
+    add_index :tracks, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_26_192602) do
+ActiveRecord::Schema.define(version: 2020_04_23_213901) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -135,6 +135,8 @@ ActiveRecord::Schema.define(version: 2020_03_26_192602) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "default", default: false
+    t.string "slug"
+    t.index ["slug"], name: "index_tracks_on_slug", unique: true
   end
 
   create_table "user_providers", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
Chore: Add Friendly Id's to Tracks

Because:
* These slugs are more user/SEO friendly

---

Chore: Add Heroku Release Phase for Running Migrations

Because
* This will automate pending database migrations when we deploy.