### PR TITLE
Feature: Enable Project Submissions Feature for JS Tic Tac Toe Project

### DIFF
--- a/app/controllers/lessons/project_submissions_controller.rb
+++ b/app/controllers/lessons/project_submissions_controller.rb
@@ -1,7 +1,7 @@
 module Lessons
   class ProjectSubmissionsController < ApplicationController
-    before_action :authenticate_user!
     before_action :set_lesson
+    before_action :check_if_project_submitable
 
     def index
       @project_submissions = Kaminari.paginate_array(
@@ -18,6 +18,12 @@ module Lessons
 
     def set_lesson
       @lesson = Lesson.friendly.find(params[:lesson_id])
+    end
+
+    def check_if_project_submitable
+      return if ProjectSubmissionFeature.enabled?(@lesson)
+
+      redirect_to lesson_path(@lesson), alert: 'That project does not accept submissions'
     end
   end
 end

--- a/app/features/project_submission_feature.rb
+++ b/app/features/project_submission_feature.rb
@@ -1,5 +1,5 @@
 class ProjectSubmissionFeature
-  def self.enabled?
-    Rails.env.development? || ENV['STAGING'].present?
+  def self.enabled?(lesson)
+    lesson.description == 'Tic Tac Toe'
   end
 end

--- a/app/javascript/components/project-submissions/components/create-form.js
+++ b/app/javascript/components/project-submissions/components/create-form.js
@@ -5,13 +5,22 @@ import { yupResolver } from '@hookform/resolvers';
 
 import schema from '../schemas/project-submission-schema'
 
-const CreateForm = ({ onClose, onSubmit }) => {
+const CreateForm = ({ onClose, onSubmit, userId }) => {
   const { register, handleSubmit, formState, errors } = useForm({
     resolver: yupResolver(schema),
     defaultValues: {
       is_public: true,
     }
   });
+
+  if(userId === null) {
+    return (
+      <div className="text-center">
+        <h1 className="bold">Please Sign in</h1>
+        <p>Please <a href='/login'>sign in</a> to add a project submission.</p>
+      </div>
+    )
+  }
 
   if (formState.isSubmitSuccessful) {
     return (

--- a/app/javascript/components/project-submissions/components/flag-form.js
+++ b/app/javascript/components/project-submissions/components/flag-form.js
@@ -7,7 +7,7 @@ const FlagForm = ({ onSubmit, submission, userId }) => {
 
   if(userId === null) {
     return (
-      <div className="text-center" style={{ width: '80%', margin: '0 auto' }}>
+      <div className="text-center">
         <h1 className="bold">Please Sign in</h1>
         <p>Please <a href='/login'>sign in</a> to flag this project submission.</p>
       </div>
@@ -16,7 +16,7 @@ const FlagForm = ({ onSubmit, submission, userId }) => {
 
   if (formState.isSubmitSuccessful) {
     return (
-      <div className="text-center" style={{ width: '80%', margin: '0 auto' }}>
+      <div className="text-center">
         <h1 className="bold">Thanks for helping us keep our community safe!</h1>
         <p>Our Moderators will review this issue shortly.</p>
       </div>

--- a/app/javascript/components/project-submissions/containers/project-submissions-container.js
+++ b/app/javascript/components/project-submissions/containers/project-submissions-container.js
@@ -89,7 +89,7 @@ const ProjectSubmissions = (props) => {
     return submissions.find(submission => submission.user_id === userId);
   }, [userId, submissions.length]);
 
-  const showAddSubmissionButton = () => !userSubmission && userId
+  const showAddSubmissionButton = () => !userSubmission
 
   return (
     <div className="submissions">
@@ -104,6 +104,7 @@ const ProjectSubmissions = (props) => {
             lessonId={lesson.id}
             onSubmit={handleCreate}
             onClose={toggleShowCreateModal}
+            userId={userId}
           />
         </Modal>
 
@@ -124,6 +125,7 @@ const ProjectSubmissions = (props) => {
           )}
         </div>
       </div>
+      <p className="text-center">This is a beta feature. If you have any feedback please let us know on discord <a href="https://discord.com/channels/505093832157691914/540903304046182425">here</a>.</p>
 
       <SubmissionsList
         submissions={submissions}

--- a/app/models/project_submission.rb
+++ b/app/models/project_submission.rb
@@ -3,7 +3,7 @@ class ProjectSubmission < ApplicationRecord
 
   belongs_to :user
   belongs_to :lesson
-  has_many :flags, dependent: :delete_all
+  has_many :flags, dependent: :destroy
 
   validates :repo_url, url: true
   validates :live_preview_url, url: true

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -2,7 +2,7 @@ class Track < ApplicationRecord
   extend FriendlyId
 
   has_many :users
-  has_many :track_courses, -> { order(:position) }, dependent: :delete_all
+  has_many :track_courses, -> { order(:position) }, dependent: :destroy
   has_many :courses, through: :track_courses
 
   validates :title, presence: true

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -25,7 +25,7 @@
   <div class="container">
     <div class="card-main">
 
-      <% if  ProjectSubmissionFeature.enabled? %>
+      <% if  ProjectSubmissionFeature.enabled?(@lesson) %>
         <%= react_component(
           "project-submissions/index",
           {

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,9 +5,7 @@
     <h1 class="text-center camel">My Dashboard</h1>
     <%= render 'profile_card', user: @user %>
     <%= render 'skills', courses: @courses%>
-    <% if ProjectSubmissionFeature.enabled? %>
-      <%= render 'project_submissions', project_submissions: @user.project_submissions %>
-    <% end %>
+    <%= render 'project_submissions', project_submissions: @user.project_submissions %>
   </div>
 
    <%= render 'shared/bottom_cta',

--- a/spec/features/project_submission_feature_spec.rb
+++ b/spec/features/project_submission_feature_spec.rb
@@ -2,8 +2,20 @@ require 'rails_helper'
 
 RSpec.describe ProjectSubmissionFeature do
   describe '.enabled?' do
-    it 'returns false' do
-      expect(ProjectSubmissionFeature.enabled?).to be(false)
+    context 'when on the tic tac toe lesson' do
+      let(:lesson) { create(:lesson, description: 'Tic Tac Toe') }
+
+      it 'returns true' do
+        expect(ProjectSubmissionFeature.enabled?(lesson)).to be(true)
+      end
+    end
+
+    context 'when not on the tic tac toe lesson' do
+      let(:lesson) { create(:lesson, description: 'Another Lesson') }
+
+      it 'returns false' do
+        expect(ProjectSubmissionFeature.enabled?(lesson)).to be(false)
+      end
     end
   end
 end


### PR DESCRIPTION
Because:
* We want to start testing this feature with users.

This commit:
* Enables the project submission feature for tic tac toe on production.
* Displays the add button for signed out users and prompts them to sign in if they click it.
* Enabled the all submissions page for signed out users.
* Checks if the project can have submissions in the lesson submissions controller and redirects them back to the project if it doesn't.