### PR TITLE
Fix: Add slugignore file to filter out any test files for production

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,2 +1,2 @@
-# Ignore any test files in app/javascript
-/app/javascript/components/**/*.test.js
+# Ignore any javascript test files outside of spec/
+*.test.js

--- a/.slugignore
+++ b/.slugignore
@@ -1,0 +1,2 @@
+# Ignore any test files in app/javascript
+/app/javascript/components/**/*.test.js


### PR DESCRIPTION
Because heroku filters out devDependency files in production

This commit ensures any .test.js file is ignored by heroku as the
imported modules aren't available in production