### PR TITLE
Fix: Project Shopping Cart titles

### DIFF
--- a/db/seeds/06_javascript_course_seeds.rb
+++ b/db/seeds/06_javascript_course_seeds.rb
@@ -378,9 +378,9 @@ create_or_update_lesson(
 
 lesson_position += 1
 create_or_update_lesson(
-  title: 'Shopping Chart',
-  title_url: 'Shopping Chart'.parameterize,
-  description: 'Shopping Chart',
+  title: 'Shopping Cart',
+  title_url: 'Shopping Cart'.parameterize,
+  description: 'Shopping Cart',
   position: lesson_position,
   section_id: section.id,
   is_project: true,


### PR DESCRIPTION
The React.js "Shopping Cart" Project lesson is currently inappropriately named for what's expected of the student.

This pull request:
- Updates the seeds file for the lesson to contain the appropriate lesson name.