### PR TITLE
Fix: Broken Link in Course Badge

### DIFF
--- a/app/views/courses/_course_card.html.erb
+++ b/app/views/courses/_course_card.html.erb
@@ -9,11 +9,9 @@
 
       <div class="course-card-header <%= course_completed_class?(course, current_user) %>">
 
-        <%= link_to course, class: 'course-card-header__link' do %>
-          <div class='course-card-header__image'>
-            <%= render 'shared/course_badge', course: course, user: current_user, modifier: '' %>
-          </div>
-        <% end %>
+        <div class='course-card-header__image'>
+          <%= render 'shared/course_badge', course: course, user: current_user, modifier: '' %>
+        </div>
 
         <%= link_to course, class: 'course-card-header__link' do %>
           <h2 id=<%= course.title.parameterize %> class="course-card-header__title">

--- a/app/views/courses/course/_banner.html.erb
+++ b/app/views/courses/course/_banner.html.erb
@@ -1,11 +1,9 @@
 <div class="banner">
   <div class='banner__badge'>
-    <%= link_to course, class: 'course-card-header__link' do %>
-      <%= render 'shared/course_badge', course: course, user: current_user, modifier: '' %>
-    <% end %>
+    <%= render 'shared/course_badge', course: course, user: current_user, modifier: '' %>
   </div>
 
-   <%= link_to course, class: 'course-card-header__link' do %>
+  <%= link_to course, class: 'course-card-header__link' do %>
     <h1 class="banner__title"><%= course.title %></h1>
-    <% end %>
+  <% end %>
 </div>

--- a/app/views/shared/_course_badge.html.erb
+++ b/app/views/shared/_course_badge.html.erb
@@ -1,13 +1,17 @@
 <% unless user_signed_in? && course_started_by_user?(course, user) %>
-  <div class="course-badge">
-    <%= image_tag course.badge, alt: "#{course.title} badge", class: 'course-badge__image' %>
-  </div>
-<% else %>
-  <div class="course-badge progress-circle <%= modifier %>" data-progress="<%= percentage_completed_by_user(course, user) %>">
-    <div class="progress-circle__inner">
-      <%= image_tag course.borderless_badge, alt: "#{course.title} badge", class: 'progress-circle__image' %>
-      <p class="bold progress-circle__content"><%= "#{percentage_completed_by_user(course, user)}%" %></p>
-      <p class="progress-circle__content">COMPLETE</p>
+  <%= link_to course do %>
+    <div class="course-badge">
+      <%= image_tag course.badge, alt: "#{course.title} badge", class: 'course-badge__image' %>
     </div>
-  </div>
+  <% end %>
+<% else %>
+  <%= link_to course do %>
+    <div class="course-badge progress-circle <%= modifier %>" data-progress="<%= percentage_completed_by_user(course, user) %>">
+      <div class="progress-circle__inner">
+        <%= image_tag course.borderless_badge, alt: "#{course.title} badge", class: 'progress-circle__image' %>
+        <p class="bold progress-circle__content"><%= "#{percentage_completed_by_user(course, user)}%" %></p>
+        <p class="progress-circle__content">COMPLETE</p>
+      </div>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/users/_skill.html.erb
+++ b/app/views/users/_skill.html.erb
@@ -1,8 +1,6 @@
 <div class="skill">
   <div class='skill__image'>
-    <%= link_to course do %>
-      <%= render 'shared/course_badge', course: course, user: @user, modifier: modifier_for_badge(course, @user) %>
-    <% end %>
+    <%= render 'shared/course_badge', course: course, user: @user, modifier: modifier_for_badge(course, @user) %>
   </div>
 
   <div class="skill__details">


### PR DESCRIPTION
Because:
* The link to the course was being removed when it was being re-rendered after clicking the lesson completion button.

This commit:
* Moves the wrapping course link into the badde component itself so it also re-renders when a lesson completion button is clicked.