### PR TITLE
Feature: Display Path Prerequisites on Path Card

### DIFF
--- a/app/assets/stylesheets/components/card.scss
+++ b/app/assets/stylesheets/components/card.scss
@@ -61,6 +61,15 @@
     letter-spacing: 0.2px;
     margin: 0;
   }
+
+  &__prerequisites {
+    padding-bottom: 20px;
+  }
+
+  &__prerequisite-link {
+    color: $primary;
+    position: relative;
+  }
 }
 
 .card-block {

--- a/app/helpers/paths_helper.rb
+++ b/app/helpers/paths_helper.rb
@@ -1,0 +1,11 @@
+module PathsHelper
+  def prerequisites_list_for(path)
+    path.prerequisites.map do |prerequisite|
+      link_to(
+        prerequisite.title,
+        path_url(prerequisite),
+        class: 'card-main__prerequisite-link'
+      )
+    end.join(', ').html_safe
+  end
+end

--- a/app/models/path.rb
+++ b/app/models/path.rb
@@ -6,6 +6,8 @@ class Path < ApplicationRecord
   has_many :users
   has_many :path_courses, -> { order(:position) }, dependent: :destroy
   has_many :courses, through: :path_courses
+  has_many :path_prerequisites, dependent: :destroy
+  has_many :prerequisites, through: :path_prerequisites, source: :prerequisite
 
   validates :title, presence: true
   validates :description, presence: true

--- a/app/models/path_prerequisite.rb
+++ b/app/models/path_prerequisite.rb
@@ -1,0 +1,6 @@
+class PathPrerequisite < ApplicationRecord
+  belongs_to :path
+  belongs_to :prerequisite, class_name: 'Path'
+
+  validates :prerequisite_id, uniqueness: { scope: :path_id }
+end

--- a/app/views/paths/index.html.erb
+++ b/app/views/paths/index.html.erb
@@ -16,6 +16,11 @@
             <% end %>
           </div>
           <div class="card-main__description">
+            <% if path.prerequisites.any? %>
+              <p class="card-main__prerequisites">
+                <strong>Prerequisites: <%= prerequisites_list_for(path) %></strong>
+              </p>
+            <% end %>
             <p><%= path.description%></p>
           </div>
         </div>

--- a/db/migrate/20201027214814_add_path_prerequisite_table.rb
+++ b/db/migrate/20201027214814_add_path_prerequisite_table.rb
@@ -1,0 +1,12 @@
+class AddPathPrerequisiteTable < ActiveRecord::Migration[6.0]
+  def change
+    create_table :path_prerequisites do |t|
+      t.references :path, index: true, foreign_key: true, null: false
+      t.references :prerequisite, index: true, foreign_key: { to_table: :paths }, null: false
+
+      t.timestamps
+    end
+
+    add_index :path_prerequisites, %i[path_id prerequisite_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_26_230831) do
+ActiveRecord::Schema.define(version: 2020_10_27_214814) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -106,6 +106,16 @@ ActiveRecord::Schema.define(version: 2020_10_26_230831) do
     t.integer "position"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "path_prerequisites", force: :cascade do |t|
+    t.bigint "path_id", null: false
+    t.bigint "prerequisite_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["path_id", "prerequisite_id"], name: "index_path_prerequisites_on_path_id_and_prerequisite_id", unique: true
+    t.index ["path_id"], name: "index_path_prerequisites_on_path_id"
+    t.index ["prerequisite_id"], name: "index_path_prerequisites_on_prerequisite_id"
   end
 
   create_table "paths", id: :serial, force: :cascade do |t|
@@ -217,6 +227,8 @@ ActiveRecord::Schema.define(version: 2020_10_26_230831) do
 
   add_foreign_key "flags", "project_submissions"
   add_foreign_key "flags", "users", column: "flagger_id"
+  add_foreign_key "path_prerequisites", "paths"
+  add_foreign_key "path_prerequisites", "paths", column: "prerequisite_id"
   add_foreign_key "project_submissions", "lessons"
   add_foreign_key "project_submissions", "users"
 end

--- a/db/seeds/paths/front_end.rb
+++ b/db/seeds/paths/front_end.rb
@@ -14,6 +14,8 @@ courses_in_path = [
   { course_id: Course.find_by_title('Getting Hired').id, position: position + 1 }
 ]
 
+path.path_prerequisites.create!(prerequisite_id: Path.find_by_title('Foundations').id)
+
 courses_in_path.each do |course_attrs|
   next if path.path_courses.map(&:course_id).include? course_attrs[:course_id]
 

--- a/db/seeds/paths/full_stack_javascript.rb
+++ b/db/seeds/paths/full_stack_javascript.rb
@@ -15,6 +15,8 @@ courses_in_path = [
   { course_id: Course.find_by_title('Getting Hired').id, position: position + 1 }
 ]
 
+path.path_prerequisites.create!(prerequisite_id: Path.find_by_title('Foundations').id)
+
 courses_in_path.each do |course_attrs|
   next if path.path_courses.map(&:course_id).include? course_attrs[:course_id]
 

--- a/db/seeds/paths/full_stack_rails.rb
+++ b/db/seeds/paths/full_stack_rails.rb
@@ -17,6 +17,8 @@ courses_in_path = [
   { course_id: Course.find_by_title('Getting Hired').id, position: position + 1 }
 ]
 
+path.path_prerequisites.create!(prerequisite_id: Path.find_by_title('Foundations').id)
+
 courses_in_path.each do |course_attrs|
   next if path.path_courses.map(&:course_id).include? course_attrs[:course_id]
 

--- a/spec/factories/path_prerequisites.rb
+++ b/spec/factories/path_prerequisites.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :path_prerequisite do
+    association :path, factory: :path
+    association :prerequisite, factory: :path
+  end
+end

--- a/spec/factories/paths.rb
+++ b/spec/factories/paths.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :path do
-    sequence(:title) { |n| "test lesson#{n}" }
+    sequence(:title) { |n| "test path#{n}" }
     sequence(:position) { |n| n }
     description { 'A Path' }
   end

--- a/spec/helpers/paths_helper_spec.rb
+++ b/spec/helpers/paths_helper_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe PathsHelper do
+  # rubocop:disable Layout/LineLength
+  describe '#prerequisites_list_for' do
+    let(:path) { create(:path, title: 'THE CURRENT PATH') }
+
+    context 'when the path only has one pprerequisite' do
+      let(:prerequisite_path) { create(:path, title: 'prerequisite path') }
+      let!(:prerequisite) { create(:path_prerequisite, path: path, prerequisite: prerequisite_path) }
+
+      it 'returns prerequisites list with one item' do
+        expect(helper.prerequisites_list_for(path)).to eql(
+          '<a class="card-main__prerequisite-link" href="http://test.host/paths/prerequisite-path">prerequisite path</a>'
+        )
+      end
+    end
+
+    context 'when path has more than one prerequisite' do
+      let(:prerequisite_path_one) { create(:path, title: 'prerequisite path one') }
+      let(:prerequisite_path_two) { create(:path, title: 'prerequisite path two') }
+      let!(:prerequisite_one) { create(:path_prerequisite, path: path, prerequisite: prerequisite_path_one) }
+      let!(:prerequisite_two) { create(:path_prerequisite, path: path, prerequisite: prerequisite_path_two) }
+
+      it 'returns prerequisites seperated by commas' do
+        expect(helper.prerequisites_list_for(path)).to eql(
+          '<a class="card-main__prerequisite-link" href="http://test.host/paths/prerequisite-path-one">prerequisite path one</a>, ' \
+          '<a class="card-main__prerequisite-link" href="http://test.host/paths/prerequisite-path-two">prerequisite path two</a>'
+        )
+      end
+    end
+  end
+  # rubocop:enable Layout/LineLength
+end

--- a/spec/models/path_prerequisite_spec.rb
+++ b/spec/models/path_prerequisite_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe PathPrerequisite do
+  subject { create(:path_prerequisite) }
+
+  it { is_expected.to belong_to(:path) }
+  it { is_expected.to belong_to(:prerequisite).class_name('Path') }
+
+  it { is_expected.to validate_uniqueness_of(:prerequisite_id).scoped_to(:path_id) }
+end

--- a/spec/models/path_spec.rb
+++ b/spec/models/path_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Path do
   it { is_expected.to have_many(:users) }
   it { is_expected.to have_many(:path_courses).order(:position) }
   it { is_expected.to have_many(:courses).through(:path_courses) }
+  it { is_expected.to have_many(:path_prerequisites).dependent(:destroy) }
+  it { is_expected.to have_many(:prerequisites).through(:path_prerequisites).source(:prerequisite) }
 
   it { is_expected.to validate_presence_of(:title) }
   it { is_expected.to validate_presence_of(:description) }


### PR DESCRIPTION
Because:
* This will inform students that they are expected to complete the foundations path first.

This Commit:
* Adds a path_prerequisites table.
* displays the path prerequisites on path cards as links.

![Screenshot 2020-10-28 at 23 01 55](https://user-images.githubusercontent.com/7963776/97506043-fb1e5500-1971-11eb-8866-ba4641164d05.png)
