### PR TITLE
Adding daily reporting for project submission votes.

### DIFF
--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -1,0 +1,3 @@
+class Vote < ApplicationRecord
+  scope :created_today, -> { where('created_at >= ?', Time.zone.now.beginning_of_day) }
+end

--- a/app/services/notifications/daily_summary.rb
+++ b/app/services/notifications/daily_summary.rb
@@ -2,9 +2,10 @@ module Notifications
   class DailySummary
     def message
       "**TOP Summary For #{Date.current.to_s(:long_ordinal)}**\n" \
-      "#{User.where('created_at >= ?', start_of_day).size} users signed up today\n" \
-      "#{LessonCompletion.created_today.size} lessons completed today\n" \
-      "#{ProjectSubmission.created_today.size} project submissions added today"
+      "#{User.where('created_at >= ?', start_of_day).size} users signed up\n" \
+      "#{LessonCompletion.created_today.size} lessons completed\n" \
+      "#{ProjectSubmission.created_today.size} project submissions added\n" \
+      "#{Vote.created_today.size} projects liked"
     end
 
     def destination

--- a/spec/services/notifications/daily_summary_spec.rb
+++ b/spec/services/notifications/daily_summary_spec.rb
@@ -15,9 +15,10 @@ RSpec.describe Notifications::DailySummary do
     it 'returns the daily summary message' do
       expect(notification.message).to eql(
         "**TOP Summary For April 10th, 2020**\n" \
-        "0 users signed up today\n" \
-        "0 lessons completed today\n" \
-        '0 project submissions added today'
+        "0 users signed up\n" \
+        "0 lessons completed\n" \
+        "0 project submissions added\n" \
+        '0 projects liked'
       )
     end
   end


### PR DESCRIPTION
This code change:

- Adds a Vote model class we can use for things like the created_at scope which
- Was added to the daily report.

Additionally, repetitive "today"'s were removed at @KevinMulhern 's request.