### PR TITLE
Fix: Lesson Header Course Links

### DIFF
--- a/app/views/courses/course/_banner.html.erb
+++ b/app/views/courses/course/_banner.html.erb
@@ -1,6 +1,11 @@
 <div class="banner">
   <div class='banner__badge'>
-    <%= render 'shared/course_badge', course: course, user: current_user, modifier: '' %>
+    <%= link_to course, class: 'course-card-header__link' do %>
+      <%= render 'shared/course_badge', course: course, user: current_user, modifier: '' %>
+    <% end %>
   </div>
-  <h1 class="banner__title"><%= course.title %></h1>
+
+   <%= link_to course, class: 'course-card-header__link' do %>
+    <h1 class="banner__title"><%= course.title %></h1>
+    <% end %>
 </div>

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -4,9 +4,7 @@
   <div class="row">
     <div class="col-12">
       <div class="lesson-header">
-        <%= link_to @lesson.course, class: 'course-card-header__link' do %>
-          <%= render 'courses/course/banner', course: @lesson.course %>
-        <% end %>
+        <%= render 'courses/course/banner', course: @lesson.course %>
         <h2 class="lesson-header__title accent"><%= @lesson.title %></h2>
       </div>
     </div>


### PR DESCRIPTION
Because:
* The entire parent div of the lesson course banner was a link.

This commit:
* Wraps the course badge and course title in individual links to the lessons course.

Fixes: https://github.com/TheOdinProject/theodinproject/issues/1221