### PR TITLE
Chore: Remove Ref Param from Internal Links.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,7 +24,7 @@ class ApplicationController < ActionController::Base
   end
 
   def after_sign_out_path_for(_resource_or_scope)
-    home_path(ref: 'logout')
+    home_path
   end
 
   def after_sign_in_path_for(_resource)

--- a/app/views/lessons/_lesson_buttons.html.erb
+++ b/app/views/lessons/_lesson_buttons.html.erb
@@ -1,5 +1,5 @@
 <%= link_to 'View Course',
-    course_path(course.title_url, ref: 'lnav'),
+    course_path(course.title_url),
     title: "Go back to '#{lesson.course.title}'",
     class: 'button button--secondary lesson-button-group__item lesson-button'
 %>
@@ -8,7 +8,7 @@
 
 <% if lesson.next_lesson %>
   <%= link_to 'Next Lesson',
-      course_lesson_path(course, lesson.next_lesson, ref: 'lnav'),
+      course_lesson_path(course, lesson.next_lesson),
       title: "Move on to '#{lesson.next_lesson.title}'",
       class: "button #{next_lesson_button_state(lesson)} lesson-button-group__item lesson-button"
   %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -62,19 +62,19 @@
           </ul>
         </li>
         <li class="nav-item <%= active_class(about_path) %>">
-          <%= link_to 'About', about_path(ref: 'homenav'), class: 'nav-link' %>
+          <%= link_to 'About', about_path, class: 'nav-link' %>
         </li>
         <li class="nav-item <%= active_class(faq_path) %>">
-          <%= link_to "FAQ", faq_path(ref: 'homehav'), class: 'nav-link' %>
+          <%= link_to "FAQ", faq_path, class: 'nav-link' %>
         </li>
 
         <li class="divider nav-link">|</li>
 
         <li class="nav-item <%= active_class(sign_up_path) %>">
-          <%= link_to 'Sign Up', sign_up_path(ref: 'homenav'), class: 'nav-link' %>
+          <%= link_to 'Sign Up', sign_up_path, class: 'nav-link' %>
         </li>
         <li class="nav-item <%= active_class(login_path) %>">
-          <%= link_to 'Log In', login_path(ref: 'homenav'), class: 'nav-link' %>
+          <%= link_to 'Log In', login_path, class: 'nav-link' %>
         </li>
       </ul>
     </nav>

--- a/app/views/shared/_navbar_modal.html.erb
+++ b/app/views/shared/_navbar_modal.html.erb
@@ -13,7 +13,7 @@
       <ul class="modal-links">
         <% if user_signed_in? %>
           <li class="nav-item <%= active_class(dashboard_path) %>">
-            <%= link_to 'Dashboard', dashboard_path(ref: 'homenav'), class: 'nav-link' %>
+            <%= link_to 'Dashboard', dashboard_path, class: 'nav-link' %>
           </li>
 
           <li class="nav-item <%= active_class(courses_path) %>">
@@ -32,7 +32,7 @@
           </li>
 
           <li class="nav-item">
-            <%= link_to "Log Out", logout_path(ref: 'homenav'), class: 'nav-link' %>
+            <%= link_to "Log Out", logout_path, class: 'nav-link' %>
           </li>
 
         <% else %>
@@ -51,20 +51,20 @@
           </li>
 
           <li class="nav-item <%= active_class(about_path) %>">
-            <%= link_to 'About', about_path(ref: 'homenav'), class: 'nav-link' %>
+            <%= link_to 'About', about_path, class: 'nav-link' %>
           </li>
 
           <li class="nav-item <%= active_class(faq_path) %>">
-            <%= link_to "FAQ", faq_path(ref: 'homehav'), class: 'nav-link' %>
+            <%= link_to "FAQ", faq_path, class: 'nav-link' %>
           </li>
 
           <div class="dropdown-divider"></div>
 
           <li class="nav-item <%= active_class(sign_up_path) %>">
-            <%= link_to 'Sign Up', sign_up_path(ref: 'homenav'), class: 'nav-link' %>
+            <%= link_to 'Sign Up', sign_up_path, class: 'nav-link' %>
           </li>
           <li class="nav-item <%= active_class(login_path) %>">
-            <%= link_to 'Log In', login_path(ref: 'homenav'), class: 'nav-link' %>
+            <%= link_to 'Log In', login_path, class: 'nav-link' %>
           </li>
         <% end %>
       </ul>

--- a/app/views/shared/_user_dropdown.html.erb
+++ b/app/views/shared/_user_dropdown.html.erb
@@ -12,7 +12,7 @@
       <% end %>
     </li>
     <li>
-      <%= link_to logout_path(ref: 'homenav'), class: 'drop-down-link accent' do %>
+      <%= link_to logout_path, class: 'drop-down-link accent' do %>
         <span class="drop-down-logo logout-logo"></span>Log out
       <% end %>
     </li>


### PR DESCRIPTION
Because:
* We have had a few reports from users not being able to login via google oauth recently. They were getting url mismatch errors, instructing them to sign in through  the login page without the ref param in the url seemed to fix it.

* This param is not needed anyway, I suspect it was used with google analytics at one point to track sign up progression in the early days of TOP.

This commit:
* Removes the ref param from internal links.