### PR TITLE
Chore: Refactor Lesson Completion Buttons

### DIFF
--- a/app/helpers/course_helper.rb
+++ b/app/helpers/course_helper.rb
@@ -1,8 +1,4 @@
 module CourseHelper
-  def lesson_completed?(user, lesson)
-    'section-lessons__item__icon--completed' if user.completed_lessons.map(&:id).include?(lesson.id)
-  end
-
   def numbered_lesson_title(lesson, lesson_index)
     if lesson.is_project?
       "#{lesson_index + 1}. <strong>#{lesson.title}</strong>".html_safe

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,7 @@ class User < ApplicationRecord
   end
 
   def completed?(lesson)
-    completed_lessons.exists?(lesson.id)
+    completed_lessons.pluck(:id).include?(lesson.id)
   end
 
   def latest_completed_lesson

--- a/app/views/courses/course/_lesson_completion_button.html.erb
+++ b/app/views/courses/course/_lesson_completion_button.html.erb
@@ -1,9 +1,9 @@
-<% if lesson_completed?(current_user, lesson) %>
+<% if current_user.completed?(lesson) %>
   <%= link_to lesson_completions_path(lesson), method: :delete, remote: true do %>
-    <i class="far fa-check-circle section-lessons__item__icon <%= lesson_completed?(current_user, lesson) %>"></i>
+    <i class="far fa-check-circle section-lessons__item__icon section-lessons__item__icon--completed"></i>
   <% end %>
 <% else %>
   <%= link_to lesson_completions_path(lesson), method: :post, remote: true do %>
-    <i class="far fa-check-circle section-lessons__item__icon <%= lesson_completed?(current_user, lesson) %>"></i>
+    <i class="far fa-check-circle section-lessons__item__icon"></i>
   <% end %>
 <% end %>

--- a/app/views/lessons/_lesson_completion_state.html.erb
+++ b/app/views/lessons/_lesson_completion_state.html.erb
@@ -1,4 +1,4 @@
-<% if lesson_completed?(user, lesson) %>
+<% if current_user.completed?(lesson) %>
   <%= link_to lesson_completions_path(lesson), method: :delete, remote: true, class: 'button button--complete lesson-button-group__item lesson-button lesson-button--complete', title: 'Mark lesson incomplete', data: { disable_with: "submitting" } do %>
     <i class="lesson-button__icon far fa-check-circle" aria-hidden="true"></i>
   <% end %>

--- a/spec/helpers/course_helper_spec.rb
+++ b/spec/helpers/course_helper_spec.rb
@@ -1,27 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe CourseHelper do
-  describe '#lesson_completed?' do
-    let(:user) { create(:user) }
-    let(:lesson) { create(:lesson) }
-
-    context 'when the user has completed the lesson' do
-      before do
-        create(:lesson_completion, student: user, lesson: lesson)
-      end
-
-      it 'returns the completed lesson class' do
-        expect(helper.lesson_completed?(user, lesson)).to eql('section-lessons__item__icon--completed')
-      end
-    end
-
-    context 'when user has not completed the lesson' do
-      it 'returns nil' do
-        expect(helper.lesson_completed?(user, lesson)).to eql(nil)
-      end
-    end
-  end
-
   describe '#numbered_lesson_title' do
     context 'when the lesson is not a project' do
       let!(:lesson) { create(:lesson, title: 'Ruby Basics') }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -55,8 +55,6 @@ RSpec.describe User do
     end
 
     context 'when the user has not completed the lesson' do
-      let!(:lesson_completion) { create(:lesson_completion, lesson: lesson) }
-
       it 'returns false' do
         expect(user.completed?(lesson)).to be(false)
       end


### PR DESCRIPTION
Because:
* We had two methods doing the same thing.

This commit:
* Uses the completed?(lesson) method on the user model to choose which button should be displayed.
* Removes the completed_lesson? helper as it was doing the same thing.
* Hard codes the completed lesson icon class in the lesson complete icon on the course page as it will always have this class.