### PR TITLE
Fix: Position of Flag on Mobile

### DIFF
--- a/app/assets/stylesheets/components/project_submissions/submissions.scss
+++ b/app/assets/stylesheets/components/project_submissions/submissions.scss
@@ -86,7 +86,7 @@
     cursor: pointer;
 
     @include media-breakpoint-down(sm) {
-      position: absolute;
+      position: absolute !important;
       top: 5px;
       right: 0;
     }


### PR DESCRIPTION
Because:
* Adding the tooltip to the flag override its position property.