### PR TITLE
Fix: Letter Opener in Development

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,7 +50,5 @@ class User < ApplicationRecord
 
   def send_welcome_email
     UserMailer.send_welcome_email_to(self).deliver_now!
-  rescue => error
-    logger.error "Error sending welcome email: #{error}"
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,7 +34,17 @@ Rails.application.configure do
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
+
+  config.action_mailer.default_url_options = {
+    host: ENV.fetch('HOST', 'localhost'),
+    port: ENV.fetch('HOST_PORT', 3000)
+  }
+  routes.default_url_options = {
+    host: ENV.fetch('HOST', 'localhost'),
+    port: ENV.fetch('HOST_PORT', 3000)
+  }
   config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.asset_host = 'http://localhost:3000'
 
   config.action_mailer.perform_caching = false
 

--- a/db/seeds/test_project_submissions.rb
+++ b/db/seeds/test_project_submissions.rb
@@ -1,4 +1,8 @@
 if Rails.env.development? || ENV['STAGING']
+  ActiveJob::Base.queue_adapter = :inline
+  ActionMailer::Base.delivery_method = :test
+  ActionMailer::Base.perform_deliveries = false
+
   users = (1..20).map do |number|
     User.find_or_create_by(email: "test_user_#{number}@email.com") do |user|
       user.username = "test_user_#{number}"


### PR DESCRIPTION
Because:
* Currently we cannot test emails in development.

This Commit:
* Adds the development action mailer configuration.
* Removes the now un-needed rescue around the weclome email method call.
* Suppresses the welcome email from being sent when creating users in the seeds file.