### PR TITLE
Feature: Render Lesson Styles from Github Url

### DIFF
--- a/app/controllers/lessons/style_tests_controller.rb
+++ b/app/controllers/lessons/style_tests_controller.rb
@@ -1,0 +1,19 @@
+class Lessons::StyleTestsController < ApplicationController
+
+  def new;end
+
+  def create
+    redirect_to lessons_style_tests_path(url: params[:url])
+  end
+
+  def show
+    @lesson_content = LessonStyles.render_for(path)
+  end
+
+  private
+
+  def path
+    URI.parse(params[:url]).path
+  end
+
+end

--- a/app/services/lesson_styles.rb
+++ b/app/services/lesson_styles.rb
@@ -1,0 +1,34 @@
+class LessonStyles
+
+  def initialize(path)
+    @path = path
+  end
+
+  def self.render_for(path)
+    new(path).render
+  end
+
+  def render
+    MarkdownConverter.new(decoded_content).as_html
+  end
+
+  private
+
+  attr_reader :path
+
+  def decoded_content
+    Base64.decode64(github_response[:content]).force_encoding('UTF-8')
+  end
+
+  def github_response
+    Octokit.contents('theodinproject/curriculum', path: "#{lesson_path}?ref=#{blob_id}")
+  end
+
+  def blob_id
+    path.split('/')[4]
+  end
+
+  def lesson_path
+    path.split('/')[5..-1].join('/')
+  end
+end

--- a/app/views/lessons/style_tests/new.html.erb
+++ b/app/views/lessons/style_tests/new.html.erb
@@ -1,0 +1,11 @@
+<div class="card-main" style="max-width:50%;margin:auto">
+  <%= form_with url: lessons_style_tests_path, html: {class: 'form' } do |form| %>
+    <div class="form__section">
+      <%= form.text_field :url, placeholder: 'Github URL', class: 'form__element' %>
+    </div>
+
+    <div class="form__button-section">
+      <%= form.submit 'Render', class: 'button button--primary full-width' %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/lessons/style_tests/show.html.erb
+++ b/app/views/lessons/style_tests/show.html.erb
@@ -1,0 +1,14 @@
+<div class="container lesson">
+  <div class="row">
+
+    <div class="col-lg-3">
+      <div class="d-none d-lg-block d-xl-block lesson-navigation"></div>
+    </div>
+
+    <div class="col-lg-9">
+      <div class="lesson-content">
+        <%= @lesson_content.html_safe %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,10 @@ Rails.application.routes.draw do
     resources :lessons, only: :show
   end
 
+  namespace :lessons do
+    resource :style_tests, only %i[new create show]
+  end
+
   resources :lessons, only: :show do
     resources :projects, only: %i(index create update destroy) do
       resources :reports, only: %i[create]

--- a/spec/services/lesson_styles_spec.rb
+++ b/spec/services/lesson_styles_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe LessonStyles do
+  subject { described_class.new(path) }
+
+  let(:path) do
+    '/TheOdinProject/curriculum/blob/28bb7681ed8a1a7b6933925a8d17c386e4b75cde/rails_programming/forms_and_authentication/form_basics.md'
+  end
+
+  describe '#render' do
+    let(:markdown_converter) { instance_double(MarkdownConverter) }
+
+    before do
+      allow(Octokit).to receive(:contents)
+        .with(
+          'theodinproject/curriculum',
+          path: 'rails_programming/forms_and_authentication/form_basics.md?ref=28bb7681ed8a1a7b6933925a8d17c386e4b75cde'
+        ).and_return({ content: 'CONTENT FROM GITHUB' })
+
+      allow(MarkdownConverter).to receive(:new).with("\b\xE3S\u0010\xD4\xC5D\xE3\u0006!1\xD4").and_return(markdown_converter)
+      allow(markdown_converter).to receive(:as_html)
+    end
+
+    it "renders the markdown content in html" do
+      subject.render
+      expect(markdown_converter).to have_received(:as_html)
+    end
+  end
+
+end


### PR DESCRIPTION
Because:
* We often don't know how Kramdown will render something until its in production. Being able to see how a lesson will render while developing will save time.

This Commit:
* Adds a service to render content from a pull request.