### PR TITLE
Feature: Ban Flagged Submission User Flow

### DIFF
--- a/app/admin/flags.rb
+++ b/app/admin/flags.rb
@@ -4,12 +4,12 @@ ActiveAdmin.register Flag do
   menu priority: 2
   config.batch_actions = false
 
-  permit_params :status,
-                :taken_action
+  permit_params :status, :taken_action
 
+  scope :active, default: true
   scope :resolved
-  scope :active
-  scope :pending
+
+  member_action :ban_flagged_user, method: :post
 
   includes :flagger, :project_submission
 
@@ -30,22 +30,28 @@ ActiveAdmin.register Flag do
 
   show do |flag|
     attributes_table do
-      row :id
       row :flagger
-      row :project_submission do
-        link_to flag.project_submission.repo_url.to_s, flag.project_submission.repo_url
-      end
       row :reason
+      row :submission_ower do
+        flag.project_submission.user.username
+      end
+      row :repo_url do
+        link_to flag.project_submission.repo_url, flag.project_submission.repo_url, target: '_blank'
+      end
+      row :live_preview_url do
+        link_to flag.project_submission.live_preview_url, flag.project_submission.live_preview_url, target: '_blank'
+      end
       row :status
       row :taken_action
       row :created_at
-      row :updated_at
       row :project_submission_flag_count do
         flags = Flag.where(project_submission: flag.project_submission)
         active = flags.count { |r| r.status == 'active' }
         resolved = flags.count { |r| r.status == 'resolved' }
         "#{flags.count} (#{active} active, #{resolved} resolved)"
       end
+
+      render 'flag_actions'
     end
   end
 
@@ -58,6 +64,18 @@ ActiveAdmin.register Flag do
     end
 
     actions
+  end
+
+  controller do
+    def ban_flagged_user
+      result = Admin::Flags::BanUser.call(flag: resource)
+
+      if result.success?
+        redirect_to resource_path(resource), notice: 'Success: User has been banned'
+      else
+        redirect_to resource_path(resource), notice: 'Failure: Unable to ban user, please check logs.'
+      end
+    end
   end
 
   filter :flagger

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,9 +15,12 @@ class ApplicationController < ActionController::Base
   end
 
   def authenticate_admin_user!
-    return unless current_user && current_user.admin?
+    authenticate_user!
 
-    redirect_to root_path
+    unless current_user.admin?
+      flash[:alert] = 'Unauthorized Access!'
+      redirect_to root_path
+    end
   end
 
   def after_sign_out_path_for(_resource_or_scope)

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -18,7 +18,7 @@ class LessonsController < ApplicationController
   end
 
   def project_submissions
-    (current_users_submission + lesson.project_submissions.for_public.with_no_active_flags.limit(10)).uniq
+    (current_users_submission + lesson.project_submissions.viewable.limit(10)).uniq
   end
 
   def current_users_submission

--- a/app/models/project_submission.rb
+++ b/app/models/project_submission.rb
@@ -9,5 +9,5 @@ class ProjectSubmission < ApplicationRecord
 
   scope :flagged, -> { joins(:flags).where(flags: { status: :active }) }
   scope :with_no_active_flags, -> { where.not(id: flagged.ids).order('created_at desc') }
-  scope :for_public, -> { where(is_public: true) }
+  scope :viewable, -> { where(is_public: true, banned: false) }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,6 +30,14 @@ class User < ApplicationRecord
     Lesson.find(last_lesson_completed.lesson_id)
   end
 
+  def active_for_authentication?
+    super && !banned?
+  end
+
+  def inactive_message
+    !banned? ? super : :banned
+  end
+
   private
 
   def last_lesson_completed

--- a/app/services/admin/flags/ban_user.rb
+++ b/app/services/admin/flags/ban_user.rb
@@ -1,0 +1,34 @@
+module Admin
+  module Flags
+    class BanUser
+      def initialize(flag:)
+        @flag = flag
+        @success = false
+      end
+
+      def self.call(*args)
+        new(*args).call
+      end
+
+      def call
+        flag.transaction do
+          flag.project_submission.update!(banned: true)
+          flag.project_submission.user.update!(banned: true)
+          flag.ban!
+          flag.resolved!
+          @success = true
+        end
+
+        self
+      end
+
+      def success?
+        @success
+      end
+
+      private
+
+      attr_reader :flag
+    end
+  end
+end

--- a/app/views/admin/flags/_flag_actions.html.erb
+++ b/app/views/admin/flags/_flag_actions.html.erb
@@ -1,0 +1,3 @@
+<div>
+  <%= button_to "Ban User", ban_flagged_user_admin_flag_path, data: { confirm: "Are you sure?" } %>
+</div>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -16,6 +16,7 @@ en:
       timeout: "Your session expired, please sign in again to continue."
       unauthenticated: "You need to sign in or sign up before continuing."
       unconfirmed: "You have to confirm your account before continuing.<br><a href='/users/confirmation/new'>Didn't receive instructions or need them again?</a>"
+      banned: "Your user account has been banned"
     mailer:
       confirmation_instructions:
         subject: "Confirmation instructions"

