### PR TITLE
Refactor and add context to project submission component

### DIFF
--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -18,7 +18,7 @@ class LessonsController < ApplicationController
   end
 
   def project_submissions
-   (current_users_submission + lesson.project_submissions.with_no_active_flags.limit(10)).uniq
+   (current_users_submission + lesson.project_submissions.for_public.with_no_active_flags.limit(10)).uniq
   end
 
   def current_users_submission

--- a/app/javascript/components/project-submissions/ProjectSubmissionContext.js
+++ b/app/javascript/components/project-submissions/ProjectSubmissionContext.js
@@ -1,0 +1,5 @@
+import React, { createContext } from 'react';
+
+const ProjectSubmissionContext = createContext(null);
+
+export default ProjectSubmissionContext;

--- a/app/javascript/components/project-submissions/components/create-form.js
+++ b/app/javascript/components/project-submissions/components/create-form.js
@@ -1,16 +1,14 @@
 import React from 'react';
-import { useForm } from "react-hook-form";
+import { useForm } from 'react-hook-form';
+import { func } from 'prop-types';
 
-const CreateForm = (props) => {
+const CreateForm = ({ onClose, onSubmit }) => {
   const { register, errors, handleSubmit, formState, reset } = useForm();
 
   const handleClose = () => {
-    reset({
-      isSubmitted: false,
-    })
-
-    props.onClose()
-  }
+    reset({ isSubmitted: false });
+    onClose();
+  };
 
   if (formState.isSubmitted) {
     return (
@@ -25,7 +23,7 @@ const CreateForm = (props) => {
     <div>
       <h1 className="text-center accent">Upload Your Project</h1>
 
-      <form className="form" onSubmit={handleSubmit(props.onSubmit)}>
+      <form className="form" onSubmit={handleSubmit(onSubmit)}>
         <div className="form__section">
           <span className="form__icon fab fa-github"></span>
           <input
@@ -43,7 +41,7 @@ const CreateForm = (props) => {
             })}
           />
         </div>
-        {errors.repo_url && <div className="form__error-message push-down"> {errors.repo_url.message}</div> }
+        {errors.repo_url && <div className="form__error-message push-down"> {errors.repo_url.message}</div>}
 
         <div className="form__section push-down-3x">
           <span className="form__icon fas fa-link"></span>
@@ -61,7 +59,7 @@ const CreateForm = (props) => {
             })}
           />
         </div>
-        {errors.live_preview_url && <div className="form__error-message push-down"> {errors.live_preview_url.message}</div> }
+        {errors.live_preview_url && <div className="form__error-message push-down"> {errors.live_preview_url.message}</div>}
 
         <div className="form__section form__section--right-aligned form__section--bottom">
             <p className="bold">MAKE SOLUTION PUBLIC</p>
@@ -71,10 +69,14 @@ const CreateForm = (props) => {
             </label>
           <button type="submit" className="button button--primary">Submit</button>
         </div>
-
       </form>
     </div>
-  )
-}
+  );
+};
 
-export default CreateForm
+CreateForm.propTypes = {
+  onClose: func.isRequired,
+  onSubmit: func.isRequired,
+};
+
+export default CreateForm;

--- a/app/javascript/components/project-submissions/components/edit-form.js
+++ b/app/javascript/components/project-submissions/components/edit-form.js
@@ -1,32 +1,33 @@
 import React from 'react';
-import { useForm } from "react-hook-form";
+import { useForm } from 'react-hook-form';
+import { func, object } from 'prop-types';
 
