### PR TITLE
issue #1230 fixed double title

### DIFF
--- a/app/javascript/src/js/lessons.js
+++ b/app/javascript/src/js/lessons.js
@@ -132,8 +132,8 @@ function constructInternalLinks(heading){
   internalLink.setAttribute('href', uri + '#' + id);
   internalLink.innerText = heading.innerText;
   internalLink.className = 'internal-link';
+  removeAllChildNodes(heading);
   heading.appendChild(internalLink);
-  heading.firstChild.remove();
 } 
 
 function spyLessonSections() {
@@ -153,3 +153,9 @@ document.addEventListener('turbolinks:load', function() {
   constructLessonNavigation();
   spyLessonSections();
 });
+
+function removeAllChildNodes(parentNode) {
+  while(parentNode.firstChild) {
+    parentNode.removeChild(parentNode.lastChild);
+  }
+}


### PR DESCRIPTION
issue #1230 

### Cause of the bug
The issue happens when there is formatting inside the heading text. In this case adding `<em>` tags around the 'is' in the title causes the inner text to break into three nodes instead of one single text node. While creating internal links, the link creator function removes the first text node of `<h3>` element but does not remove the other nodes of the `<h3>` element created due to the `<em>` tags.
![Screenshot from 2020-07-19 12-52-09](https://user-images.githubusercontent.com/49481287/87869638-f1727200-c9be-11ea-806a-b6ebaa969b53.png)


### Solution
add a function `removeAllChildNodes()` which removes all the child nodes of the `<h3>` element before adding the internal link node.