### PR TITLE
Chore: Add a FactoryBot Linter Test

### DIFF
--- a/spec/factories_spec.rb
+++ b/spec/factories_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+describe FactoryBot do
+  it { FactoryBot.lint traits: true }
+end


### PR DESCRIPTION
Because:
* Factories can become invalid when validations and the schema change.