### PR TITLE
Added Margin to Top of First Card on Pages

### DIFF
--- a/app/assets/stylesheets/components/card.scss
+++ b/app/assets/stylesheets/components/card.scss
@@ -7,6 +7,7 @@
   transition: 0.3s;
   border-radius: 10px;
   margin-bottom: 60px;
+  margin-top: 30px;
 
   &--clickable {
     &:hover {


### PR DESCRIPTION
## Description
### Changes:

Added 30px margin to the card.scss file. This adds a margin to the first card on the page so that the text doesn't come right up to it. This is preferred over adding margin-bottom to all of the paragraphs/headings that precede a card and also helps ensure any new content added is formatted correctly.

## Related Issues
#1441 `fix lack of margin on contributing and on my path`