### PR TITLE
Fix: 404 Page Not Displaying

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,10 @@ Bundler.require(*Rails.groups)
 
 module Theodinproject
   class Application < Rails::Application
+    require Rails.root.join('lib/custom_public_exceptions')
+    config.exceptions_app = CustomPublicExceptions.new(Rails.public_path)
+    config.middleware.insert_after ActionDispatch::Static, Rack::Deflater
+
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.0
 


### PR DESCRIPTION
Because:
* the code for handling our custom 404 page was accidently removed when we upgraded to Rails 6 earlier this year.