### PR TITLE
Fix: Not ignoring React Tests when Building

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -1,2 +1,3 @@
 # Ignore any javascript test files outside of spec/
 *.test.js
+*.test.jsx


### PR DESCRIPTION
Because:
* We changed the react test files to `.jsx` files.

This commit:
* Ignores any js tests that have the jsx extention when deploying to heroku.