### PR TITLE
Fixed Discord chat floating icon tracker

### DIFF
--- a/app/views/shared/_sidecar.html.erb
+++ b/app/views/shared/_sidecar.html.erb
@@ -5,7 +5,7 @@
     <% end %>
   </div>
   <div class="floating-dropdown__item floating-dropdown--hidden-item text-center" data-toggle='tooltip' data-placement='left' title='Forum'>
-    <%= link_to forum_link, target: :_blank, rel: 'noreferrer' do %>
+    <%= link_to forum_link, target: :_blank, rel: 'noreferrer', class: "chat-floating-btn" do %>
       <i class="fas fa-users" aria-hidden="true"></i>
     <% end %>
   </div>


### PR DESCRIPTION
Added the chat-floating-btn class to the link