### PR TITLE
Chore: Remove Course and Lesson Title above Lesson Buttons

### DIFF
--- a/app/assets/stylesheets/components/lesson/lesson_button_group.scss
+++ b/app/assets/stylesheets/components/lesson/lesson_button_group.scss
@@ -1,6 +1,5 @@
 .lesson-button-group {
   display: flex;
-  margin-top: 1.5rem;
 
   @include media-breakpoint-down(md) {
     display: block;

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -26,13 +26,6 @@
 <div class="lesson-functions">
   <div class="container">
     <div class="card-main">
-      <h1 class="lesson-functions__title">
-        <%= @lesson.course.title %>
-      </h1>
-
-      <h3 class="lesson-functions__sub-title accent bold">
-        <%= @lesson.title %>
-      </h3>
 
       <div class="lesson-button-group">
         <%= render 'lesson_buttons', lesson: @lesson, course: @lesson.course, user: @user %>


### PR DESCRIPTION
Because:
* This isn't needed as the student will know which lesson/project they are on.
* It opens up some real estate for the project submissions component.

![Screenshot 2020-04-24 at 00 26 56](https://user-images.githubusercontent.com/7963776/80159237-5c7bfa80-85c2-11ea-83f7-949caa322298.png)
