### PR TITLE
Feature: Hide Edit Flag

### DIFF
--- a/app/admin/flags.rb
+++ b/app/admin/flags.rb
@@ -1,7 +1,7 @@
 ActiveAdmin.register Flag do
   config.filters = false
 
-  actions :all, except: %i[destroy new]
+  actions :all, except: %i[destroy new edit]
 
   menu priority: 2
   config.batch_actions = false


### PR DESCRIPTION
Because:
* The filters have performance problems and we shouldn't need to edit a flag.

This Commit:
* Removes the edit endpoint in admin flags.