### PR TITLE
Chore: Add Jemloc Buildpack

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,9 +4,17 @@
       "formation": [
         { "process": "web",    "quantity": 1 }
       ],
+      "buildpacks": [
+        {
+          "url": "heroku/ruby"
+        },
+        {
+          "url": "https://github.com/gaffneyc/heroku-buildpack-jemalloc.git"
+        }
+      ],
       "addons": ["heroku-postgresql:hobby-dev"],
       "scripts": {
-        "postdeploy": "bundle exec rails db:seed"
+        "postdeploy": "bundle exec rails db:seed curriculum:update_content"
       }
     }
   }


### PR DESCRIPTION
Because:
* We wrap our web process in this in the procfile, so the app will not run without it.

This commit:
* Adds the jemloc buildpack to app.json.
* Pulls in lesson content after the review app is deployed.