### PR TITLE
Feature: Prompt Student to Choose Path at the End of Web Dev 101

### DIFF
--- a/app/controllers/lesson_completions_controller.rb
+++ b/app/controllers/lesson_completions_controller.rb
@@ -1,43 +1,30 @@
 class LessonCompletionsController < ApplicationController
-  before_action :authenticate_request
-  before_action :lookup_lesson
-  before_action :set_user
+  before_action :authenticate_user!
 
   def create
-    LessonCompletion.create(student_id: current_user.id, lesson_id: @lesson.id)
+    current_user.lesson_completions.create(lesson_id: lesson.id)
+
+    if redirect_url.present?
+      redirect_to redirect_url
+    end
   end
 
   def destroy
+    lesson_completion = current_user.lesson_completions.find_by_lesson_id(lesson.id)
+
     lesson_completion.destroy
     render :create
   end
 
   private
 
-  def lesson_completion
-    LessonCompletion.where(
-      student_id: @user.id,
-      lesson_id: @lesson.id
-    ).first
-  end
-
-  def set_user
-    @user = User.includes(:lesson_completions).find(current_user.id)
-  end
-
-  def new_lesson_completion
-    LessonCompletion.new(student_id: current_user.id, lesson_id: @lesson.id)
-  end
-
-  def lookup_lesson
-    @lesson = LessonDecorator.new(lesson)
-  end
-
   def lesson
-    Lesson.friendly.find(params[:lesson_id])
+    @lesson ||= LessonDecorator.new(
+      Lesson.friendly.find(params[:lesson_id])
+    )
   end
 
-  def authenticate_request
-    head :unauthorized unless user_signed_in?
+  def redirect_url
+    params[:redirect_url]
   end
 end

--- a/app/views/lesson_completions/create.js.erb
+++ b/app/views/lesson_completions/create.js.erb
@@ -1,8 +1,8 @@
-$('.banner__badge').html("<%= j render 'shared/course_badge', course: @lesson.course, user: @user, modifier: '' %>");
+$('.banner__badge').html("<%= j render 'shared/course_badge', course: @lesson.course, user: current_user, modifier: '' %>");
 
 if($('.lesson-button-group').length == 0) {
-  $("#section-lessons__<%= @lesson.id %>").html("<%= j render 'courses/course/lesson_completion_button', lesson: @lesson, course: @lesson.course, user: @user %>");
+  $("#section-lessons__<%= @lesson.id %>").html("<%= j render 'courses/course/lesson_completion_button', lesson: @lesson, course: @lesson.course, user: current_user %>");
 } else {
-  $('.lesson-button-group').html("<%= j render 'lessons/lesson_buttons', lesson: @lesson, course: @lesson.course, user: @user  %>");
+  $('.lesson-button-group').html("<%= j render 'lessons/lesson_buttons', lesson: @lesson, course: @lesson.course, user: current_user  %>");
 }
 

--- a/app/views/lessons/_lesson_completion_state.html.erb
+++ b/app/views/lessons/_lesson_completion_state.html.erb
@@ -1,9 +1,13 @@
 <% if current_user.completed?(lesson) %>
-  <%= link_to lesson_completions_path(lesson), method: :delete, remote: true, class: 'button button--complete lesson-button-group__item lesson-button lesson-button--complete', title: 'Mark lesson incomplete', data: { disable_with: "submitting" } do %>
+  <%= link_to lesson_completions_path(lesson), method: :delete, remote: true, class: 'button button--complete lesson-button-group__item lesson-button lesson-button--complete', title: 'Mark lesson incomplete', data: { disable_with: "Submitting..." } do %>
     <i class="lesson-button__icon far fa-check-circle" aria-hidden="true"></i>
   <% end %>
+<% elsif lesson.choose_path_lesson? %>
+  <%= link_to lesson_completions_path(lesson, redirect_url: paths_url), remote: true, method: :post, class: 'button button--primary lesson-button-group__item lesson-button', title: 'Mark lesson complete', data: { disable_with: "Submitting..." } do %>
+    <i class="lesson-button__icon far fa-check-circle" aria-hidden="true"></i>Complete and Choose Path
+  <% end %>
 <% else %>
-  <%= link_to lesson_completions_path(lesson), remote: true, method: :post, class: 'button button--primary lesson-button-group__item lesson-button', title: 'Mark lesson complete', data: { disable_with: "submitting" } do %>
+  <%= link_to lesson_completions_path(lesson), remote: true, method: :post, class: 'button button--primary lesson-button-group__item lesson-button', title: 'Mark lesson complete', data: { disable_with: "Submitting..." } do %>
     <i class="lesson-button__icon far fa-check-circle" aria-hidden="true"></i>Complete
   <% end %>
 <% end %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_13_061108) do
+ActiveRecord::Schema.define(version: 2020_10_18_223629) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -95,6 +95,7 @@ ActiveRecord::Schema.define(version: 2020_10_13_061108) do
     t.string "repo"
     t.boolean "accepts_submission", default: false, null: false
     t.boolean "has_live_preview", default: false, null: false
+    t.boolean "choose_path_lesson", default: false, null: false
     t.index ["position"], name: "index_lessons_on_position"
     t.index ["slug", "section_id"], name: "index_lessons_on_slug_and_section_id", unique: true
   end

--- a/db/seeds/01_web_dev_101_seeds.rb
+++ b/db/seeds/01_web_dev_101_seeds.rb
@@ -498,5 +498,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/web_development_101/tying_it_all_together/conclusion.md',
-  repo: 'curriculum'
+  repo: 'curriculum',
+  choose_path_lesson: true
 )

--- a/spec/controllers/lesson_completions_controller_spec.rb
+++ b/spec/controllers/lesson_completions_controller_spec.rb
@@ -29,8 +29,9 @@ RSpec.describe LessonCompletionsController do
 
   context 'authenticated user' do
     before do
+      request.env['devise.mapping'] = Devise.mappings[:user]
+      sign_in user
       allow(controller).to receive(:current_user).and_return(user)
-      allow(DiscordNotifier).to receive(:notify)
     end
 
     describe 'POST #create' do


### PR DESCRIPTION
Because:
* We currently enroll students on the rails path by default and don't prompt them to consider their path.

This commit:
* Changes the complete button in the last lesson of web dev 101 to "Complete and Choose Path".
* Refactors the lesson completions controller to allow redirects and simplify its implementation.

![Screenshot 2020-10-18 at 23 55 26](https://user-images.githubusercontent.com/7963776/96388202-387b2980-119f-11eb-8fd7-553a09fc287f.png)
