### PR TITLE
Chore: Remove Old Omniauth Columns

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -11,24 +11,19 @@ class RegistrationsController < Devise::RegistrationsController
     dashboard_path
   end
 
-  def update_resource(resource, params)
-    if current_user.provider == 'github'
-      params.delete('current_password')
-      resource.update_without_password(params)
-    else
-      resource.update_with_password(params)
-    end
-  end
-
   private
 
   def register_mailing_list
-    if resource.persisted? && Rails.env.production?
-      MailchimpSubscription.create(
-        email: resource.email,
-        username: resource.username,
-        signup_date: resource.created_at
-      )
-    end
+    return unless resource.persisted? && production?
+
+    MailchimpSubscription.create(
+      email: resource.email,
+      username: resource.username,
+      signup_date: resource.created_at
+    )
+  end
+
+  def production?
+    Rails.env.production? && !ENV['STAGING'].present?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,6 +37,8 @@ class User < ApplicationRecord
   end
 
   def send_welcome_email
+    return if ENV['STAGING']
+
     UserMailer.send_welcome_email_to(self).deliver_now!
   end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -8,7 +8,7 @@
       <%= render 'devise/registrations/profile', user: @user %>
       <%= render 'devise/registrations/learning_goal', user: @user %>
 
-      <% if @user.provider.nil? %>
+      <% unless @user.user_providers.any? %>
         <%= render 'devise/registrations/password', user: @user %>
       <% end %>
 

--- a/db/migrate/20200831182324_remove_provider_and_uid_from_users.rb
+++ b/db/migrate/20200831182324_remove_provider_and_uid_from_users.rb
@@ -1,0 +1,6 @@
+class RemoveProviderAndUidFromUsers < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :users, :provider
+    remove_column :users, :uid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_30_213319) do
+ActiveRecord::Schema.define(version: 2020_08_31_182324) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -177,8 +177,6 @@ ActiveRecord::Schema.define(version: 2020_08_30_213319) do
     t.datetime "updated_at", null: false
     t.string "username"
     t.text "learning_goal"
-    t.string "provider"
-    t.string "uid"
     t.string "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"


### PR DESCRIPTION
Because:
* These are no longer needed since we have a seperate table for provider details

This Commit:
* Removes the provider column from the users table.
* Removes the Uid column from the users table.