### PR TITLE
Chore: Remove Old Switch Path Prompts

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,7 +5,6 @@ class UsersController < ApplicationController
 
   def show
     @courses = decorated_path_courses
-    @path = @user.path
   end
 
   def update

--- a/app/views/paths/show.html.erb
+++ b/app/views/paths/show.html.erb
@@ -11,24 +11,13 @@
     <%= render 'courses/course_card', course: course %>
   <% end %>
 
-  <% if user_signed_in? %>
-    <%if current_user.path == @path %>
-      <p class="text-center path-description">
-        You are currently enrolled in this path.
-      </p>
-    <% else %>
-      <p class="text-center path-description">
-      <%= link_to 'Select This Path', users_paths_url(path_id: @path.id), remote: true, method: :post, class: 'button button--primary' %>
-      </p>
-    <% end %>
-  <% else %>
-      <p class="text-center path-description">
-        <%= render 'shared/bottom_cta',
-          button: sign_in_or_view_curriculum_button,
-          heading: 'Start learning for free now!',
-          sub_heading: ''
-        %>
-      </p>
+  <% unless user_signed_in? %>
+    <p class="text-center path-description">
+      <%= render 'shared/bottom_cta',
+        button: sign_in_or_view_curriculum_button,
+        heading: 'Start learning for free now!',
+        sub_heading: ''
+      %>
+    </p>
   <% end %>
-  <p class="text-center path-description">You are viewing the <%= @path.title %> path.  To view all available paths <%= link_to 'click here', paths_url %></p>
 </div>

--- a/app/views/users/_skills.html.erb
+++ b/app/views/users/_skills.html.erb
@@ -9,6 +9,4 @@
   <% courses.each do |course| %>
     <%= render 'skill', course: course %>
   <% end %>
-
-  <p class="text-center">You are currently enrolled in the <%= @path.title %> path. To view all available paths <%= link_to 'click here', paths_url %></p>
 </div>


### PR DESCRIPTION
Because:
* We have moved these to the all paths and path pages.

This Commit:
* Removes the prompt at the bottom of path pages.
* Removes the prompt on the dashboard.