### PR TITLE
Fix: User Submission Not Scoped to Lesson

### DIFF
--- a/app/helpers/lessons_helper.rb
+++ b/app/helpers/lessons_helper.rb
@@ -15,9 +15,10 @@ module LessonsHelper
     github_link("curriculum/blob/master/legacy_submissions#{lesson.url}")
   end
 
-  def user_submission(current_user)
-    project_submission = ProjectSubmission.find_by(user_id: current_user&.id)
+  def user_submission(current_user, lesson)
+    return if current_user.blank?
 
+    project_submission = current_user.project_submissions.find_by(lesson_id: lesson.id)
     ProjectSubmissionSerializer.as_json(project_submission, current_user) if project_submission.present?
   end
 end

--- a/app/views/lessons/project_submissions/index.html.erb
+++ b/app/views/lessons/project_submissions/index.html.erb
@@ -10,10 +10,10 @@
             course: @lesson.course.as_json,
             lesson: @lesson.as_json,
             submissions: @project_submissions.map { |submission| ProjectSubmissionSerializer.as_json(submission, current_user) },
-            userSubmission: user_submission(current_user)
+            userSubmission: user_submission(current_user, @lesson)
           }
         ) %>
-      
+
     <%= paginate @project_submissions %>
     </div>
   </div>

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -35,7 +35,7 @@
             submissions: @project_submissions.map { |submission| ProjectSubmissionSerializer.as_json(submission, current_user) },
             allSubmissionsPath: lesson_project_submissions_path(@lesson),
             legacySubmissionsUrl: legacy_submissions_url(@lesson),
-            userSubmission: user_submission(current_user)
+            userSubmission: user_submission(current_user, @lesson)
           }
         ) %>
       <% end %>

--- a/spec/helpers/lessons_helper_spec.rb
+++ b/spec/helpers/lessons_helper_spec.rb
@@ -45,4 +45,36 @@ RSpec.describe LessonsHelper do
       )
     end
   end
+
+  describe '#user_submission' do
+    let(:current_user) { create(:user) }
+    let(:lesson) { create(:lesson) }
+
+    context 'when the user has a project submission for the lesson' do
+      let!(:project_submission) { create(:project_submission, user: current_user, lesson: lesson) }
+
+      before do
+        allow(ProjectSubmissionSerializer).to receive(:as_json)
+      end
+
+      it "returns the users submission in json format" do
+        helper.user_submission(current_user, lesson)
+        expect(ProjectSubmissionSerializer).to have_received(:as_json).with(project_submission, current_user)
+      end
+    end
+
+    context "when the user is not logged in" do
+      let(:current_user) { nil }
+
+      it "returns nil" do
+        expect(helper.user_submission(current_user, lesson)).to be_nil
+      end
+    end
+
+    context 'when the user does not have a project submission for the lesson' do
+      it 'returns nil' do
+        expect(helper.user_submission(current_user, lesson)).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
Because:
* It was finding the first submission associated to the user and displaying that submission in all submission lists.

This commit:
* Scopes the submission to the user and lesson.