### PR TITLE
Fixing dupe submission bug and adding likes to current_user's submission.

### DIFF
--- a/app/helpers/lessons_helper.rb
+++ b/app/helpers/lessons_helper.rb
@@ -14,4 +14,10 @@ module LessonsHelper
   def legacy_submissions_url(lesson)
     github_link("curriculum/blob/master/legacy_submissions#{lesson.url}")
   end
+
+  def user_submission(current_user)
+    project_submission = ProjectSubmission.find_by(user_id: current_user&.id)
+
+    ProjectSubmissionSerializer.as_json(project_submission, current_user) if project_submission.present?
+  end
 end

--- a/app/javascript/components/project-submissions/components/like.js
+++ b/app/javascript/components/project-submissions/components/like.js
@@ -11,7 +11,7 @@ const Like = ({ submission, handleLikeToggle }) => {
     <>
       <a className='submissions__like hint--top' aria-label={userId !== null ? (submission.is_liked_by_current_user ? 'Unlike submission' : 'Like submission') : 'Log in to like!'} onClick={(event) => {
         event.preventDefault();
-        handleLikeToggle(submission);
+        handleLikeToggle(submission, isCurrentUsersSubmission);
       }
       }>
         {submission.likes} <i className={submission.is_liked_by_current_user ? 'fa fa-heart liked' : 'fa fa-heart'}></i>

--- a/app/javascript/components/project-submissions/components/like.js
+++ b/app/javascript/components/project-submissions/components/like.js
@@ -9,17 +9,13 @@ const Like = ({ submission, handleLikeToggle }) => {
 
   return (
     <>
-      {!isCurrentUsersSubmission
-        ?
-        <a className='submissions__like hint--top' aria-label={userId !== null ? (submission.is_liked_by_current_user ? 'Unlike submission' : 'Like submission') : 'Log in to like!'} onClick={(event) => {
-          event.preventDefault();
-          handleLikeToggle(submission);
-        }
-        }>
-         {submission.likes} <i className={submission.is_liked_by_current_user ? 'fa fa-heart liked' : 'fa fa-heart'}></i>
-        </a>
-        : ''
+      <a className='submissions__like hint--top' aria-label={userId !== null ? (submission.is_liked_by_current_user ? 'Unlike submission' : 'Like submission') : 'Log in to like!'} onClick={(event) => {
+        event.preventDefault();
+        handleLikeToggle(submission);
       }
+      }>
+        {submission.likes} <i className={submission.is_liked_by_current_user ? 'fa fa-heart liked' : 'fa fa-heart'}></i>
+      </a>
     </>
   );
 };

--- a/app/javascript/components/project-submissions/components/submissions-list.js
+++ b/app/javascript/components/project-submissions/components/submissions-list.js
@@ -7,12 +7,28 @@ import ProjectSubmissionContext from '../ProjectSubmissionContext';
 
 const noop = () => {};
 
-const SubmissionsList = ({ submissions, handleDelete, onFlag, handleUpdate, isDashboardView, handleLikeToggle }) => {
+const SubmissionsList = ({ submissions, handleDelete, onFlag, handleUpdate, isDashboardView, handleLikeToggle, userSubmission }) => {
   const { allSubmissionsPath, legacySubmissionsUrl } = useContext(ProjectSubmissionContext);
   const hasSubmissions = submissions.length > 0;
+  
+  if (userSubmission) {
+    submissions = submissions.filter((submission) => submission.user_id !== userId);
+  }
 
   return (
     <div>
+        { userSubmission
+        ? <Submission
+            key={userSubmission.id}
+            submission={userSubmission}
+            handleUpdate={handleUpdate}
+            onFlag={onFlag}
+            handleDelete={handleDelete}
+            isDashboardView={isDashboardView}
+            handleLikeToggle={handleLikeToggle}
+          />
+        : ''
+        }
         { hasSubmissions
           ? <FlipMove>
               {submissions.sort((a, b) => b.likes - a.likes).map(submission => (
@@ -42,12 +58,14 @@ const SubmissionsList = ({ submissions, handleDelete, onFlag, handleUpdate, isDa
 
 SubmissionsList.defaultProps = {
   allSubmissionsPath: '',
+  userSubmission: null,
   onFlag: noop,
   isDashboardView: false,
 }
 
 SubmissionsList.propTypes = {
   submissions: arrayOf(object).isRequired,
+  userSubmission: object,
   handleDelete: func.isRequired,
   onFlag: func,
   handleUpdate: func.isRequired,

--- a/app/javascript/components/project-submissions/components/submissions-list.js
+++ b/app/javascript/components/project-submissions/components/submissions-list.js
@@ -11,9 +11,9 @@ const SubmissionsList = ({ submissions, handleDelete, onFlag, handleUpdate, isDa
   const { allSubmissionsPath, legacySubmissionsUrl } = useContext(ProjectSubmissionContext);
   const hasSubmissions = submissions.length > 0;
   
-  if (userSubmission) {
-    submissions = submissions.filter((submission) => submission.user_id !== userId);
-  }
+  // if (userSubmission) {
+  //   submissions = submissions.filter((submission) => submission.user_id !== userSubmission.user_id);
+  // }
 
   return (
     <div>

--- a/app/javascript/components/project-submissions/containers/project-submissions-container.js
+++ b/app/javascript/components/project-submissions/containers/project-submissions-container.js
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useContext } from 'react';
+import React, { useState, useContext } from 'react';
 
 import { SubmissionsList, Modal, CreateForm, FlagForm } from '../components';
 import axios from '../../../src/js/axiosWithCsrf';
@@ -10,7 +10,7 @@ const ProjectSubmissions = (props) => {
   const [showFlagModal, setShowFlagModal] = useState(false);
   const [submissions, setSubmissions] = useState(props.submissions);
   const [flaggedSubmission, setFlaggedSubmission] = useState({});
-
+  const [userSubmission, setUserSubmission] = useState(props.userSubmission);
 
   const toggleShowFlagModal = () => setShowFlagModal(prevShowFlagModal => !prevShowFlagModal);
 
@@ -35,7 +35,7 @@ const ProjectSubmissions = (props) => {
       }
     );
     if (response.status === 200) {
-      setSubmissions(prevSubmissions => [response.data, ...prevSubmissions]);
+      setUserSubmission(prevSubmission => response.data);
     }
   };
 
@@ -56,9 +56,7 @@ const ProjectSubmissions = (props) => {
       }
     );
     if (response.status === 200) {
-      setSubmissions(prevSubmissions =>
-        Object.assign([], prevSubmissions, {[0]: response.data})
-      );
+      setUserSubmission(prevSubmission => response.data);
     }
   };
 
@@ -67,9 +65,7 @@ const ProjectSubmissions = (props) => {
 
     const response = await axios.delete(`/project_submissions/${id}`, {});
     if (response.status === 200) {
-      setSubmissions(prevSubmissions =>
-        prevSubmissions.filter((submission) => submission.id !== id)
-      );
+      setUserSubmission(prevSubmissions => null);
     }
   };
 
@@ -85,7 +81,7 @@ const ProjectSubmissions = (props) => {
     }
   };
 
-  const toggleLikeSubmission = async (submission) => {
+  const toggleLikeSubmission = async (submission, isUserSubmission = false) => {
     const response = await axios.post(
       `/project_submissions/${submission.id}/likes`,
       {
@@ -97,23 +93,23 @@ const ProjectSubmissions = (props) => {
     if (response.status === 200) {
       const updatedSubmission = response.data;
 
-      setSubmissions(prevSubmissions => {
-        const newSubmissions = prevSubmissions.map((submission) => {
-          if (updatedSubmission.id === submission.id) {
-            return updatedSubmission;
-          }
+      if (isUserSubmission) {
+        setUserSubmission(prevSubmission => updatedSubmission);
+      } else {
+        setSubmissions(prevSubmissions => {
+          const newSubmissions = prevSubmissions.map((submission) => {
+            if (updatedSubmission.id === submission.id) {
+              return updatedSubmission;
+            }
 
-          return submission;
-        })
+            return submission;
+          })
 
-        return newSubmissions;
-      });
+          return newSubmissions;
+        });
+      }
     }
   };
-
-  const userSubmission = useMemo(() => {
-    return submissions.find(submission => submission.user_id === userId);
-  }, [userId, submissions.length]);
 
   const showAddSubmissionButton = () => !userSubmission
 

--- a/app/javascript/components/project-submissions/containers/project-submissions-container.js
+++ b/app/javascript/components/project-submissions/containers/project-submissions-container.js
@@ -157,6 +157,7 @@ const ProjectSubmissions = (props) => {
       </p>
       <SubmissionsList
         submissions={submissions}
+        userSubmission={userSubmission}
         handleUpdate={handleUpdate}
         onFlag={(submission) => { setFlaggedSubmission(submission); toggleShowFlagModal() }}
         handleDelete={handleDelete}

--- a/app/javascript/components/project-submissions/index.jsx
+++ b/app/javascript/components/project-submissions/index.jsx
@@ -3,9 +3,9 @@ import { number, array, object, string } from 'prop-types';
 import ProjectSubmissionsContainer from './containers/project-submissions-container';
 import ProjectSubmissionContext from "./ProjectSubmissionContext";
 
-const ProjectSubmissions = ({ submissions, course, lesson, userId, allSubmissionsPath, legacySubmissionsUrl }) => (
+const ProjectSubmissions = ({ submissions, course, lesson, userId, allSubmissionsPath, legacySubmissionsUrl, userSubmission }) => (
   <ProjectSubmissionContext.Provider value={{ userId, lesson, course, allSubmissionsPath, legacySubmissionsUrl }}>
-    <ProjectSubmissionsContainer submissions={submissions} />
+    <ProjectSubmissionsContainer submissions={submissions} userSubmission={userSubmission} />
   </ProjectSubmissionContext.Provider>
 );
 
@@ -21,6 +21,7 @@ ProjectSubmissions.propTypes = {
   course: object.isRequired,
   allSubmissionsPath: string,
   legacySubmissionsUrl: string,
+  userSubmission: object
 };
 
 export default ProjectSubmissions;

--- a/app/queries/lesson_project_submissions_query.rb
+++ b/app/queries/lesson_project_submissions_query.rb
@@ -5,14 +5,10 @@ class LessonProjectSubmissionsQuery
   end
 
   def with_current_user_submission_first(user)
-    lesson_project_submissions
+    lesson.project_submissions.where.not(user_id: user&.id).viewable.order(cached_votes_total: :desc, created_at: :desc).limit(limit)
   end
 
   private
 
   attr_reader :lesson, :limit
-
-  def lesson_project_submissions
-    lesson.project_submissions.viewable.order(cached_votes_total: :desc, created_at: :desc).limit(limit)
-  end
 end

--- a/app/queries/lesson_project_submissions_query.rb
+++ b/app/queries/lesson_project_submissions_query.rb
@@ -5,7 +5,11 @@ class LessonProjectSubmissionsQuery
   end
 
   def with_current_user_submission_first(user)
-    lesson.project_submissions.where.not(user_id: user&.id).viewable.order(cached_votes_total: :desc, created_at: :desc).limit(limit)
+    lesson.project_submissions
+          .where
+          .not(user_id: user&.id)
+          .viewable.order(cached_votes_total: :desc, created_at: :desc)
+          .limit(limit)
   end
 
   private

--- a/app/queries/lesson_project_submissions_query.rb
+++ b/app/queries/lesson_project_submissions_query.rb
@@ -5,9 +5,7 @@ class LessonProjectSubmissionsQuery
   end
 
   def with_current_user_submission_first(user)
-    return lesson_project_submissions if user.nil?
-
-    (user.project_submissions.where(lesson_id: lesson.id) + lesson_project_submissions).uniq
+    lesson_project_submissions
   end
 
   private

--- a/app/views/lessons/project_submissions/index.html.erb
+++ b/app/views/lessons/project_submissions/index.html.erb
@@ -9,7 +9,8 @@
             userId: current_user&.id,
             course: @lesson.course.as_json,
             lesson: @lesson.as_json,
-            submissions: @project_submissions.map { |submission| ProjectSubmissionSerializer.as_json(submission, current_user) }
+            submissions: @project_submissions.map { |submission| ProjectSubmissionSerializer.as_json(submission, current_user) },
+            userSubmission: user_submission(current_user)
           }
         ) %>
       

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -34,7 +34,8 @@
             lesson: @lesson.as_json,
             submissions: @project_submissions.map { |submission| ProjectSubmissionSerializer.as_json(submission, current_user) },
             allSubmissionsPath: lesson_project_submissions_path(@lesson),
-            legacySubmissionsUrl: legacy_submissions_url(@lesson)
+            legacySubmissionsUrl: legacy_submissions_url(@lesson),
+            userSubmission: user_submission(current_user)
           }
         ) %>
       <% end %>

--- a/spec/queries/lesson_project_submissions_query_spec.rb
+++ b/spec/queries/lesson_project_submissions_query_spec.rb
@@ -20,22 +20,5 @@ RSpec.describe LessonProjectSubmissionsQuery do
         )
       end
     end
-
-    context 'when the current user is not nil' do
-      let(:user) { create(:user) }
-      let!(:users_submission) { create(:project_submission, lesson: lesson, user: user) }
-      let!(:project_submission_one) { create(:project_submission, lesson: lesson, created_at: 3.hours.ago) }
-      let!(:project_submission_two) { create(:project_submission, lesson: lesson, created_at: 1.day.ago) }
-
-      it 'returns the lesson project submissions with the users submission first' do
-        expect(query.with_current_user_submission_first(user)).to eq(
-          [
-            users_submission,
-            project_submission_one,
-            project_submission_two
-          ]
-        )
-      end
-    end
   end
 end


### PR DESCRIPTION
This code: 

- Adds liking functionality to the current user's submission, allowing them to like their own project submission.
- Removes prepending the list of submissions with the user's submission.
- Renders the user's submission separate from the rest so that user submission renders at the top and isn't duped when visibility is changed.