-const EditForm = (props) => {
+const EditForm = ({ submission, onSubmit, onClose, onDelete }) => {
   const { register, errors, handleSubmit, formState, reset } = useForm({
     defaultValues: {
-      repo_url: props.submission.repo_url,
-      live_preview_url: props.submission.live_preview_url,
-      is_public: props.submission.is_public,
+      repo_url: submission.repo_url,
+      live_preview_url: submission.live_preview_url,
+      is_public: submission.is_public,
     }
   });
 
   const handleClose = () => {
     reset({
-      repo_url: props.submission.repo_url,
-      live_preview_url: props.submission.live_preview_url,
-      is_public: props.submission.is_public,
+      repo_url: submission.repo_url,
+      live_preview_url: submission.live_preview_url,
+      is_public: submission.is_public,
     },
     {
       isSubmitted: false,
     });
 
-    props.onClose();
-  }
+    onClose();
+  };
 
   const handleDelete = () => {
-    props.onDelete(props.submission.id);
-    props.onClose();
-  }
+    onDelete(submission.id);
+    onClose();
+  };
 
   if (formState.isSubmitted) {
     return (
@@ -34,15 +35,20 @@ const EditForm = (props) => {
         <h1 className="accent">Thanks for Updating Your Solution!</h1>
         <button className="button button--primary" onClick={handleClose}>Close</button>
       </div>
-    )
+    );
+  }
+
+  const textFieldPattern = {
+    value: /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/,
+    message: "Must be a URL"
   }
 
   return (
     <div>
       <h1 className="text-center accent">Edit Your Project</h1>
 
-      <form className="form" onSubmit={handleSubmit(props.onSubmit)}>
-        <input type="hidden" name="project_submission_id" value={props.submission.id}  ref={register()} />
+      <form className="form" onSubmit={handleSubmit(onSubmit)}>
+        <input type="hidden" name="project_submission_id" value={submission.id}  ref={register()} />
         <div className="form__section">
           <span className="form__icon fab fa-github"></span>
           <input
@@ -50,17 +56,10 @@ const EditForm = (props) => {
             type="text"
             name="repo_url"
             placeholder="Repository URL"
-            ref={register({
-              required: 'Required',
-              pattern: {
-                value: /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/,
-                message: "Must be a URL"
-              }
-
-            })}
+            ref={register({ required: 'Required', pattern: textFieldPattern })}
           />
         </div>
-        {errors.repo_url && <div className="form__error-message push-down"> {errors.repo_url.message}</div> }
+        {errors.repo_url && <div className="form__error-message push-down"> {errors.repo_url.message}</div>}
 
         <div className="form__section push-down-3x">
           <span className="form__icon fas fa-link"></span>
@@ -69,13 +68,7 @@ const EditForm = (props) => {
             type="text"
             placeholder="Live Preview URL"
             name="live_preview_url"
-            ref={register({
-              required: "Required",
-              pattern: {
-                value: /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/,
-                message: "Must be a URL"
-              }
-            })}
+            ref={register({ required: "Required", pattern: textFieldPattern })}
           />
         </div>
         {errors.live_preview_url && <div className="form__error-message push-down"> {errors.live_preview_url.message}</div> }
@@ -92,10 +85,16 @@ const EditForm = (props) => {
           &nbsp;
           <button type="submit" className="button button--primary">Update</button>
         </div>
-
       </form>
     </div>
-  )
+  );
+};
+
+EditForm.propTypes = {
+  submission: object.isRequired,
+  onSubmit: func.isRequired,
+  onClose: func.isRequired,
+  onDelete: func.isRequired,
 }
 
-export default EditForm
+export default EditForm;

--- a/app/javascript/components/project-submissions/components/flag-form.js
+++ b/app/javascript/components/project-submissions/components/flag-form.js
@@ -1,88 +1,59 @@
 import React from 'react';
 import { useForm } from "react-hook-form";
+import { func, object } from 'prop-types';
 
-const FlagForm = (props) => {
+const FLAG_REASONS = [
+  "It's sexually inappropriate",
+  "It's spam",
+  "I find it offensive",
+  "It's violent or prohibited content",
+];
+
+const FlagForm = ({ onSubmit, submission }) => {
   const { register, handleSubmit, formState } = useForm();
-
 
   if (formState.isSubmitted) {
     return (
-      <div className="text-center" style={ { width: '80%', margin: '0 auto' } }>
+      <div className="text-center" style={{ width: '80%', margin: '0 auto' }}>
         <h1 className="bold">Thanks for helping us keep our community safe!</h1>
         <p>We will temporarily hide this solution and our moderators will review this issue.</p>
       </div>
     )
   }
 
-  return (
+  const renderFlaggingReasons = () => {
+    return FLAG_REASONS.map((flagReason, index) => {
+      return (
+        <div key={`flag-reason-${index + 1}`} className="flag-form__option">
+          <p>{flagReason}</p>
+          <label className="toggle">
+            <input
+              className="toggle__input"
+              type="checkbox"
+              name="reasons"
+              value={flagReason}
+              ref={register}
+            />
+            <div className="toggle__fill"></div>
+          </label>
+        </div>
+      )
+    })
+  }
 
+  return (
     <div>
       <h1 className="text-center accent">What's the reason for flagging?</h1>
 
-      <form className="form flag-form__container" onSubmit={handleSubmit(props.onSubmit)}>
-        <input type="hidden" name="project_submission_id" value={props.submission.id}  ref={register()} />
+      <form className="form flag-form__container" onSubmit={handleSubmit(onSubmit)}>
+        <input type="hidden" name="project_submission_id" value={submission.id}  ref={register()} />
 
         <div className="flag-form__icon-container">
-          <i className="fas fa-exclamation-triangle" style={ { color: '#bd4147'} }></i>
+          <i className="fas fa-exclamation-triangle" style={{ color: '#bd4147'}}></i>
         </div>
 
         <div className="flag-form__options">
-
-          <div className="flag-form__option">
-            <p>It's sexually inappropriate</p>
-            <label className="toggle">
-              <input
-                className="toggle__input"
-                type="checkbox"
-                name="reasons"
-                value="It's sexually inappropriate"
-                ref={register}
-              />
-              <div className="toggle__fill"></div>
-            </label>
-          </div>
-
-          <div className="flag-form__option">
-            <p>It's spam</p>
-            <label className="toggle">
-              <input
-                className="toggle__input"
-                type="checkbox"
-                name="reasons"
-                value="It's spam"
-                ref={register}
-              />
-              <div className="toggle__fill"></div>
-            </label>
-          </div>
-
-          <div className="flag-form__option">
-            <p>I find it offensive</p>
-            <label className="toggle">
-              <input
-                className="toggle__input"
-                type="checkbox"
-                name="reasons"
-                value="I find it offensive"
-                ref={register}
-              />
-              <div className="toggle__fill"></div>
-            </label>
-          </div>
-
-          <div className="flag-form__option">
-            <p>It's violent or prohibited content</p>
-            <label className="toggle">
-              <input
-                className="toggle__input"
-                type="checkbox"
-                name="reasons"
-                value="It's violent or prohibited content"
-                ref={register}
-              />
-              <div className="toggle__fill"></div>
-            </label>
-          </div>
+          {renderFlaggingReasons()}
         </div>
 
         <div className="flag-form__submit-button">
@@ -90,7 +61,12 @@ const FlagForm = (props) => {
         </div>
       </form>
     </div>
-  )
+  );
+};
+
+FlagForm.propTypes = {
+  onSubmit: func.isRequired,
+  submission: object,
 }
 
 export default FlagForm

--- a/app/javascript/components/project-submissions/components/index.js
+++ b/app/javascript/components/project-submissions/components/index.js
@@ -1,0 +1,9 @@
+import SubmissionsList from './submissions-list';
+import Modal from './modal';
+import CreateForm from './create-form';
+
+export {
+  SubmissionsList,
+  Modal,
+  CreateForm,
+};

--- a/app/javascript/components/project-submissions/components/modal.js
+++ b/app/javascript/components/project-submissions/components/modal.js
@@ -1,16 +1,23 @@
 import React from 'react';
+import { func, bool, node } from 'prop-types';
 
 const Modal = ({ handleClose, show, children }) => {
-  const showHideClassName = show ? 'react-modal' : 'react-modal--hidden'
+  const showHideClassName = show ? 'react-modal' : 'react-modal--hidden';
 
   return (
     <div className={showHideClassName}>
       <div className='react-modal__body'>
         <div className="react-modal__close-btn" onClick={handleClose}></div>
-        { children }
+        {children}
       </div>
     </div>
-  )
-}
+  );
+};
+
+Modal.propTypes = {
+  handleClose: func.isRequired,
+  show: bool.isRequired,
+  children: node.isRequired,
+};
 
 export default Modal

--- a/app/javascript/components/project-submissions/components/submission.js
+++ b/app/javascript/components/project-submissions/components/submission.js
@@ -1,57 +1,69 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo, useContext } from 'react';
+import { object, func } from 'prop-types';
 
 import Modal from './modal';
 import FlagForm from './flag-form';
 import EditForm from './edit-form';
