### PR TITLE
Feature: Lesson Preview

### DIFF
--- a/app/assets/stylesheets/components/lesson-preview.scss
+++ b/app/assets/stylesheets/components/lesson-preview.scss
@@ -1,0 +1,8 @@
+.lesson-preview {
+
+  &__input {
+    width: 100%;
+    height: 600px;
+    padding: 1rem;
+  }
+}

--- a/app/controllers/lessons/previews_controller.rb
+++ b/app/controllers/lessons/previews_controller.rb
@@ -1,0 +1,19 @@
+module Lessons
+  class PreviewsController < ApplicationController
+    def show; end
+
+    def create
+      if content.present?
+        render json: { content: MarkdownConverter.new(params[:content]).as_html }
+      else
+        render json: { content: 'Nothing to preview' }
+      end
+    end
+
+    private
+
+    def content
+      params[:content]
+    end
+  end
+end

--- a/app/javascript/components/lesson-preview/components/lesson-content-input.jsx
+++ b/app/javascript/components/lesson-preview/components/lesson-content-input.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+const LessonContentInput = ({onChange, content}) => {
+  const handleOnChange = (event) => {
+    onChange(event.target.value)
+  }
+
+  return (
+    <textarea
+      className="lesson-preview__input form__element"
+      placeholder="Lesson content..."
+      onChange={handleOnChange}
+      value={content}
+    >
+
+    </textarea>
+  )
+
+};
+
+export default LessonContentInput;

--- a/app/javascript/components/lesson-preview/components/lesson-content-preview.jsx
+++ b/app/javascript/components/lesson-preview/components/lesson-content-preview.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const LessonContentInput = ({content}) => (
+  <div className="lesson-content"><div dangerouslySetInnerHTML={{ __html: content }} /></div>
+);
+
+export default LessonContentInput;

--- a/app/javascript/components/lesson-preview/components/lesson-preview.jsx
+++ b/app/javascript/components/lesson-preview/components/lesson-preview.jsx
@@ -1,0 +1,44 @@
+import React, { useState, useEffect } from 'react';
+import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
+import Prism from 'prismjs';
+
+import LessonContentInput from './lesson-content-input';
+import LessonContentPreview from './lesson-content-preview';
+import axios from '../../../src/js/axiosWithCsrf';
+
+import 'react-tabs/style/react-tabs.css';
+
+const LessonPreview = () => {
+  const [content, setContent] = useState('')
+  const [convertedContent, setConvertedContent] = useState('');
+
+  const fetchLessonPreview = async () => {
+    const response = await axios.post('/lessons/preview', { content });
+
+    if (response.status === 200) {
+      setConvertedContent(response.data.content);
+    }
+  }
+
+  useEffect(() => {
+    Prism.highlightAll();
+  },[convertedContent]);
+
+  return (
+    <Tabs>
+      <TabList>
+        <Tab>Write</Tab>
+        <Tab onClick={fetchLessonPreview}>Preview</Tab>
+      </TabList>
+
+    <TabPanel>
+      <LessonContentInput onChange={setContent} content={content}/>
+    </TabPanel>
+    <TabPanel>
+      <LessonContentPreview content={convertedContent} />
+    </TabPanel>
+  </Tabs>
+  );
+};
+
+export default LessonPreview;

--- a/app/javascript/components/lesson-preview/index.jsx
+++ b/app/javascript/components/lesson-preview/index.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import LessonPreviewContainer from './components/lesson-preview';
+
+const LessonPreview = () => (
+  <LessonPreviewContainer />
+);
+
+LessonPreview.propTypes = {
+
+};
+
+export default LessonPreview;

--- a/app/views/lessons/previews/show.html.erb
+++ b/app/views/lessons/previews/show.html.erb
@@ -1,0 +1,14 @@
+<div class="container lesson">
+  <div class="row">
+
+    <div class="col-lg-3">
+      <div class="d-none d-lg-block d-xl-block lesson-navigation"></div>
+    </div>
+
+    <div class="col-lg-9">
+      <div>
+        <%= react_component("lesson-preview/index", {}) %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,7 @@ Rails.application.routes.draw do
   end
 
   namespace :lessons do
+    resource :preview, only: %i[show create]
     resource :style_tests, only: %i[new create show]
   end
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-flip-move": "^3.0.4",
     "react-hook-form": "^6.11.5",
     "react-scrolllock": "^5.0.1",
+    "react-tabs": "^3.1.1",
     "react_ujs": "^2.6.1",
     "regenerator-runtime": "^0.13.7",
     "stickyfilljs": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2136,6 +2136,11 @@ clone-deep@^4.0.1:
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
 
+clsx@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
+  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
+
 coa@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/coa/-/coa-2.0.2.tgz#43f6c21151b4ef2bf57187db0d73de229e3e7ec3"
@@ -6208,7 +6213,7 @@ promise-inflight@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
-prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -6396,6 +6401,14 @@ react-scrolllock@^5.0.1:
   integrity sha512-poeEsjnZAlpA6fJlaNo4rZtcip2j6l5mUGU/SJe1FFlicEudS943++u7ZSdA7lk10hoyYK3grOD02/qqt5Lxhw==
   dependencies:
     exenv "^1.2.2"
+
+react-tabs@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/react-tabs/-/react-tabs-3.1.1.tgz#b363a239f76046bb2158875a1e5921b11064052f"
+  integrity sha512-HpySC29NN1BkzBAnOC+ajfzPbTaVZcSWzMSjk56uAhPC/rBGtli8lTysR4CfPAyEE/hfweIzagOIoJ7nu80yng==
+  dependencies:
+    clsx "^1.1.0"
+    prop-types "^15.5.0"
 
 react@^16.14.0:
   version "16.14.0"


### PR DESCRIPTION
Because:
* We need an easy way to preview lesson markdown with the site styles applied.

This commit:
* Adds a lesson preview page which renders a react component that allows users to enter lesson content and preview it in a tab. Like Github comments.