### PR TITLE
Feature: Allow Admins to Dismiss Flags

### DIFF
--- a/app/admin/flags.rb
+++ b/app/admin/flags.rb
@@ -10,6 +10,7 @@ ActiveAdmin.register Flag do
   scope :resolved
 
   member_action :ban_flagged_user, method: :post
+  member_action :dismiss, method: :post
 
   includes :flagger, :project_submission
 
@@ -51,7 +52,7 @@ ActiveAdmin.register Flag do
         "#{flags.count} (#{active} active, #{resolved} resolved)"
       end
 
-      render 'flag_actions'
+      render 'flag_actions', flag: flag
     end
   end
 
@@ -71,9 +72,19 @@ ActiveAdmin.register Flag do
       result = Admin::Flags::BanUser.call(flag: resource)
 
       if result.success?
-        redirect_to resource_path(resource), notice: 'Success: User has been banned'
+        redirect_to resource_path(resource), notice: 'Success: User has been banned.'
       else
         redirect_to resource_path(resource), notice: 'Failure: Unable to ban user, please check logs.'
+      end
+    end
+
+    def dismiss
+      result = Admin::Flags::Dismiss.call(flag: resource)
+
+      if result.success?
+        redirect_to resource_path(resource), notice: 'Success: Flag has been dismissed.'
+      else
+        redirect_to resource_path(resource), notice: 'Failure: Unable to dismiss flag, please check logs.'
       end
     end
   end

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -6,3 +6,9 @@ $am-theme-accent: #4a4a4a;
 
 @import "active_admin/mixins";
 @import "active_material";
+
+input[type="submit"] {
+  &:disabled {
+    background-color: grey;
+  }
+}

--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -5,5 +5,5 @@ class Flag < ApplicationRecord
   validates :reason, presence: true
 
   enum status: { active: 0, resolved: 1 }
-  enum taken_action: { pending: 0, warning: 1, ban: 2 }
+  enum taken_action: { pending: 0, dismiss: 1, ban: 2 }
 end

--- a/app/services/admin/flags/dismiss.rb
+++ b/app/services/admin/flags/dismiss.rb
@@ -1,0 +1,30 @@
+module Admin
+  module Flags
+    class Dismiss
+      def initialize(flag:)
+        @flag = flag
+        @success = false
+      end
+
+      def self.call(*args)
+        new(*args).call
+      end
+
+      def call
+        flag.resolved!
+        flag.dismiss!
+        @success = true
+
+        self
+      end
+
+      def success?
+        @success
+      end
+
+      private
+
+      attr_reader :flag
+    end
+  end
+end

--- a/app/views/admin/flags/_flag_actions.html.erb
+++ b/app/views/admin/flags/_flag_actions.html.erb
@@ -1,3 +1,4 @@
-<div>
-  <%= button_to "Ban User", ban_flagged_user_admin_flag_path, data: { confirm: "Are you sure?" } %>
+<div style="display:flex;">
+  <%= button_to "Dismiss Flag", dismiss_admin_flag_path, data: { confirm: "Are you sure?" }, disabled: flag.resolved? %>
+  <%= button_to "Ban User", ban_flagged_user_admin_flag_path, data: { confirm: "Are you sure?" }, disabled: flag.resolved? %>
 </div>

--- a/spec/models/flag_spec.rb
+++ b/spec/models/flag_spec.rb
@@ -8,5 +8,5 @@ RSpec.describe Flag do
 
   it { is_expected.to validate_presence_of(:reason) }
   it { is_expected.to define_enum_for(:status).with_values(%i[active resolved]) }
-  it { is_expected.to define_enum_for(:taken_action).with_values(%i[pending warning ban]) }
+  it { is_expected.to define_enum_for(:taken_action).with_values(%i[pending dismiss ban]) }
 end

--- a/spec/services/admin/flags/dismiss_spec.rb
+++ b/spec/services/admin/flags/dismiss_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Admin::Flags::Dismiss do
+  subject(:service) { described_class.call(flag: flag) }
+
+  let(:flag) { create(:flag) }
+
+  describe '#call' do
+    it 'sets the flags taken action to dimiss' do
+      expect { service }.to change { flag.taken_action }.from('pending').to('dismiss')
+    end
+
+    it 'sets the flags status to resolved' do
+      expect { service }.to change { flag.status }.from('active').to('resolved')
+    end
+  end
+
+  describe '#success?' do
+    it 'returns true' do
+      expect(service.success?).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
Because
* Submissions may be flagged by accident or for no reason.

This Commit:
* Adds a dismiss button to admin show flag page which when clicked will trigger a dismiss flag service.
* Disables the flag action buttons when the flag has been resolved.