### PR TITLE
Chore: Allow Points Response to be Limited and Offset

### DIFF
--- a/app/controllers/api/points_controller.rb
+++ b/app/controllers/api/points_controller.rb
@@ -2,7 +2,7 @@ class Api::PointsController < ActionController::Base
   before_action :authenticate, except: %i[index show]
 
   def index
-    render json: Point.all.order(points: :desc)
+    render json: Point.all.order(points: :desc).limit(limit).offset(offset)
   end
 
   def show
@@ -23,6 +23,14 @@ class Api::PointsController < ActionController::Base
   end
 
   private
+
+  def offset
+    params[:offset]
+  end
+
+  def limit
+    params[:limit]
+  end
 
   def authenticate
     authenticate_or_request_with_http_token do |token|


### PR DESCRIPTION
Because:
* We should only return what we need.