### PR TITLE
fixed 404 page in html and css course lessons

### DIFF
--- a/db/seeds/05_html_css_course_seeds.rb
+++ b/db/seeds/05_html_css_course_seeds.rb
@@ -11,7 +11,7 @@ lesson_position = 0
 
 course = create_or_update_course(
   title: "HTML and CSS",
-  title_url: "HTML5 and CSS3".parameterize,
+  title_url: "HTML and CSS".parameterize,
   description: "Good web design doesn't happen by accident. Learn how to make all that work you've done on the backend look great in a web browser! You'll be equipped to deeply understand and create your own design frameworks.",
   position: course_position
 )


### PR DESCRIPTION
"View course" redirected to 404 in individual lessons in html and css course.