### PR TITLE
add media-query for all-paths page

### DIFF
--- a/app/assets/stylesheets/components/paths.scss
+++ b/app/assets/stylesheets/components/paths.scss
@@ -17,3 +17,9 @@
     letter-spacing: 0.2px;
   }
 }
+
+@media (max-width: 767px) {
+  .paths .paths-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
quickfix to prevent gnarly overflows on low-res screens