### PR TITLE
Feature: Add Project Submissions to Daily Summary Notification

### DIFF
--- a/app/models/project_submission.rb
+++ b/app/models/project_submission.rb
@@ -10,4 +10,5 @@ class ProjectSubmission < ApplicationRecord
   validates :repo_url, :live_preview_url, presence: { message: 'Required' }
 
   scope :viewable, -> { where(is_public: true, banned: false) }
+  scope :created_today, -> { where('created_at >= ?', Time.zone.now.beginning_of_day) }
 end

--- a/app/services/notifications/daily_summary.rb
+++ b/app/services/notifications/daily_summary.rb
@@ -3,7 +3,8 @@ module Notifications
     def message
       "**TOP Summary For #{Date.current.to_s(:long_ordinal)}**\n" \
       "#{User.where('created_at >= ?', start_of_day).size} users signed up today\n" \
-      "#{LessonCompletion.created_today.size} lessons completed today"
+      "#{LessonCompletion.created_today.size} lessons completed today\n" \
+      "#{ProjectSubmission.created_today.size} project submissions added today"
     end
 
     def destination

--- a/spec/factories/lesson_completions.rb
+++ b/spec/factories/lesson_completions.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :lesson_completion do
     association :student, factory: :user
+    association :lesson, factory: :lesson
   end
 end

--- a/spec/models/lesson_completion_spec.rb
+++ b/spec/models/lesson_completion_spec.rb
@@ -10,20 +10,16 @@ RSpec.describe LessonCompletion do
   it { is_expected.to validate_presence_of(:lesson_id) }
 
   describe '.created_today' do
-    let(:student) { create(:user) }
-    let(:lesson_one) { create(:lesson) }
-    let(:lesson_two) { create(:lesson) }
-
-    let(:lesson_completed_today) do
-      create(:lesson_completion, created_at: Time.zone.today, student: student, lesson: lesson_one)
+    let!(:lesson_completed_today) do
+      create(:lesson_completion, created_at: Time.zone.today)
     end
 
-    let(:lesson_not_completed_today) do
-      create(:lesson_completion, created_at: Time.zone.today - 2.days, student: student, lesson: lesson_one)
+    let!(:lesson_not_completed_today) do
+      create(:lesson_completion, created_at: Time.zone.today - 2.days)
     end
 
     it 'returns lessons completed today' do
-      expect(LessonCompletion.created_today).to include(lesson_completed_today)
+      expect(LessonCompletion.created_today).to contain_exactly(lesson_completed_today)
     end
   end
 end

--- a/spec/models/project_submission_spec.rb
+++ b/spec/models/project_submission_spec.rb
@@ -30,4 +30,18 @@ RSpec.describe ProjectSubmission, type: :model do
       )
     end
   end
+
+  describe '.created_today' do
+    let!(:project_submission_created_today) do
+      create(:project_submission, created_at: Time.zone.today)
+    end
+
+    let!(:project_submission_not_not_created_today) do
+      create(:project_submission, created_at: Time.zone.today - 2.days)
+    end
+
+    it 'returns projects submission created today' do
+      expect(ProjectSubmission.created_today).to contain_exactly(project_submission_created_today)
+    end
+  end
 end

--- a/spec/services/notifications/daily_summary_spec.rb
+++ b/spec/services/notifications/daily_summary_spec.rb
@@ -14,7 +14,10 @@ RSpec.describe Notifications::DailySummary do
 
     it 'returns the daily summary message' do
       expect(notification.message).to eql(
-        "**TOP Summary For April 10th, 2020**\n0 users signed up today\n0 lessons completed today"
+        "**TOP Summary For April 10th, 2020**\n" \
+        "0 users signed up today\n" \
+        "0 lessons completed today\n" \
+        '0 project submissions added today'
       )
     end
   end


### PR DESCRIPTION
Because:
* This allows us to keep an eye on the use of this feature.

This Commit:
* Adds a new line for project submissions to the daily summary notification
* Adds a created_today scope to the project submission model.
* Tidies up the lesson completions created today scope tests.