### PR TITLE
Fixing user dashboard modal and submission list bugs.

### DIFF
--- a/app/javascript/components/project-submissions/components/submissions-list.js
+++ b/app/javascript/components/project-submissions/components/submissions-list.js
@@ -11,88 +11,45 @@ const SubmissionsList = ({ submissions, handleDelete, onFlag, handleUpdate, isDa
   const { allSubmissionsPath, legacySubmissionsUrl } = useContext(ProjectSubmissionContext);
   const hasSubmissions = submissions.length > 0;
 
-  console.log(isDashboardView);
+  return (
+    <div>
+      { userSubmission
+        ? <Submission
+          key={userSubmission.id}
+          submission={userSubmission}
+          handleUpdate={handleUpdate}
+          onFlag={onFlag}
+          handleDelete={handleDelete}
+          isDashboardView={isDashboardView}
+          handleLikeToggle={handleLikeToggle}
+        />
+        : ''
+      }
+      { hasSubmissions
+        ? <FlipMove>
+          {submissions.sort((a, b) => b.likes - a.likes).map(submission => (
+            <Submission
+              key={submission.id}
+              submission={submission}
+              handleUpdate={handleUpdate}
+              onFlag={onFlag}
+              handleDelete={handleDelete}
+              isDashboardView={isDashboardView}
+              handleLikeToggle={handleLikeToggle}
+            />
+          ))}
+        </FlipMove>
+        : <h2 className='submissions__blank-slate'>No Submissions yet, be the first!</h2>
+      }
 
-  if (isDashboardView) {
-    return (
-      <div>
-        { userSubmission
-          ? <Submission
-            key={userSubmission.id}
-            submission={userSubmission}
-            handleUpdate={handleUpdate}
-            onFlag={onFlag}
-            handleDelete={handleDelete}
-            isDashboardView={isDashboardView}
-            handleLikeToggle={handleLikeToggle}
-          />
-          : ''
-        }
-        { hasSubmissions ?
-          <> { submissions.map(submission => (
-              <Submission
-                key={submission.id}
-                submission={submission}
-                handleUpdate={handleUpdate}
-                onFlag={onFlag}
-                handleDelete={handleDelete}
-                isDashboardView={isDashboardView}
-                handleLikeToggle={handleLikeToggle}
-              />
-            ))
-          } </>
-          : <h2 className='submissions__blank-slate'>No Submissions yet, be the first!</h2>
-        }
-
-        { allSubmissionsPath &&
-          <p className='submissions__view-more'>
-            <span>Showing {submissions.length} most recent submissions - </span>
-            <a href={allSubmissionsPath}> View full list of solutions</a> or <a href={legacySubmissionsUrl} target='_blank'>View old submissions</a>
-          </p>
-        }
-      </div>
-    )
-  } else {
-    return (
-      <div>
-        { userSubmission
-          ? <Submission
-            key={userSubmission.id}
-            submission={userSubmission}
-            handleUpdate={handleUpdate}
-            onFlag={onFlag}
-            handleDelete={handleDelete}
-            isDashboardView={isDashboardView}
-            handleLikeToggle={handleLikeToggle}
-          />
-          : ''
-        }
-        { hasSubmissions
-          ? <FlipMove>
-            {submissions.sort((a, b) => b.likes - a.likes).map(submission => (
-              <Submission
-                key={submission.id}
-                submission={submission}
-                handleUpdate={handleUpdate}
-                onFlag={onFlag}
-                handleDelete={handleDelete}
-                isDashboardView={isDashboardView}
-                handleLikeToggle={handleLikeToggle}
-              />
-            ))}
-          </FlipMove>
-          : <h2 className='submissions__blank-slate'>No Submissions yet, be the first!</h2>
-        }
-
-        { allSubmissionsPath &&
-          <p className='submissions__view-more'>
-            <span>Showing {submissions.length} most recent submissions - </span>
-            <a href={allSubmissionsPath}> View full list of solutions</a> or <a href={legacySubmissionsUrl} target='_blank'>View old submissions</a>
-          </p>
-        }
-      </div>
-    )
-  }
+      { allSubmissionsPath &&
+        <p className='submissions__view-more'>
+          <span>Showing {submissions.length} most recent submissions - </span>
+          <a href={allSubmissionsPath}> View full list of solutions</a> or <a href={legacySubmissionsUrl} target='_blank'>View old submissions</a>
+        </p>
+      }
+    </div>
+  )
 };
 
 SubmissionsList.defaultProps = {

--- a/app/javascript/components/project-submissions/components/submissions-list.js
+++ b/app/javascript/components/project-submissions/components/submissions-list.js
@@ -5,20 +5,19 @@ import FlipMove from 'react-flip-move';
 import Submission from './submission';
 import ProjectSubmissionContext from '../ProjectSubmissionContext';
 
-const noop = () => {};
+const noop = () => { };
 
 const SubmissionsList = ({ submissions, handleDelete, onFlag, handleUpdate, isDashboardView, handleLikeToggle, userSubmission }) => {
   const { allSubmissionsPath, legacySubmissionsUrl } = useContext(ProjectSubmissionContext);
   const hasSubmissions = submissions.length > 0;
-  
-  // if (userSubmission) {
-  //   submissions = submissions.filter((submission) => submission.user_id !== userSubmission.user_id);
-  // }
 
-  return (
-    <div>
+  console.log(isDashboardView);
+
+  if (isDashboardView) {
+    return (
+      <div>
         { userSubmission
-        ? <Submission
+          ? <Submission
             key={userSubmission.id}
             submission={userSubmission}
             handleUpdate={handleUpdate}
@@ -27,33 +26,73 @@ const SubmissionsList = ({ submissions, handleDelete, onFlag, handleUpdate, isDa
             isDashboardView={isDashboardView}
             handleLikeToggle={handleLikeToggle}
           />
-        : ''
+          : ''
         }
-        { hasSubmissions
-          ? <FlipMove>
-              {submissions.sort((a, b) => b.likes - a.likes).map(submission => (
-                <Submission
-                  key={submission.id}
-                  submission={submission}
-                  handleUpdate={handleUpdate}
-                  onFlag={onFlag}
-                  handleDelete={handleDelete}
-                  isDashboardView={isDashboardView}
-                  handleLikeToggle={handleLikeToggle}
-                />
-              ))}
-            </FlipMove>
+        { hasSubmissions ?
+          <> { submissions.map(submission => (
+              <Submission
+                key={submission.id}
+                submission={submission}
+                handleUpdate={handleUpdate}
+                onFlag={onFlag}
+                handleDelete={handleDelete}
+                isDashboardView={isDashboardView}
+                handleLikeToggle={handleLikeToggle}
+              />
+            ))
+          } </>
           : <h2 className='submissions__blank-slate'>No Submissions yet, be the first!</h2>
         }
 
-      { allSubmissionsPath &&
-        <p className='submissions__view-more'>
-          <span>Showing {submissions.length} most recent submissions - </span>
-          <a href={allSubmissionsPath}> View full list of solutions</a> or <a href={legacySubmissionsUrl} target='_blank'>View old submissions</a>
-        </p>
-      }
-    </div>
-  )
+        { allSubmissionsPath &&
+          <p className='submissions__view-more'>
+            <span>Showing {submissions.length} most recent submissions - </span>
+            <a href={allSubmissionsPath}> View full list of solutions</a> or <a href={legacySubmissionsUrl} target='_blank'>View old submissions</a>
+          </p>
+        }
+      </div>
+    )
+  } else {
+    return (
+      <div>
+        { userSubmission
+          ? <Submission
+            key={userSubmission.id}
+            submission={userSubmission}
+            handleUpdate={handleUpdate}
+            onFlag={onFlag}
+            handleDelete={handleDelete}
+            isDashboardView={isDashboardView}
+            handleLikeToggle={handleLikeToggle}
+          />
+          : ''
+        }
+        { hasSubmissions
+          ? <FlipMove>
+            {submissions.sort((a, b) => b.likes - a.likes).map(submission => (
+              <Submission
+                key={submission.id}
+                submission={submission}
+                handleUpdate={handleUpdate}
+                onFlag={onFlag}
+                handleDelete={handleDelete}
+                isDashboardView={isDashboardView}
+                handleLikeToggle={handleLikeToggle}
+              />
+            ))}
+          </FlipMove>
+          : <h2 className='submissions__blank-slate'>No Submissions yet, be the first!</h2>
+        }
+
+        { allSubmissionsPath &&
+          <p className='submissions__view-more'>
+            <span>Showing {submissions.length} most recent submissions - </span>
+            <a href={allSubmissionsPath}> View full list of solutions</a> or <a href={legacySubmissionsUrl} target='_blank'>View old submissions</a>
+          </p>
+        }
+      </div>
+    )
+  }
 };
 
 SubmissionsList.defaultProps = {

--- a/app/javascript/components/project-submissions/containers/user-project-submissions-container.js
+++ b/app/javascript/components/project-submissions/containers/user-project-submissions-container.js
@@ -23,9 +23,16 @@ const ProjectSubmissions = (props) => {
       }
     );
     if (response.status === 200) {
-      setSubmissions(prevSubmissions =>
-        Object.assign([], prevSubmissions, {[0]: response.data})
-      );
+      const updatedSubmission = response.data;
+
+      setSubmissions(prevSubmissions => {
+        return prevSubmissions.map(previousSubmission => {
+          if (previousSubmission.id === updatedSubmission.id) return updatedSubmission;          
+
+          return previousSubmission;
+        });
+        //Object.assign([], prevSubmissions, {[0]: response.data})
+      });
     }
   };
 
@@ -40,12 +47,40 @@ const ProjectSubmissions = (props) => {
     }
   };
 
+  const toggleLikeSubmission = async (submission, isUserSubmission = false) => {
+    const response = await axios.post(
+      `/project_submissions/${submission.id}/likes`,
+      {
+        submission_id: submission.id,
+        is_liked_by_current_user: submission.is_liked_by_current_user
+      }
+    );
+
+    if (response.status === 200) {
+      const updatedSubmission = response.data;
+
+      setSubmissions(prevSubmissions => {
+        const newSubmissions = prevSubmissions.map((submission) => {
+          if (updatedSubmission.id === submission.id) {
+            return updatedSubmission;
+          }
+
+          return submission;
+        })
+
+        return newSubmissions;
+      });
+
+    }
+  };
+
   return (
     <div className="submissions">
       <SubmissionsList
         submissions={submissions}
         handleUpdate={handleUpdate}
         handleDelete={handleDelete}
+        handleLikeToggle={toggleLikeSubmission}
         isDashboardView
       />
     </div>

--- a/app/javascript/components/project-submissions/containers/user-project-submissions-container.js
+++ b/app/javascript/components/project-submissions/containers/user-project-submissions-container.js
@@ -31,7 +31,6 @@ const ProjectSubmissions = (props) => {
 
           return previousSubmission;
         });
-        //Object.assign([], prevSubmissions, {[0]: response.data})
       });
     }
   };


### PR DESCRIPTION
This code:

- Fixes the bug where the modal would not close. The JS would bomb when the user container wasn't passing down a method for toggling likes.

- Tackles a bug where the dashboard submission list would start duplicating submissions client-side whenever Update's occurred. This is done by rendering SubmissionList differently if on the user dashboard and being more meticulous with updating submissions in the update method.