--- a/db/migrate/20200908195212_add_banned_column_to_project_submissions.rb
+++ b/db/migrate/20200908195212_add_banned_column_to_project_submissions.rb
@@ -1,0 +1,5 @@
+class AddBannedColumnToProjectSubmissions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :project_submissions, :banned, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20200908195534_add_banned_column_to_user.rb
+++ b/db/migrate/20200908195534_add_banned_column_to_user.rb
@@ -1,0 +1,5 @@
+class AddBannedColumnToUser < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :banned, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_31_182324) do
+ActiveRecord::Schema.define(version: 2020_09_08_195534) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -105,6 +105,7 @@ ActiveRecord::Schema.define(version: 2020_08_31_182324) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "is_public", default: true, null: false
+    t.boolean "banned", default: false, null: false
     t.index ["is_public"], name: "index_project_submissions_on_is_public"
     t.index ["lesson_id"], name: "index_project_submissions_on_lesson_id"
     t.index ["user_id", "lesson_id"], name: "index_project_submissions_on_user_id_and_lesson_id", unique: true
@@ -184,6 +185,7 @@ ActiveRecord::Schema.define(version: 2020_08_31_182324) do
     t.boolean "admin", default: false, null: false
     t.string "avatar"
     t.integer "track_id", default: 1
+    t.boolean "banned", default: false, null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/spec/models/project_submission_spec.rb
+++ b/spec/models/project_submission_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe ProjectSubmission, type: :model do
     end
   end
 
-  describe '#with_no_active_flags' do
+  describe '.with_no_active_flags' do
     let!(:project_submission_with_no_flags) { create(:project_submission) }
     let(:project_submission_with_flag) { create(:project_submission) }
     let(:project_submission_with_resolved_flag) { create(:project_submission) }
@@ -49,6 +49,41 @@ RSpec.describe ProjectSubmission, type: :model do
       expect(ProjectSubmission.with_no_active_flags).to contain_exactly(
         project_submission_with_no_flags,
         project_submission_with_resolved_flag
+      )
+    end
+  end
+
+  describe '.with_no_active_flags' do
+    let!(:project_submission_with_no_flags) { create(:project_submission) }
+    let(:project_submission_with_flag) { create(:project_submission) }
+    let(:project_submission_with_resolved_flag) { create(:project_submission) }
+    let(:project_submission_flagged_again) { create(:project_submission) }
+
+    before do
+      create(:flag, project_submission: project_submission_with_flag)
+      create(:flag, project_submission: project_submission_with_resolved_flag, status: :resolved)
+      create(:flag, project_submission: project_submission_flagged_again, status: :resolved)
+      create(:flag, project_submission: project_submission_flagged_again)
+    end
+
+    it 'returns project submissions that have no active flags' do
+      expect(ProjectSubmission.with_no_active_flags).to contain_exactly(
+        project_submission_with_no_flags,
+        project_submission_with_resolved_flag
+      )
+    end
+  end
+
+  describe '.viewable' do
+    let!(:banned_project_submission) { create(:project_submission, banned: true) }
+    let!(:private_project_submission) { create(:project_submission, is_public: false) }
+    let!(:viewable_project_submission_one) { create(:project_submission) }
+    let!(:viewable_project_submission_two) { create(:project_submission) }
+
+    it 'returns viewable project submissions' do
+      expect(ProjectSubmission.viewable).to contain_exactly(
+        viewable_project_submission_one,
+        viewable_project_submission_two
       )
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -102,4 +102,40 @@ RSpec.describe User do
       end
     end
   end
+
+  describe '#active_for_authentication?' do
+    context 'when user has not been banned' do
+      let(:user) { create(:user) }
+
+      it 'returns true' do
+        expect(user.active_for_authentication?).to be(true)
+      end
+    end
+
+    context 'when user has been banned' do
+      let(:user) { create(:user, banned: true) }
+
+      it 'returns false' do
+        expect(user.active_for_authentication?).to be(false)
+      end
+    end
+  end
+
+  describe '#inactive_message' do
+    context 'when user has not been banned' do
+      let(:user) { create(:user) }
+
+      it 'returns default inactive translation key' do
+        expect(user.inactive_message).to eq(:inactive)
+      end
+    end
+
+    context 'when user has been banned' do
+      let(:user) { create(:user, banned: true) }
+
+      it 'returns banned translation key' do
+        expect(user.inactive_message).to eq(:banned)
+      end
+    end
+  end
 end

--- a/spec/services/admin/flags/ban_user_spec.rb
+++ b/spec/services/admin/flags/ban_user_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Admin::Flags::BanUser do
+  subject(:service) { described_class.call(flag: flag) }
+
+  let(:flag) { create(:flag, project_submission: project_submission) }
+  let(:project_submission) { create(:project_submission, user: user) }
+  let(:user) { create(:user) }
+
+  describe '#call' do
+    it 'sets the flagged project submission to banned' do
+      expect { service }.to change { project_submission.banned }.from(false).to(true)
+    end
+
+    it 'sets the flagged project submissions owner to banned' do
+      expect { service }.to change { user.banned }.from(false).to(true)
+    end
+
+    it 'sets the flags taken action to ban' do
+      expect { service }.to change { flag.taken_action }.from('pending').to('ban')
+    end
+
+    it 'sets the flags status to resolved' do
+      expect { service }.to change { flag.status }.from('active').to('resolved')
+    end
+  end
+
+  describe '#success?' do
+    it 'returns true' do
+      expect(service.success?).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
Because:
* We need an efficent way to hide the flagged submission and ban its owner.

This Commit:
* Adds authentication around the admin dashboard
* Bans the flagged submission and hides it.
* Bans the owner of the flagged submission.
* tweaks the details displayed on the admin flag show view.