### PR TITLE
Feature: Allow the Live Preview Field to be Hidden for Individual Projects

### DIFF
--- a/app/javascript/components/project-submissions/components/create-form.js
+++ b/app/javascript/components/project-submissions/components/create-form.js
@@ -1,11 +1,13 @@
-import React from 'react';
+import React, { Fragment, useContext } from 'react';
 import { useForm } from 'react-hook-form';
 import { func } from 'prop-types';
 import { yupResolver } from '@hookform/resolvers';
 
 import schema from '../schemas/project-submission-schema'
+import ProjectSubmissionContext from '../ProjectSubmissionContext';
 
 const CreateForm = ({ onClose, onSubmit, userId }) => {
+  const { lesson } = useContext(ProjectSubmissionContext);
   const { register, handleSubmit, formState, errors } = useForm({
     resolver: yupResolver(schema),
     defaultValues: {
@@ -49,17 +51,21 @@ const CreateForm = ({ onClose, onSubmit, userId }) => {
         </div>
         {errors.repo_url && <div className="form__error-message push-down"> {errors.repo_url.message}</div>}
 
-        <div className="form__section">
-          <span className="form__icon fas fa-link"></span>
-          <input
-            className="form__element form__element--with-icon"
-            type="url"
-            placeholder="Live Preview URL"
-            name="live_preview_url"
-            ref={register()}
-          />
-        </div>
-        {errors.live_preview_url && <div className="form__error-message push-down"> {errors.live_preview_url.message}</div>}
+        { lesson.has_live_preview &&
+          <Fragment>
+            <div className="form__section">
+              <span className="form__icon fas fa-link"></span>
+              <input
+                className="form__element form__element--with-icon"
+                type="url"
+                placeholder="Live Preview URL"
+                name="live_preview_url"
+                ref={register()}
+              />
+            </div>
+            { errors.live_preview_url && <div className="form__error-message push-down"> {errors.live_preview_url.message}</div> }
+           </Fragment>
+        }
 
         <div className="form__section form__section--right-aligned form__section--bottom">
           <div className="form__toggle-checkbox">

--- a/app/javascript/components/project-submissions/components/edit-form.js
+++ b/app/javascript/components/project-submissions/components/edit-form.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { useForm } from 'react-hook-form';
 import { func, object } from 'prop-types';
 import { yupResolver } from '@hookform/resolvers';
@@ -48,18 +48,21 @@ const EditForm = ({ submission, onSubmit, onClose, onDelete }) => {
           />
         </div>
         {errors.repo_url && <div className="form__error-message push-down"> {errors.repo_url.message}</div>}
-
-        <div className="form__section">
-          <span className="form__icon fas fa-link"></span>
-          <input
-            className="form__element form__element--with-icon"
-            type="text"
-            placeholder="Live Preview URL"
-            name="live_preview_url"
-            ref={register()}
-          />
-        </div>
-        {errors.live_preview_url && <div className="form__error-message push-down"> {errors.live_preview_url.message}</div> }
+        { submission.lesson_has_live_preview &&
+          <Fragment>
+            <div className="form__section">
+              <span className="form__icon fas fa-link"></span>
+              <input
+                className="form__element form__element--with-icon"
+                type="text"
+                placeholder="Live Preview URL"
+                name="live_preview_url"
+                ref={register()}
+              />
+            </div>
+            {errors.live_preview_url && <div className="form__error-message push-down"> {errors.live_preview_url.message}</div> }
+            </Fragment>
+        }
 
         <div className="form__section form__section--right-aligned form__section--bottom">
 

--- a/app/javascript/components/project-submissions/components/submissions-list.js
+++ b/app/javascript/components/project-submissions/components/submissions-list.js
@@ -8,7 +8,7 @@ const noop = () => {};
 
 const SubmissionsList = ({ submissions, handleDelete, onFlag, handleUpdate, isDashboardView }) => {
   const { allSubmissionsPath, legacySubmissionsUrl } = useContext(ProjectSubmissionContext);
-
+  console.log("submissions", allSubmissionsPath)
   return (
     <div>
       <div>
@@ -24,7 +24,7 @@ const SubmissionsList = ({ submissions, handleDelete, onFlag, handleUpdate, isDa
         ))}
       </div>
 
-      { allSubmissionsPath.length > 0 &&
+      { allSubmissionsPath &&
         <p className='submissions__view-more'>
           <span>Showing {submissions.length} most recent submissions - </span>
           <a href={allSubmissionsPath}> View full list of solutions</a> or <a href={legacySubmissionsUrl} target='_blank'>View old submissions</a>

--- a/app/serializers/project_submission_serializer.rb
+++ b/app/serializers/project_submission_serializer.rb
@@ -18,9 +18,10 @@ class ProjectSubmissionSerializer
       is_public: project_submission.is_public,
       user_name: project_submission.user.username,
       user_id: project_submission.user.id,
-      lesson_id: project_submission.lesson.id,
-      lesson_title: project_submission.lesson.title,
-      lesson_path: lesson_path(project_submission.lesson),
+      lesson_id: lesson.id,
+      lesson_title: lesson.title,
+      lesson_path: lesson_path(lesson),
+      lesson_has_live_preview: lesson.has_live_preview,
     }
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
@@ -28,4 +29,8 @@ class ProjectSubmissionSerializer
   private
 
   attr_reader :project_submission
+
+  def lesson
+    project_submission.lesson
+  end
 end

--- a/db/migrate/20200930164027_add_has_live_preview_to_lessons.rb
+++ b/db/migrate/20200930164027_add_has_live_preview_to_lessons.rb
@@ -1,0 +1,5 @@
+class AddHasLivePreviewToLessons < ActiveRecord::Migration[6.0]
+  def change
+    add_column :lessons, :has_live_preview, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20200930171734_change_project_submission_live_preview_url_default.rb
+++ b/db/migrate/20200930171734_change_project_submission_live_preview_url_default.rb
@@ -1,0 +1,5 @@
+class ChangeProjectSubmissionLivePreviewUrlDefault < ActiveRecord::Migration[6.0]
+  def change
+    change_column :project_submissions, :live_preview_url, :string, default: '', null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_23_172005) do
+ActiveRecord::Schema.define(version: 2020_09_30_171734) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -94,13 +94,14 @@ ActiveRecord::Schema.define(version: 2020_09_23_172005) do
     t.string "slug"
     t.string "repo"
     t.boolean "accepts_submission", default: false, null: false
+    t.boolean "has_live_preview", default: false, null: false
     t.index ["position"], name: "index_lessons_on_position"
     t.index ["slug", "section_id"], name: "index_lessons_on_slug_and_section_id", unique: true
   end
 
   create_table "project_submissions", id: :serial, force: :cascade do |t|
     t.string "repo_url"
-    t.string "live_preview_url"
+    t.string "live_preview_url", default: "", null: false
     t.integer "user_id"
     t.integer "lesson_id"
     t.datetime "created_at", null: false

--- a/db/seeds/03_database_course_seeds.rb
+++ b/db/seeds/03_database_course_seeds.rb
@@ -61,5 +61,7 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/databases/project_databases.md',
-  repo: 'curriculum'
+  repo: 'curriculum',
+  accepts_submission: true,
+  has_live_preview: false
 )

--- a/db/seeds/05_html_css_course_seeds.rb
+++ b/db/seeds/05_html_css_course_seeds.rb
@@ -87,7 +87,8 @@ create_or_update_lesson(
   is_project: true,
   url: '/html_css/project_media.md',
   repo: 'curriculum',
-  accepts_submission: true
+  accepts_submission: true,
+  has_live_preview: true
 )
 
 lesson_position += 1
@@ -161,7 +162,8 @@ create_or_update_lesson(
   is_project: true,
   url: '/html_css/project_html_forms.md',
   repo: 'curriculum',
-  accepts_submission: true
+  accepts_submission: true,
+  has_live_preview: true
 )
 
 # +++++++++++
@@ -247,7 +249,8 @@ create_or_update_lesson(
   is_project: true,
   url: '/html_css/project_positioning.md',
   repo: 'curriculum',
-  accepts_submission: true
+  accepts_submission: true,
+  has_live_preview: true
 )
 
 lesson_position += 1
@@ -284,7 +287,8 @@ create_or_update_lesson(
   is_project: true,
   url: '/html_css/project_backgrounds.md',
   repo: 'curriculum',
-  accepts_submission: true
+  accepts_submission: true,
+  has_live_preview: true
 )
 
 # +++++++++++
@@ -334,7 +338,8 @@ create_or_update_lesson(
   is_project: true,
   url: '/html_css/project_design.md',
   repo: 'curriculum',
-  accepts_submission: true
+  accepts_submission: true,
+  has_live_preview: true
 )
 
 # +++++++++++
@@ -372,7 +377,8 @@ create_or_update_lesson(
   is_project: true,
   url: '/html_css/project_responsive.md',
   repo: 'curriculum',
-  accepts_submission: true
+  accepts_submission: true,
+  has_live_preview: true
 )
 
 lesson_position += 1
@@ -397,7 +403,8 @@ create_or_update_lesson(
   is_project: true,
   url: '/html_css/project_bootstrap.md',
   repo: 'curriculum',
-  accepts_submission: true
+  accepts_submission: true,
+  has_live_preview: true
 )
 
 # +++++++++++
@@ -447,7 +454,8 @@ create_or_update_lesson(
   is_project: true,
   url: '/html_css/project_css_frameworks.md',
   repo: 'curriculum',
-  accepts_submission: true
+  accepts_submission: true,
+  has_live_preview: true
 )
 
 lesson_position += 1

--- a/db/seeds/06_javascript_course_seeds.rb
+++ b/db/seeds/06_javascript_course_seeds.rb
@@ -102,7 +102,8 @@ create_or_update_lesson(
   is_project: true,
   url: '/javascript/organizing-js/library-project.md',
   repo: 'curriculum',
-  accepts_submission: true
+  accepts_submission: true,
+  has_live_preview: true
 )
 
 lesson_position += 1
@@ -127,7 +128,8 @@ create_or_update_lesson(
   is_project: true,
   url: '/javascript/organizing-js/tic-tac-toe-project.md',
   repo: 'curriculum',
-  accepts_submission: true
+  accepts_submission: true,
+  has_live_preview: true
 )
 
 lesson_position += 1
@@ -189,7 +191,8 @@ create_or_update_lesson(
   is_project: true,
   url: '/javascript/organizing-js/todo-project.md',
   repo: 'curriculum',
-  accepts_submission: true
+  accepts_submission: true,
+  has_live_preview: true
 )
 
 # +++++++++++
@@ -324,7 +327,8 @@ create_or_update_lesson(
   is_project: true,
   url: '/javascript/react-js/project-cv.md',
   repo: 'curriculum',
-  accepts_submission: true
+  accepts_submission: true,
+  has_live_preview: true
 )
 
 lesson_position += 1
@@ -361,7 +365,8 @@ create_or_update_lesson(
   is_project: true,
   url: '/javascript/react-js/project-memory-card.md',
   repo: 'curriculum',
-  accepts_submission: true
+  accepts_submission: true,
+  has_live_preview: true
 )
 
 lesson_position += 1
@@ -386,7 +391,8 @@ create_or_update_lesson(
   is_project: true,
   url: '/javascript/react-js/project-shopping-chart.md',
   repo: 'curriculum',
-  accepts_submission: true
+  accepts_submission: true,
+  has_live_preview: true
 )
 
 lesson_position += 1
@@ -472,7 +478,8 @@ create_or_update_lesson(
   is_project: true,
   url: '/javascript/async-apis/project.md',
   repo: 'curriculum',
-  accepts_submission: true
+  accepts_submission: true,
+  has_live_preview: true
 )
 
 # +++++++++++
@@ -510,7 +517,8 @@ create_or_update_lesson(
   is_project: true,
   url: '/javascript/testing/testing-practice.md',
   repo: 'curriculum',
-  accepts_submission: true
+  accepts_submission: true,
+  has_live_preview: true
 )
 
 lesson_position += 1
@@ -535,7 +543,8 @@ create_or_update_lesson(
   is_project: true,
   url: '/javascript/testing/battleship-project.md',
   repo: 'curriculum',
-  accepts_submission: true
+  accepts_submission: true,
+  has_live_preview: true
 )
 # +++++++++++
 # section
@@ -572,7 +581,8 @@ create_or_update_lesson(
   is_project: true,
   url: '/javascript/js-rails/project_rails_backend.md',
   repo: 'curriculum',
-  accepts_submission: true
+  accepts_submission: true,
+  has_live_preview: true,
 )
 
 # +++++++++++
@@ -598,7 +608,8 @@ create_or_update_lesson(
   is_project: true,
   url: '/javascript/finishing-up/project_final_js.md',
   repo: 'curriculum',
-  accepts_submission: true
+  accepts_submission: true,
+  has_live_preview: true
 )
 
 lesson_position += 1

--- a/db/seeds/07_getting_hired_course_seeds.rb
+++ b/db/seeds/07_getting_hired_course_seeds.rb
@@ -98,7 +98,8 @@ create_or_update_lesson(
   is_project: true,
   url: '/getting_hired/project_portfolio.md',
   repo: 'curriculum',
-  accepts_submission: true
+  accepts_submission: true,
+  has_live_preview: true
 )
 
 # +++++++++++
@@ -148,7 +149,8 @@ create_or_update_lesson(
   is_project: true,
   url: '/getting_hired/project_resume.md',
   repo: 'curriculum',
-  accepts_submission: false
+  accepts_submission: false,
+  has_live_preview: false
 )
 
 lesson_position += 1

--- a/db/seeds/08_node_js_course_seeds.rb
+++ b/db/seeds/08_node_js_course_seeds.rb
@@ -63,7 +63,8 @@ create_or_update_lesson(
   is_project: true,
   url: '/nodeJS/getting-started/Getting-Started-Project.md',
   repo: 'curriculum',
-  accepts_submission: true
+  accepts_submission: true,
+  has_live_preview: true
 )
 
 # +++++++++++
@@ -137,7 +138,8 @@ create_or_update_lesson(
   is_project: true,
   url: '/nodeJS/express-basics/Express-Mini-Message-Board.md',
   repo: 'curriculum',
-  accepts_submission: true
+  accepts_submission: true,
+  has_live_preview: true
 )
 
 lesson_position += 1
@@ -186,7 +188,8 @@ create_or_update_lesson(
   is_project: true,
   url: '/nodeJS/express-basics/Express-Inventory-Application.md',
   repo: 'curriculum',
-  accepts_submission: true
+  accepts_submission: true,
+  has_live_preview: true
 )
 
 # +++++++++++
@@ -236,7 +239,8 @@ create_or_update_lesson(
   is_project: true,
   url: '/nodeJS/authentication/Members-Only.md',
   repo: 'curriculum',
-  accepts_submission: true
+  accepts_submission: true,
+  has_live_preview: true
 )
 
 # +++++++++++
@@ -286,7 +290,8 @@ create_or_update_lesson(
   is_project: true,
   url: '/nodeJS/APIs/Blog-Project.md',
   repo: 'curriculum',
-  accepts_submission: true
+  accepts_submission: true,
+  has_live_preview: true
 )
 
 # +++++++++++
@@ -349,5 +354,6 @@ create_or_update_lesson(
   is_project: true,
   url: '/nodeJS/Odin-Book.md',
   repo: 'curriculum',
-  accepts_submission: true
+  accepts_submission: true,
+  has_live_preview: true
 )

--- a/spec/serializers/project_submission_serializer_spec.rb
+++ b/spec/serializers/project_submission_serializer_spec.rb
@@ -15,11 +15,7 @@ RSpec.describe ProjectSubmissionSerializer do
     )
   end
   let(:user) { create(:user, id: 123, username: 'A USERNAME') }
-  let(:lesson) { create(:lesson, id: 12, title: 'A LESSON TITLE') }
-
-  # before do
-  #   allow(subject).to receive(:lesson_path).and_return('/lesson_path')
-  # end
+  let(:lesson) { create(:lesson, id: 12, title: 'A LESSON TITLE', has_live_preview: true) }
 
   describe '#as_json' do
     let(:serialized_project_submission) do
@@ -33,6 +29,7 @@ RSpec.describe ProjectSubmissionSerializer do
         lesson_id: 12,
         lesson_title: 'A LESSON TITLE',
         lesson_path: '/lessons/a-lesson-title',
+        lesson_has_live_preview: true,
       }
     end
 


### PR DESCRIPTION
Because:
* Some Projects do not have any thing to deploy to a live preview site.

This Commit:
* Adds a has_live_preview field to the lessons table.
* Hides the live preview in the create and edit submission forms if that column is set to false.