### PR TITLE
Feature: All Project Submissions for a Lesson Page

### DIFF
--- a/app/assets/stylesheets/components/pagination.scss
+++ b/app/assets/stylesheets/components/pagination.scss
@@ -1,0 +1,8 @@
+.pagination {
+  justify-content: center;
+  font-size: 1.25rem;
+
+  span {
+    margin-right: 0.4em;
+  }
+}

--- a/app/assets/stylesheets/components/project_submissions/submissions.scss
+++ b/app/assets/stylesheets/components/project_submissions/submissions.scss
@@ -105,4 +105,13 @@
     }
   }
 
+  &__view-more {
+    text-align: center;
+    padding: 1.5rem 0;
+
+    a {
+      text-decoration: none;
+    }
+  }
+
 }

--- a/app/assets/stylesheets/components/react_modal.scss
+++ b/app/assets/stylesheets/components/react_modal.scss
@@ -15,7 +15,7 @@
     left:50%;
     transform: translate(-50%,-50%);
     padding: 2.5rem;
-    width: 45%;
+    width: 40%;
 
     @include media-breakpoint-down(lg) {
       width: 60%;

--- a/app/controllers/lessons/project_submissions_controller.rb
+++ b/app/controllers/lessons/project_submissions_controller.rb
@@ -1,0 +1,24 @@
+module Lessons
+  class ProjectSubmissionsController < ApplicationController
+    
+    before_action :authenticate_user!
+    before_action :set_lesson
+    
+    def index
+      @project_submissions = Kaminari.paginate_array(
+        project_submissions,
+        total_count: project_submissions.size
+      ).page(params[:page]).per(15)
+    end
+
+    private
+
+    def project_submissions
+      ::LessonProjectSubmissionsQuery.new(@lesson).with_current_user_submission_first(current_user)
+    end
+
+    def set_lesson
+      @lesson = Lesson.friendly.find(params[:lesson_id])
+    end
+  end
+end

--- a/app/controllers/lessons/project_submissions_controller.rb
+++ b/app/controllers/lessons/project_submissions_controller.rb
@@ -1,9 +1,8 @@
 module Lessons
   class ProjectSubmissionsController < ApplicationController
-    
     before_action :authenticate_user!
     before_action :set_lesson
-    
+
     def index
       @project_submissions = Kaminari.paginate_array(
         project_submissions,

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -3,10 +3,7 @@ class LessonsController < ApplicationController
 
   def show
     @lesson = decorated_lesson
-
-    @project_submissions = project_submissions.map do |submission|
-      ProjectSubmissionSerializer.as_json(submission)
-    end
+    @project_submissions = project_submissions
   end
 
   private
@@ -18,13 +15,7 @@ class LessonsController < ApplicationController
   end
 
   def project_submissions
-    (current_users_submission + lesson.project_submissions.viewable.limit(10)).uniq
-  end
-
-  def current_users_submission
-    return [] unless current_user
-
-    current_user.project_submissions.where(lesson_id: @lesson.id)
+    ::LessonProjectSubmissionsQuery.new(@lesson, limit: 10).with_current_user_submission_first(current_user)
   end
 
   def decorated_lesson

--- a/app/controllers/project_submissions_controller.rb
+++ b/app/controllers/project_submissions_controller.rb
@@ -2,8 +2,6 @@ class ProjectSubmissionsController < ApplicationController
   before_action :authenticate_user!
   before_action :find_project_submission, only: %i[update destroy]
 
-  def index; end
-
   def create
     project_submission = current_user.project_submissions.new(project_submission_params)
 

--- a/app/javascript/components/project-submissions/components/submissions-list.js
+++ b/app/javascript/components/project-submissions/components/submissions-list.js
@@ -1,29 +1,43 @@
 import React from 'react';
-import { object, func, arrayOf } from 'prop-types';
+import { object, func, arrayOf, string } from 'prop-types';
 
 import Submission from './submission'
 
-const SubmissionsList = ({ submissions, handleDelete, onFlag, handleUpdate }) => {
+const SubmissionsList = ({ submissions, handleDelete, onFlag, handleUpdate, allSubmissionsPath }) => {
   return (
     <div>
-      {submissions.map(submission => (
-        <Submission
-          key={submission.id}
-          submission={submission}
-          handleUpdate={handleUpdate}
-          onFlag={onFlag}
-          handleDelete={handleDelete}
-        />
-      ))}
+      <div>
+        {submissions.map(submission => (
+          <Submission
+            key={submission.id}
+            submission={submission}
+            handleUpdate={handleUpdate}
+            onFlag={onFlag}
+            handleDelete={handleDelete}
+          />
+        ))}
+      </div>
+
+      { allSubmissionsPath.length > 0 &&
+        <p className="submissions__view-more">
+          Showing 10 most recent submissions.
+          <a href={allSubmissionsPath}> View full list of solutions here.</a>
+        </p>
+      }
     </div>
   )
 };
+
+SubmissionsList.allSubmissionsPath = {
+  allSubmissionsPath: '',
+}
 
 SubmissionsList.propTypes = {
   submissions: arrayOf(object).isRequired,
   handleDelete: func.isRequired,
   onFlag: func.isRequired,
   handleUpdate: func.isRequired,
+  allSubmissionsPath: string,
 }
 
 export default SubmissionsList;

--- a/app/javascript/components/project-submissions/components/submissions-list.js
+++ b/app/javascript/components/project-submissions/components/submissions-list.js
@@ -20,7 +20,7 @@ const SubmissionsList = ({ submissions, handleDelete, onFlag, handleUpdate, allS
 
       { allSubmissionsPath.length > 0 &&
         <p className="submissions__view-more">
-          Showing 10 most recent submissions.
+          Showing {submissions.length} most recent submissions.
           <a href={allSubmissionsPath}> View full list of solutions here.</a>
         </p>
       }

--- a/app/javascript/components/project-submissions/containers/project-submissions-container.js
+++ b/app/javascript/components/project-submissions/containers/project-submissions-container.js
@@ -5,7 +5,7 @@ import axios from '../../../src/js/axiosWithCsrf';
 import ProjectSubmissionContext from "../ProjectSubmissionContext";
 
 const ProjectSubmissions = (props) => {
-  const { userId, lesson, course } = useContext(ProjectSubmissionContext);
+  const { userId, lesson, course, allSubmissionsPath } = useContext(ProjectSubmissionContext);
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [showFlagModal, setShowFlagModal] = useState(false);
   const [submissions, setSubmissions] = useState(props.submissions);
@@ -24,7 +24,7 @@ const ProjectSubmissions = (props) => {
     event.preventDefault();
 
     const response = await axios.post(
-      `/lessons/${lesson.id}/project_submissions`,
+      `/project_submissions`,
       {
         project_submission: {
           repo_url,
@@ -45,7 +45,7 @@ const ProjectSubmissions = (props) => {
     event.preventDefault();
 
     const response = await axios.put(
-      `/lessons/${lesson.id}/project_submissions/${project_submission_id}`,
+      `/project_submissions/${project_submission_id}`,
       {
         project_submission: {
           repo_url,
@@ -65,7 +65,7 @@ const ProjectSubmissions = (props) => {
   const handleDelete = async (id) => {
     event.preventDefault();
 
-    const response = await axios.delete(`/lessons/${lesson.id}/project_submissions/${id}`, {});
+    const response = await axios.delete(`/project_submissions/${id}`, {});
     if (response.status === 200) {
       setSubmissions(prevSubmissions =>
         prevSubmissions.filter((submission) => submission.id !== id)
@@ -128,6 +128,7 @@ const ProjectSubmissions = (props) => {
         handleUpdate={handleUpdate}
         onFlag={(submission) => { setFlaggedSubmission(submission); toggleShowFlagModal() }}
         handleDelete={handleDelete}
+        allSubmissionsPath={allSubmissionsPath}
       />
     </div>
   )

--- a/app/javascript/components/project-submissions/index.jsx
+++ b/app/javascript/components/project-submissions/index.jsx
@@ -1,19 +1,24 @@
 import React from 'react';
-import { number, array, object } from 'prop-types';
+import { number, array, object, string } from 'prop-types';
 import ProjectSubmissionsContainer from './containers/project-submissions-container';
 import ProjectSubmissionContext from "./ProjectSubmissionContext";
 
-const ProjectSubmissions = ({ submissions, course, lesson, userId }) => (
-  <ProjectSubmissionContext.Provider value={{ userId, lesson, course }}>
+const ProjectSubmissions = ({ submissions, course, lesson, userId, allSubmissionsPath }) => (
+  <ProjectSubmissionContext.Provider value={{ userId, lesson, course, allSubmissionsPath }}>
     <ProjectSubmissionsContainer submissions={submissions} />
   </ProjectSubmissionContext.Provider>
 );
+
+ProjectSubmissions.defaultProps = {
+  allSubmissionsPath: '',
+}
 
 ProjectSubmissions.propTypes = {
   userId: number,
   submissions: array.isRequired,
   lesson: object.isRequired,
   course: object.isRequired,
+  allSubmissionsPath: string,
 };
 
 export default ProjectSubmissions;

--- a/app/models/project_submission.rb
+++ b/app/models/project_submission.rb
@@ -1,4 +1,6 @@
 class ProjectSubmission < ApplicationRecord
+  paginates_per 15
+
   belongs_to :user
   belongs_to :lesson
   has_many :flags, dependent: :delete_all

--- a/app/queries/lesson_project_submissions_query.rb
+++ b/app/queries/lesson_project_submissions_query.rb
@@ -1,0 +1,20 @@
+class LessonProjectSubmissionsQuery
+
+  def initialize(lesson)
+    @lesson = lesson
+  end
+
+  def with_current_user_submission_first(user)
+    return lesson_project_submissions if user.nil?
+
+    (user.project_submissions.where(lesson_id: lesson.id) + lesson_project_submissions).uniq
+  end
+
+  private
+  
+  attr_reader :lesson
+
+  def lesson_project_submissions
+    lesson.project_submissions.viewable.order(:created_at)
+  end
+end

--- a/app/queries/lesson_project_submissions_query.rb
+++ b/app/queries/lesson_project_submissions_query.rb
@@ -1,7 +1,7 @@
 class LessonProjectSubmissionsQuery
-
-  def initialize(lesson)
+  def initialize(lesson, limit: nil)
     @lesson = lesson
+    @limit = limit
   end
 
   def with_current_user_submission_first(user)
@@ -11,10 +11,10 @@ class LessonProjectSubmissionsQuery
   end
 
   private
-  
-  attr_reader :lesson
+
+  attr_reader :lesson, :limit
 
   def lesson_project_submissions
-    lesson.project_submissions.viewable.order(:created_at)
+    lesson.project_submissions.viewable.order(:created_at).limit(limit)
   end
 end

--- a/app/views/lessons/project_submissions/index.html.erb
+++ b/app/views/lessons/project_submissions/index.html.erb
@@ -1,0 +1,19 @@
+<%= title(@lesson.title) %>
+
+<div class="container lesson">
+  <div class="row">
+    <div class="col-12">
+      <%= react_component(
+          "project-submissions/index",
+          {
+            userId: current_user&.id,
+            course: @lesson.course.as_json,
+            lesson: @lesson.as_json,
+            submissions: @project_submissions.map { |submission| ProjectSubmissionSerializer.as_json(submission) }
+          }
+        ) %>
+      
+    <%= paginate @project_submissions %>
+    </div>
+  </div>
+</div>

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -32,7 +32,8 @@
             userId: current_user&.id,
             course: @lesson.course.as_json,
             lesson: @lesson.as_json,
-            submissions: @project_submissions
+            submissions: @project_submissions,
+            allSubmissionsPath: lesson_project_submissions_path(@lesson),
           }
         ) %>
       <% end %>

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -32,7 +32,7 @@
             userId: current_user&.id,
             course: @lesson.course.as_json,
             lesson: @lesson.as_json,
-            submissions: @project_submissions,
+            submissions: @project_submissions.map { |submission| ProjectSubmissionSerializer.as_json(submission) },
             allSubmissionsPath: lesson_project_submissions_path(@lesson),
           }
         ) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,10 +52,7 @@ Rails.application.routes.draw do
   end
 
   resources :lessons, only: :show do
-    resources :project_submissions, only: %i[index create update destroy] do
-      resources :votes, only: %i[create]
-      delete 'vote', to: 'votes#destroy'
-    end
+    resources :project_submissions, only: %i[index], controller: 'lessons/project_submissions'
 
     resources :lesson_completions, only: %i[create], as: 'completions'
     delete 'lesson_completions' => 'lesson_completions#destroy', as: 'lesson_completions'


### PR DESCRIPTION
Because:
* We need a page to display all project submissions for a lesson as we only show the 10 most recent on the lesson page.

This Commit:
* Adds a lesson project submissions controller and index view.
* Adds a query object to encapsulate the logic for constructing the project submission list with the users submission at the top.
* Adds pagination so we only display 15 submissions at a time on the lesson project submissions page.