+import ProjectSubmissionContext from '../ProjectSubmissionContext';
+import SubmissionsList from './submissions-list';
 
-const Submission = ({submission, userId, handleUpdate, handleFlag, handleDelete}) => {
+const Submission = ({ submission, handleUpdate, handleFlag, handleDelete }) => {
+  const { userId } = useContext(ProjectSubmissionContext);
   const [showFlagModal, setShowFlagModal] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
+  const isCurrentUsersSubmission = useMemo(() =>
+    userId === submission.user_id, [userId, submission.user_id]);
 
-  const isCurrentUsersSubmission = () => (
-    userId === submission.user_id
-  )
+  const toggleShowFlagModal = () => setShowFlagModal(prevShowFlagModal => !prevShowFlagModal);
+  const toggleShowEditModal = () => setShowEditModal(prevShowEditModal => !prevShowEditModal);
 
   return (
     <div className="submissions__item">
       <p className="submissions__user">{submission.user_name}</p>
 
       <div className="submissions__actions">
-
-        { isCurrentUsersSubmission() &&
+        {isCurrentUsersSubmission && (
           <button
             className="submissions__button submissions__button--green"
-            onClick={() => setShowEditModal(true)}
+            onClick={toggleShowEditModal}
           >
             Edit Solution
           </button>
-        }
-
+        )}
         <a href={submission.repo_url} target="_blank" className="submissions__button">View Code</a>
         <a href={submission.live_preview_url} target="_blank" className="submissions__button">Live Preview</a>
-        <a className="submissions__flag" onClick={(event) => { event.preventDefault(); setShowFlagModal(true)}}>
-          <i className="fas fa-flag "></i>
-        </a>
+        {!isCurrentUsersSubmission && (
+          <a className="submissions__flag" onClick={(event) => { event.preventDefault(); toggleShowFlagModal()}}>
+            <i className="fas fa-flag "></i>
+          </a>
+        )}
       </div>
 
-      <Modal show={showEditModal} handleClose={() => setShowEditModal(false)}>
+      <Modal show={showEditModal} handleClose={toggleShowEditModal}>
         <EditForm
           submission={submission}
           onSubmit={handleUpdate}
           onDelete={handleDelete}
-          onClose={() => setShowEditModal(false)}
+          onClose={toggleShowEditModal}
         />
       </Modal>
 
-      <Modal show={showFlagModal} handleClose={() => setShowFlagModal(false)}>
+      <Modal show={showFlagModal} handleClose={toggleShowFlagModal}>
         <FlagForm
           submission={submission}
           onSubmit={handleFlag}
-          onClose={() => setShowFlagModal(false)}
+          onClose={toggleShowFlagModal}
         />
       </Modal>
     </div>
-  )
-}
+  );
+};
 
