### PR TITLE
Chore: Reduce Username Length Limit

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
   acts_as_voter
 
   validates_uniqueness_of :email
-  validates :username, length: { in: 4..100 }
+  validates :username, length: { in: 2..100 }
   validates :learning_goal, length: { maximum: 1700 }
 
   has_many :lesson_completions, foreign_key: :student_id

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe User do
       .and_return(lesson_completions)
   end
 
-  it { is_expected.to validate_length_of(:username).is_at_least(4).is_at_most(100) }
+  it { is_expected.to validate_length_of(:username).is_at_least(2).is_at_most(100) }
   it { is_expected.to validate_length_of(:learning_goal).is_at_most(1700) }
   it { is_expected.to have_many(:lesson_completions) }
   it { is_expected.to have_many(:completed_lessons) }


### PR DESCRIPTION
Because:
* Usernames populated through Github can be less than 4 characters.