### PR TITLE
BLOCKED: Fix formatting issue with long username

### DIFF
--- a/app/assets/stylesheets/components/project_submissions/submissions.scss
+++ b/app/assets/stylesheets/components/project_submissions/submissions.scss
@@ -29,6 +29,7 @@
   }
 
   &__item {
+    white-space: nowrap;
     border-top: solid 1px $very-pale-grey;
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
When a username is longer than 18 characters and the width of the broswer is between 770px and 1000px, the formatting for the submission items now does not breaks.