### PR TITLE
Move babel-plugin-prismjs to dependencies to get Heroku deployment working

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "dependencies": {
     "@rails/ujs": "^6.0.2-2",
     "@rails/webpacker": "5.0.1",
+    "babel-plugin-prismjs": "^2.0.1",
     "bootstrap": "^4.4.1",
     "core-js": "^3.6.4",
     "jquery": "^3.4.1",
@@ -15,7 +16,6 @@
     "validate.js": "^0.13.1"
   },
   "devDependencies": {
-    "babel-plugin-prismjs": "^2.0.1",
     "webpack-dev-server": "^3.10.3"
   }
 }


### PR DESCRIPTION
I am not sure why the Heroku ruby buildpack does not install both dependencies and devDependencies as [Heroku Node.js buildpack](https://devcenter.heroku.com/articles/nodejs-support#package-installation) does. There is [a hacky solution](https://stackoverflow.com/questions/22954782/install-devdependencies-on-heroku) to get Heroku to install devDependencies but I am adding `babel-plugin-prismjs` to `dependencies` to get the Heroku deployment working for now. We'll have to revisit this to find a better solution.