### PR TITLE
Better cache and remove DB dependency on docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,21 +5,20 @@
 #
 
 FROM ruby:2.6-buster
-MAINTAINER Andy Duss <mindovermiles262@gmail.com>
+LABEL maintainer="Andy Duss <mindovermiles262@gmail.com>"
 
 RUN apt-get -qq update && \
   apt-get -qq install -y nodejs vim
 
-ENV RAILS_ENV=docker
-ADD . /rails
 WORKDIR /rails
+COPY bin bin
+COPY Gemfile* ./
 RUN bin/bundle install
 
-
-RUN bin/rails db:create && \
-    bin/rails db:migrate && \
-    bin/rails db:seed
+ENV RAILS_ENV=docker
+COPY . .
 
 EXPOSE 3000
-CMD bin/rails server
+CMD ["entrypoint.sh"]
+
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+bin/rails db:create
+bin/rails db:migrate
+bin/rails db:seed
+bin/rails server -b 0.0.0.0
+


### PR DESCRIPTION
- `MAINTAINER` is deprecated. Ref. https://docs.docker.com/engine/reference/builder/#maintainer-deprecated 
- `ADD` is anti-pattern and should be `COPY` unless there's any specific reason. Ref. https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy
- Having DB dependency in docker build is not "portable", which is what Docker should bring us

I also can add `docker-compose` for PostgreSQL not just for those who want to use Docker for this Rails app, but also who don't want to prepare DB on their local environment.