-export default Submission
+Submission.propTypes = {
+  submission: object.isRequired,
+  handleUpdate: func.isRequired,
+  handleFlag: func.isRequired,
+  handleDelete: func.isRequired,
+};
+
+export default Submission;

--- a/app/javascript/components/project-submissions/components/submissions-list.js
+++ b/app/javascript/components/project-submissions/components/submissions-list.js
@@ -1,16 +1,29 @@
 import React from 'react';
+import { object, func, arrayOf } from 'prop-types';
 
 import Submission from './submission'
 
-const SubmissionsList = ({ submissions, ...otherProps }) =>
-  <div>
-    {submissions.map(submission => (
-      <Submission
-        submission={submission}
-        key={submission.id}
-        { ...otherProps }
-      />
-    ))}
-  </div>
+const SubmissionsList = ({ submissions, handleDelete, handleFlag, handleUpdate }) => {
+  return (
+    <div>
+      {submissions.map(submission => (
+        <Submission
+          key={submission.id}
+          submission={submission}
+          handleUpdate={handleUpdate}
+          handleFlag={handleFlag}
+          handleDelete={handleDelete}
+        />
+      ))}
+    </div>
+  )
+};
 
-  export default SubmissionsList
+SubmissionsList.propTypes = {
+  submissions: arrayOf(object).isRequired,
+  handleDelete: func.isRequired,
+  handleFlag: func.isRequired,
+  handleUpdate: func.isRequired,
+}
+
+export default SubmissionsList;

