### PR TITLE
Chore: Remove Bundler Audit from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ before_script:
   - bundle install
   - psql -c 'create database theodinproject_test;' -U postgres
 script:
-  - gem install bundler-audit
-  - bundle audit check --update --ignore CVE-2015-9284
   - RAILS_ENV=test bundle exec rails db:schema:load
   - bundle exec rubocop
   - bundle exec rspec


### PR DESCRIPTION
Because:
* CI shouldn't fail because of security issues in dependencies as this breaks automatic deploys until the gem can be bumped.