### PR TITLE
Chore: Remove Methods on User Model For Old Omniauth

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,22 +30,10 @@ class User < ApplicationRecord
     Lesson.find(last_lesson_completed.lesson_id)
   end
 
-  def password_required?
-    super && provider.blank?
-  end
-
   private
 
   def last_lesson_completed
     lesson_completions.order(created_at: :asc).last
-  end
-
-  def self.new_with_session(params, session)
-    super.tap do |user|
-      if data = session["devise.github_data"] && session["devise.github_data"]["extra"]["raw_info"]
-        user.email = data["email"] if user.email.blank?
-      end
-    end
   end
 
   def send_welcome_email

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -102,24 +102,4 @@ RSpec.describe User do
       end
     end
   end
-
-  describe '#password_required?' do
-    let(:user) { create(:user, provider: provider) }
-
-    context 'when the provider is blank' do
-      let(:provider) { '' }
-
-      it 'returns true' do
-        expect(user.password_required?).to eql(true)
-      end
-    end
-
-    context 'when the provider is not blank' do
-      let(:provider) { 'github' }
-
-      it 'returns false' do
-        expect(user.password_required?).to eql(false)
-      end
-    end
-  end
 end


### PR DESCRIPTION
Because:
* These don't seem to be needed anymore since we have a custom omniauth signup process

This Commit:
* Removes password_required? and new_with_session methods from user model.