### PR TITLE
Feature: Display a Link to Legacy Submissions

### DIFF
--- a/app/helpers/lessons_helper.rb
+++ b/app/helpers/lessons_helper.rb
@@ -10,4 +10,8 @@ module LessonsHelper
   def github_edit_url(lesson)
     github_link("curriculum/edit/master#{lesson.url}")
   end
+
+  def legacy_submissions_url(lesson)
+    github_link("curriculum/blob/master/legacy_submissions#{lesson.url}")
+  end
 end

--- a/app/javascript/components/project-submissions/components/submissions-list.js
+++ b/app/javascript/components/project-submissions/components/submissions-list.js
@@ -1,11 +1,14 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { object, func, arrayOf, string, bool } from 'prop-types';
 
-import Submission from './submission'
+import Submission from './submission';
+import ProjectSubmissionContext from '../ProjectSubmissionContext';
 
-const noop = () => {}
+const noop = () => {};
 
-const SubmissionsList = ({ submissions, handleDelete, onFlag, handleUpdate, allSubmissionsPath, isDashboardView }) => {
+const SubmissionsList = ({ submissions, handleDelete, onFlag, handleUpdate, isDashboardView }) => {
+  const { allSubmissionsPath, legacySubmissionsUrl } = useContext(ProjectSubmissionContext);
+
   return (
     <div>
       <div>
@@ -22,9 +25,9 @@ const SubmissionsList = ({ submissions, handleDelete, onFlag, handleUpdate, allS
       </div>
 
       { allSubmissionsPath.length > 0 &&
-        <p className="submissions__view-more">
-          Showing {submissions.length} most recent submissions.
-          <a href={allSubmissionsPath}> View full list of solutions here.</a>
+        <p className='submissions__view-more'>
+          <span>Showing {submissions.length} most recent submissions - </span>
+          <a href={allSubmissionsPath}> View full list of solutions</a> or <a href={legacySubmissionsUrl} target='_blank'>View old submissions</a>
         </p>
       }
     </div>

--- a/app/javascript/components/project-submissions/containers/project-submissions-container.js
+++ b/app/javascript/components/project-submissions/containers/project-submissions-container.js
@@ -5,7 +5,7 @@ import axios from '../../../src/js/axiosWithCsrf';
 import ProjectSubmissionContext from "../ProjectSubmissionContext";
 
 const ProjectSubmissions = (props) => {
-  const { userId, lesson, course, allSubmissionsPath } = useContext(ProjectSubmissionContext);
+  const { userId, lesson, course } = useContext(ProjectSubmissionContext);
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [showFlagModal, setShowFlagModal] = useState(false);
   const [submissions, setSubmissions] = useState(props.submissions);
@@ -125,14 +125,15 @@ const ProjectSubmissions = (props) => {
           )}
         </div>
       </div>
-      <p className="text-center">This is a beta feature. If you have any feedback please let us know on discord <a href="https://discord.com/channels/505093832157691914/540903304046182425">here</a>.</p>
-
+      <p className="text-center">
+        <span>This is a beta feature. If you have any feedback </span>
+        <a href="https://discord.com/channels/505093832157691914/540903304046182425">please let us know</a>.
+      </p>
       <SubmissionsList
         submissions={submissions}
         handleUpdate={handleUpdate}
         onFlag={(submission) => { setFlaggedSubmission(submission); toggleShowFlagModal() }}
         handleDelete={handleDelete}
-        allSubmissionsPath={allSubmissionsPath}
       />
     </div>
   )

--- a/app/javascript/components/project-submissions/index.jsx
+++ b/app/javascript/components/project-submissions/index.jsx
@@ -3,8 +3,8 @@ import { number, array, object, string } from 'prop-types';
 import ProjectSubmissionsContainer from './containers/project-submissions-container';
 import ProjectSubmissionContext from "./ProjectSubmissionContext";
 
-const ProjectSubmissions = ({ submissions, course, lesson, userId, allSubmissionsPath }) => (
-  <ProjectSubmissionContext.Provider value={{ userId, lesson, course, allSubmissionsPath }}>
+const ProjectSubmissions = ({ submissions, course, lesson, userId, allSubmissionsPath, legacySubmissionsUrl }) => (
+  <ProjectSubmissionContext.Provider value={{ userId, lesson, course, allSubmissionsPath, legacySubmissionsUrl }}>
     <ProjectSubmissionsContainer submissions={submissions} />
   </ProjectSubmissionContext.Provider>
 );
@@ -20,6 +20,7 @@ ProjectSubmissions.propTypes = {
   lesson: object.isRequired,
   course: object.isRequired,
   allSubmissionsPath: string,
+  legacySubmissionsUrl: string,
 };
 
 export default ProjectSubmissions;

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -34,6 +34,7 @@
             lesson: @lesson.as_json,
             submissions: @project_submissions.map { |submission| ProjectSubmissionSerializer.as_json(submission) },
             allSubmissionsPath: lesson_project_submissions_path(@lesson),
+            legacySubmissionsUrl: legacy_submissions_url(@lesson)
           }
         ) %>
       <% end %>

--- a/spec/helpers/lessons_helper_spec.rb
+++ b/spec/helpers/lessons_helper_spec.rb
@@ -35,4 +35,14 @@ RSpec.describe LessonsHelper do
       )
     end
   end
+
+  describe '#legacy_submissions_url' do
+    let(:lesson) { create(:lesson) }
+
+    it 'returns the legacy submissions url for the lesson' do
+      expect(helper.legacy_submissions_url(lesson)).to eql(
+        'https://github.com/TheOdinProject/curriculum/blob/master/legacy_submissions/lesson_course/lesson_title.md'
+      )
+    end
+  end
 end


### PR DESCRIPTION
Because:
* We should provide an easy way to view legacy solutions while the new submissions feature is adopted.

This Commit:
* Adds a helper for creating a url to the legacy submissions for a lesson on github.
* Passes a legacy submission url to the project submissions component.
* Displays the legacy submission url beside the link to the all submissions page.