--- a/app/javascript/components/project-submissions/index.jsx
+++ b/app/javascript/components/project-submissions/index.jsx
@@ -1,17 +1,19 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import { number, array, object } from 'prop-types';
 import ProjectSubmissionsContainer from './containers/project-submissions-container';
-
+import ProjectSubmissionContext from "./ProjectSubmissionContext";
 
 const ProjectSubmissions = ({ submissions, course, lesson, userId }) => (
-  <ProjectSubmissionsContainer submissions={submissions} course={course} lesson={lesson} userId={userId} />
+  <ProjectSubmissionContext.Provider value={{ userId, lesson, course }}>
+    <ProjectSubmissionsContainer submissions={submissions} />
+  </ProjectSubmissionContext.Provider>
 );
 
 ProjectSubmissions.propTypes = {
-  userId: PropTypes.number,
-  submissions: PropTypes.array.isRequired,
-  lesson: PropTypes.object.isRequired,
-  course: PropTypes.object.isRequired,
+  userId: number,
+  submissions: array.isRequired,
+  lesson: object.isRequired,
+  course: object.isRequired,
 };
 
 export default ProjectSubmissions;

--- a/app/models/project_submission.rb
+++ b/app/models/project_submission.rb
@@ -11,4 +11,5 @@ class ProjectSubmission < ApplicationRecord
 
   scope :flagged, -> { joins(:flags).where(flags: { status: :active }) }
   scope :with_no_active_flags, -> { where.not(id: flagged.ids).order('created_at desc') }
+  scope :for_public, -> { where(is_public: true) }
 end


### PR DESCRIPTION
First, great job 🎉  I honestly think this was a great implementation and code. I only did minor refactoring and added the context to share some data that not all components needed.

To the context I added `userId`, `lesson` and `course` since these won't change unless user navigates to another lesson or course in which case a new component will be rendered anyways. The only data that was really being passed down multiple places without the need to, was `userId` but I included` lesson` and `course as well, it is redundant right now but it also doesn't cause any harm.

I tested this to the best of my knowledge, but it would be best to test this further as you have deeper knowledge of how exactly it is suppose to work and maybe I missed some crucial parts.

**Additionally:** besides the refactoring, I did catch 2 crucial things, one was that current user was able to flag their own project it seems silly but I hid that action, and the most important one is that all submissions were being shown so I added a scope to only show publicly enabled submissions.

Let me know what you think and if you have any questions whatsoever.