### PR TITLE
Adding conclusion lesson to NodeJS seeds.

### DIFF
--- a/db/seeds/08_node_js_course_seeds.rb
+++ b/db/seeds/08_node_js_course_seeds.rb
@@ -359,3 +359,15 @@ create_or_update_lesson(
   accepts_submission: true,
   has_live_preview: true
 )
+
+lesson_position += 1
+create_or_update_lesson(
+  title: 'Conclusion',
+  title_url: 'Conclusion'.parameterize,
+  description: 'Wow you\'ve gotten to the last lesson!',
+  position: lesson_position,
+  section_id: section.id,
+  is_project: false,
+  url: '/nodeJS/conclusion.md',
+  repo: 'curriculum'
+)


### PR DESCRIPTION
This code:

- Adds the NodeJS conclusion lesson to the seeds file. The lesson had been added to the curriculum repo but not to the site.

Resolves issue #1516 