### PR TITLE
Feature: Reorder Submissions When Liked

### DIFF
--- a/app/javascript/components/project-submissions/components/submission.js
+++ b/app/javascript/components/project-submissions/components/submission.js
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useContext } from 'react';
+import React, { useState, useMemo, useContext, forwardRef } from 'react';
 import { object, func, bool } from 'prop-types';
 
 import Modal from './modal';
@@ -10,7 +10,7 @@ import VisibleToggle from './visible-toggle';
 
 const noop = () => { }
 
-const Submission = ({ submission, handleUpdate, onFlag, handleDelete, isDashboardView, handleLikeToggle }) => {
+const Submission = forwardRef(({ submission, handleUpdate, onFlag, handleDelete, isDashboardView, handleLikeToggle }, ref) => {
   const { userId } = useContext(ProjectSubmissionContext);
   const [showEditModal, setShowEditModal] = useState(false);
   const isCurrentUsersSubmission = useMemo(() =>
@@ -20,7 +20,7 @@ const Submission = ({ submission, handleUpdate, onFlag, handleDelete, isDashboar
   const livePreview = submission.live_preview_url.length > 0;
 
   return (
-    <div className="submissions__item">
+    <div className="submissions__item" ref={ref}>
       <div className="submissions__left-container">
         <Like submission={submission} handleLikeToggle={handleLikeToggle} />
         <p className="submissions__submission-title">
@@ -61,7 +61,7 @@ const Submission = ({ submission, handleUpdate, onFlag, handleDelete, isDashboar
       </Modal>
     </div>
   );
-};
+});
 
 Submission.defaultProps = {
   onFlag: noop,

--- a/app/javascript/components/project-submissions/components/submissions-list.js
+++ b/app/javascript/components/project-submissions/components/submissions-list.js
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import { object, func, arrayOf, string, bool } from 'prop-types';
+import FlipMove from 'react-flip-move';
 
 import Submission from './submission';
 import ProjectSubmissionContext from '../ProjectSubmissionContext';
@@ -13,8 +14,8 @@ const SubmissionsList = ({ submissions, handleDelete, onFlag, handleUpdate, isDa
   return (
     <div>
         { hasSubmissions
-          ? <div>
-              {submissions.map(submission => (
+          ? <FlipMove>
+              {submissions.sort((a, b) => b.likes - a.likes).map(submission => (
                 <Submission
                   key={submission.id}
                   submission={submission}
@@ -25,7 +26,7 @@ const SubmissionsList = ({ submissions, handleDelete, onFlag, handleUpdate, isDa
                   handleLikeToggle={handleLikeToggle}
                 />
               ))}
-            </div>
+            </FlipMove>
           : <h2 className='submissions__blank-slate'>No Submissions yet, be the first!</h2>
         }
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
+    "react-flip-move": "^3.0.4",
     "react-hook-form": "^6.11.0",
     "react-scrolllock": "^5.0.1",
     "react_ujs": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6385,6 +6385,11 @@ react-dom@^16.14.0:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
+react-flip-move@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/react-flip-move/-/react-flip-move-3.0.4.tgz#261f66101fbc305f9b7b28959c5cf8236413ca74"
+  integrity sha512-HyUVv9g3t/BS7Yz9HgrtYSWyRNdR2F81nkj+C5iRY675AwlqCLB5JU9mnZWg0cdVz7IM4iquoyZx70vzZv3Z8Q==
+
 react-hook-form@^6.11.0:
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.11.0.tgz#db041861414799e002ea482e54da6f9bc452f1b0"


### PR DESCRIPTION
Because:
* At present the submissions stay in the same position after being liked.

This commit:
* Reorders the submissions based on likes dynamically.
* Adds react-flip-move library to animate the submission items when they reorder.