### PR TITLE
Fix project submission form not resetting after modal close

### DIFF
--- a/app/javascript/components/project-submissions/components/modal.js
+++ b/app/javascript/components/project-submissions/components/modal.js
@@ -8,7 +8,7 @@ const Modal = ({ handleClose, show, children }) => {
     <div className={showHideClassName}>
       <div className='react-modal__body'>
         <div className="react-modal__close-btn" onClick={handleClose}></div>
-        {children}
+        {show && children}
       </div>
     </div>
   );

--- a/app/models/project_submission.rb
+++ b/app/models/project_submission.rb
@@ -1,7 +1,7 @@
 class ProjectSubmission < ApplicationRecord
   belongs_to :user
   belongs_to :lesson
-  has_many :flags
+  has_many :flags, dependent: :delete_all
 
   validates :repo_url, url: true
   validates :live_preview_url, url: true


### PR DESCRIPTION
Added to this PR is a fix for deleting project submission when it has been previously flagged. I am not sure what we want to do in this case for now I am assuming to just delete all flags if the owner of the submission decides to delete it. I am not sure if this is the behavior or outcome that is wanted. If it is not please let me know and I can change it.