### PR TITLE
Feature: Display Thanks for Flagging Message

### DIFF
--- a/app/controllers/project_submissions/flags_controller.rb
+++ b/app/controllers/project_submissions/flags_controller.rb
@@ -27,6 +27,8 @@ class ProjectSubmissions::FlagsController < ApplicationController
   end
 
   def notify_discord_admins
+    return if Rails.env.development?
+
     DiscordNotifier.notify(Notifications::FlagSubmission.new(
       flagger: current_user,
       project_submission: project_submission,

--- a/app/javascript/components/project-submissions/components/index.js
+++ b/app/javascript/components/project-submissions/components/index.js
@@ -1,9 +1,11 @@
 import SubmissionsList from './submissions-list';
 import Modal from './modal';
 import CreateForm from './create-form';
+import FlagForm from './flag-form';
 
 export {
   SubmissionsList,
   Modal,
   CreateForm,
+  FlagForm,
 };

--- a/app/javascript/components/project-submissions/components/submission.js
+++ b/app/javascript/components/project-submissions/components/submission.js
@@ -2,19 +2,16 @@ import React, { useState, useMemo, useContext } from 'react';
 import { object, func } from 'prop-types';
 
 import Modal from './modal';
-import FlagForm from './flag-form';
 import EditForm from './edit-form';
 import ProjectSubmissionContext from '../ProjectSubmissionContext';
-import SubmissionsList from './submissions-list';
 
-const Submission = ({ submission, handleUpdate, handleFlag, handleDelete }) => {
+const Submission = ({ submission, handleUpdate, onFlag, handleDelete }) => {
   const { userId } = useContext(ProjectSubmissionContext);
-  const [showFlagModal, setShowFlagModal] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
   const isCurrentUsersSubmission = useMemo(() =>
     userId === submission.user_id, [userId, submission.user_id]);
 
-  const toggleShowFlagModal = () => setShowFlagModal(prevShowFlagModal => !prevShowFlagModal);
+
   const toggleShowEditModal = () => setShowEditModal(prevShowEditModal => !prevShowEditModal);
 
   return (
@@ -33,7 +30,7 @@ const Submission = ({ submission, handleUpdate, handleFlag, handleDelete }) => {
         <a href={submission.repo_url} target="_blank" className="submissions__button">View Code</a>
         <a href={submission.live_preview_url} target="_blank" className="submissions__button">Live Preview</a>
         {!isCurrentUsersSubmission && (
-          <a className="submissions__flag" onClick={(event) => { event.preventDefault(); toggleShowFlagModal()}}>
+          <a className="submissions__flag" onClick={(event) => { event.preventDefault(); onFlag(submission)}}>
             <i className="fas fa-flag "></i>
           </a>
         )}
@@ -47,14 +44,6 @@ const Submission = ({ submission, handleUpdate, handleFlag, handleDelete }) => {
           onClose={toggleShowEditModal}
         />
       </Modal>
-
-      <Modal show={showFlagModal} handleClose={toggleShowFlagModal}>
-        <FlagForm
-          submission={submission}
-          onSubmit={handleFlag}
-          onClose={toggleShowFlagModal}
-        />
-      </Modal>
     </div>
   );
 };
@@ -62,7 +51,7 @@ const Submission = ({ submission, handleUpdate, handleFlag, handleDelete }) => {
 Submission.propTypes = {
   submission: object.isRequired,
   handleUpdate: func.isRequired,
-  handleFlag: func.isRequired,
+  onFlag: func.isRequired,
   handleDelete: func.isRequired,
 };
 

--- a/app/javascript/components/project-submissions/components/submissions-list.js
+++ b/app/javascript/components/project-submissions/components/submissions-list.js
@@ -3,7 +3,7 @@ import { object, func, arrayOf } from 'prop-types';
 
 import Submission from './submission'
 
-const SubmissionsList = ({ submissions, handleDelete, handleFlag, handleUpdate }) => {
+const SubmissionsList = ({ submissions, handleDelete, onFlag, handleUpdate }) => {
   return (
     <div>
       {submissions.map(submission => (
@@ -11,7 +11,7 @@ const SubmissionsList = ({ submissions, handleDelete, handleFlag, handleUpdate }
           key={submission.id}
           submission={submission}
           handleUpdate={handleUpdate}
-          handleFlag={handleFlag}
+          onFlag={onFlag}
           handleDelete={handleDelete}
         />
       ))}
@@ -22,7 +22,7 @@ const SubmissionsList = ({ submissions, handleDelete, handleFlag, handleUpdate }
 SubmissionsList.propTypes = {
   submissions: arrayOf(object).isRequired,
   handleDelete: func.isRequired,
-  handleFlag: func.isRequired,
+  onFlag: func.isRequired,
   handleUpdate: func.isRequired,
 }
 

--- a/app/javascript/components/project-submissions/containers/project-submissions-container.js
+++ b/app/javascript/components/project-submissions/containers/project-submissions-container.js
@@ -1,13 +1,18 @@
 import React, { useState, useMemo, useContext } from 'react';
 
-import { SubmissionsList, Modal, CreateForm } from '../components';
+import { SubmissionsList, Modal, CreateForm, FlagForm } from '../components';
 import axios from '../../../src/js/axiosWithCsrf';
 import ProjectSubmissionContext from "../ProjectSubmissionContext";
 
 const ProjectSubmissions = (props) => {
   const { userId, lesson, course } = useContext(ProjectSubmissionContext);
   const [showCreateModal, setShowCreateModal] = useState(false);
+  const [showFlagModal, setShowFlagModal] = useState(false);
   const [submissions, setSubmissions] = useState(props.submissions);
+  const [flaggedSubmission, setFlaggedSubmission] = useState({});
+
+
+  const toggleShowFlagModal = () => setShowFlagModal(prevShowFlagModal => !prevShowFlagModal);
 
   const toggleShowCreateModal = () => {
     setShowCreateModal(prevShowCreateModal => !prevShowCreateModal);
@@ -76,6 +81,8 @@ const ProjectSubmissions = (props) => {
       { reason: reasons.join(', ') }
     );
     if (response.status === 200) {
+      setFlaggedSubmission({});
+
       setSubmissions(prevSubmissions =>
         prevSubmissions.filter((submission) => submission.id !== parseInt(project_submission_id))
       );
@@ -102,6 +109,14 @@ const ProjectSubmissions = (props) => {
           />
         </Modal>
 
+        <Modal show={showFlagModal} handleClose={toggleShowFlagModal}>
+          <FlagForm
+            submission={flaggedSubmission}
+            onSubmit={handleFlag}
+            onClose={toggleShowFlagModal}
+          />
+        </Modal>
+
         <div>
           {!userSubmission && (
             <button className="submissions__add button button--primary" onClick={toggleShowCreateModal}>
@@ -115,7 +130,7 @@ const ProjectSubmissions = (props) => {
         submissions={submissions}
         userId={userId}
         handleUpdate={handleUpdate}
-        handleFlag={handleFlag}
+        onFlag={(submission) => { setFlaggedSubmission(submission); toggleShowFlagModal() }}
         handleDelete={handleDelete}
       />
     </div>


### PR DESCRIPTION
Because:
* This gives the user visual feedback that their flag was successful and explains what happens next.

This Commit:
* Moves the flag modal to the container so only one of them is ever rendered.
* Stops sending flag notification to discord on development.