### PR TITLE
Chore: Add Flaggers Dismissed Flag Count to Admin Flag View

### DIFF
--- a/app/admin/flags.rb
+++ b/app/admin/flags.rb
@@ -40,6 +40,9 @@ ActiveAdmin.register Flag do
       row :status
       row :taken_action
       row :created_at
+      row :number_of_times_flagger_has_had_a_dismissed_flag do
+        flag.flagger.dismissed_flags.size
+      end
       row :project_submission_flag_count do
         flags = Flag.where(project_submission: flag.project_submission)
         active = flags.count { |r| r.status == 'active' }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,7 @@ class User < ApplicationRecord
   has_many :completed_lessons, through: :lesson_completions, source: :lesson
   has_many :project_submissions, dependent: :destroy
   has_many :user_providers, dependent: :destroy
+  has_many :flags, foreign_key: :flagger_id, dependent: :destroy
   belongs_to :track
 
   def progress_for(course)
@@ -36,6 +37,10 @@ class User < ApplicationRecord
 
   def inactive_message
     !banned? ? super : :banned
+  end
+
+  def dismissed_flags
+    flags.where(taken_action: :dismiss)
   end
 
   private

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe User do
   it { is_expected.to have_many(:completed_lessons) }
   it { is_expected.to have_many(:project_submissions).dependent(:destroy) }
   it { is_expected.to have_many(:user_providers).dependent(:destroy) }
+  it { is_expected.to have_many(:flags).dependent(:destroy) }
   it { is_expected.to belong_to(:track) }
 
   context 'when user is created' do
@@ -136,6 +137,15 @@ RSpec.describe User do
       it 'returns banned translation key' do
         expect(user.inactive_message).to eq(:banned)
       end
+    end
+  end
+
+  describe '#dismissed_flags' do
+    let!(:non_dismissed_flag) { create(:flag, flagger: user, taken_action: :ban) }
+    let!(:dismissed_flag) { create(:flag, flagger: user, taken_action: :dismiss) }
+
+    it 'returns flags the user has made that have been dismissed' do
+      expect(user.dismissed_flags).to contain_exactly(dismissed_flag)
     end
   end
 end


### PR DESCRIPTION
Because:
* This will allow us easily deduce if a flagger has a pattern of flagging submissions for no reason.

This Commit:
* Adds a number of times the flagger has had a dismissed flag column to the admin flag view.
* Adds the flag association to users.
* Adds a dismissed_flag instance method to the user model.