### PR TITLE
Feature: Change Lesson Titles to Links in User Submission List

### DIFF
--- a/app/javascript/components/project-submissions/components/submission-title.js
+++ b/app/javascript/components/project-submissions/components/submission-title.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { object, bool } from 'prop-types';
+
+const SubmissionTitle = ({ submission, isDashboardView }) => {
+  if (isDashboardView) {
+    return <a href={ submission.lesson_path }>{ submission.lesson_title }</a>
+  } else {
+    return submission.user_name
+  }
+};
+
+SubmissionTitle.defaultProps = {
+  isDashboardView: false,
+}
+
+SubmissionTitle.propTypes = {
+  submission: object.isRequired,
+  isDashboardView: bool,
+};
+
+export default SubmissionTitle;

--- a/app/javascript/components/project-submissions/components/submission.js
+++ b/app/javascript/components/project-submissions/components/submission.js
@@ -4,6 +4,7 @@ import { object, func, bool } from 'prop-types';
 import Modal from './modal';
 import EditForm from './edit-form';
 import ProjectSubmissionContext from '../ProjectSubmissionContext';
+import SubmissionTitle from './submission-title';
 
 const noop = () => {}
 
@@ -14,11 +15,12 @@ const Submission = ({ submission, handleUpdate, onFlag, handleDelete, isDashboar
     userId === submission.user_id, [userId, submission.user_id]);
 
   const toggleShowEditModal = () => setShowEditModal(prevShowEditModal => !prevShowEditModal);
-  const submissionTitle = isDashboardView ? submission.lesson_title : submission.user_name;
 
   return (
     <div className="submissions__item">
-      <p className="submissions__user">{submissionTitle}</p>
+      <p>
+        <SubmissionTitle submission={submission} isDashboardView={isDashboardView} />
+      </p>
 
       <div className="submissions__actions">
         {isCurrentUsersSubmission && (

--- a/app/javascript/components/project-submissions/components/submissions-list.js
+++ b/app/javascript/components/project-submissions/components/submissions-list.js
@@ -6,7 +6,6 @@ import Submission from './submission'
 const noop = () => {}
 
 const SubmissionsList = ({ submissions, handleDelete, onFlag, handleUpdate, allSubmissionsPath, isDashboardView }) => {
-  console.log("all submissions path", allSubmissionsPath)
   return (
     <div>
       <div>

--- a/app/serializers/project_submission_serializer.rb
+++ b/app/serializers/project_submission_serializer.rb
@@ -1,4 +1,6 @@
 class ProjectSubmissionSerializer
+  include Rails.application.routes.url_helpers
+
   def initialize(project_submission)
     @project_submission = project_submission
   end
@@ -7,7 +9,7 @@ class ProjectSubmissionSerializer
     new(project_submission).as_json
   end
 
-  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def as_json(_options = nil)
     {
       id: project_submission.id,
@@ -16,11 +18,12 @@ class ProjectSubmissionSerializer
       is_public: project_submission.is_public,
       user_name: project_submission.user.username,
       user_id: project_submission.user.id,
-      lesson_id: project_submission.lesson_id,
+      lesson_id: project_submission.lesson.id,
       lesson_title: project_submission.lesson.title,
+      lesson_path: lesson_path(project_submission.lesson),
     }
   end
-  # rubocop:enable Metrics/AbcSize
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   private
 

--- a/spec/serializers/project_submission_serializer_spec.rb
+++ b/spec/serializers/project_submission_serializer_spec.rb
@@ -4,31 +4,35 @@ RSpec.describe ProjectSubmissionSerializer do
   subject { described_class.as_json(project_submission) }
 
   let(:project_submission) do
-    instance_double(
-      ProjectSubmission,
+    create(
+      :project_submission,
       id: 1,
-      repo_url: 'www.repourl.com/path',
-      live_preview_url: 'www.livepreviewurl.com/path',
+      repo_url: 'https://www.repourl.com/path',
+      live_preview_url: 'https://www.livepreviewurl.com/path',
       is_public: false,
       user: user,
-      lesson_id: 12,
       lesson: lesson
     )
   end
-  let(:user) { instance_double(User, id: 123, username: 'A USERNAME') }
-  let(:lesson) { instance_double(Lesson, title: 'A LESSON TITLE') }
+  let(:user) { create(:user, id: 123, username: 'A USERNAME') }
+  let(:lesson) { create(:lesson, id: 12, title: 'A LESSON TITLE') }
+
+  # before do
+  #   allow(subject).to receive(:lesson_path).and_return('/lesson_path')
+  # end
 
   describe '#as_json' do
     let(:serialized_project_submission) do
       {
         id: 1,
-        repo_url: 'www.repourl.com/path',
-        live_preview_url: 'www.livepreviewurl.com/path',
+        repo_url: 'https://www.repourl.com/path',
+        live_preview_url: 'https://www.livepreviewurl.com/path',
         is_public: false,
         user_name: 'A USERNAME',
         user_id: 123,
         lesson_id: 12,
         lesson_title: 'A LESSON TITLE',
+        lesson_path: '/lessons/a-lesson-title',
       }
     end
 


### PR DESCRIPTION
Because:
* This will make it easier for the student to view the project page for the submission.

This Commit:
* Adds a lesson_path value to the project submissions serializer.
* Adds a SubmissionTitle Component to hold the logic for displaying the submission title.