### PR TITLE
Chore: Run db:schema:load in review apps during the release phase

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-release: bin/rails db:migrate
+release: bin/heroku_release
 web: jemalloc.sh bundle exec puma -C config/puma.rb
 worker: bundle exec sidekiq -c 2

--- a/app.json
+++ b/app.json
@@ -1,9 +1,12 @@
 {
   "environments": {
     "review": {
+      "formation": [
+        { "process": "web",    "quantity": 1 }
+      ],
       "addons": ["heroku-postgresql:hobby-dev"],
       "scripts": {
-        "postdeploy": "bundle exec rails db:schema:load db:seed"
+        "postdeploy": "bundle exec rails db:seed"
       }
     }
   }

--- a/bin/heroku_release
+++ b/bin/heroku_release
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Usage: bin/heroku_deploy
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NO_COLOR='\033[0m'
+
+set -euo pipefail
+
+schema_version=$(bin/rails db:version | { grep "^Current version: [0-9]\\+$" || true; } | tr -s ' ' | cut -d ' ' -f3)
+
+if [ -z "$schema_version" ]; then
+  printf "💀${RED}   [Release Phase]: Database schema version could not be determined. Does the database exist?${NO_COLOR}\n"
+  exit 1
+fi
+
+if [ "$schema_version" -eq "0" ]; then
+  printf "\n⏳${YELLOW}   [Release Phase]: Loading the database schema.${NO_COLOR}\n"
+  bin/rails db:schema:load
+else
+  printf "\n⏳${YELLOW}   [Release Phase]: Running database migrations.${NO_COLOR}\n"
+  bin/rails db:migrate
+fi
+
+printf "\n🎉${GREEN}   [Release Phase]: Database is up to date.${NO_COLOR}\n"


### PR DESCRIPTION
Because:
* It was trying to create a new db with db:migrate.

This commit:
* Adds a bash script for choosing to run db:migrate or db:schema during herokus release phase.
* Adds a formation config option to the app.json file used by heroku.