### PR TITLE
Redirect tracks urls to paths

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -176,3 +176,6 @@ Performance/Squeeze:
 
 Performance/StringInclude:
   Enabled: true
+
+Style/FormatStringToken:
+  Enabled: false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,4 +71,6 @@ Rails.application.routes.draw do
   get '/courses/curriculum' => redirect('/courses')
   get 'curriculum' => redirect('/courses')
   get 'scheduler' => redirect('/courses')
+  get '/tracks', to: redirect('/paths')
+  get '/tracks/:id', to: redirect('/paths/%{id}')
 end


### PR DESCRIPTION
Now that tracks have been renamed to paths this commit updates the routes file to redirect tracks to paths. This is to ensure anybody still trying to reach tracks doesn't find a missing page.