### PR TITLE
Fix long links wrapping in lessons

### DIFF
--- a/app/assets/stylesheets/components/lesson/lesson_content.scss
+++ b/app/assets/stylesheets/components/lesson/lesson_content.scss
@@ -31,6 +31,7 @@
     margin-bottom: 30px;
     line-height: 1.9;
     color: $text-primary;
+    word-break: break-word;
   }
 
   pre {


### PR DESCRIPTION
Fixing the  [issue](https://github.com/TheOdinProject/curriculum/issues/18314)  from the curriculum: