### PR TITLE
Upgrade Skylight gem to 5.0beta

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'webpacker'
 
 group :production do
   gem 'rails_12factor', '~> 0.0.3'
-  gem 'skylight'
+  gem 'skylight', '~> 5.0.0.beta4'
 end
 
 group :development, :test, :docker do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -431,10 +431,8 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.2)
-    skylight (4.3.1)
-      skylight-core (= 4.3.1)
-    skylight-core (4.3.1)
-      activesupport (>= 4.2.0)
+    skylight (5.0.0.beta4)
+      activesupport (>= 5.2.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -535,7 +533,7 @@ DEPENDENCIES
   shoulda-matchers
   sidekiq
   simplecov
-  skylight
+  skylight (~> 5.0.0.beta4)
   sprockets (~> 3.7.2)
   timecop
   turbolinks


### PR DESCRIPTION
Thank you so much for participating in the [Skylight for Open Source](https://www.skylight.io/oss) program. We'd like to invite The Odin Project to participate in the public alpha for Source Locations for Skylight!

With this new feature, Skylight can help you pinpoint the locations in your code that correspond to events in the Skylight Event Sequence. This feature will allow your contributors to more easily find out exactly where an expensive operation originated without having to scour your code.

![https://d2ryfneqiwuan6.cloudfront.net/assets/skylight/docs/features/source-locations-popover-1181b5debba553a2b06bd914405997dce0334388b69fe3877c30acc21393ca25.png](https://d2ryfneqiwuan6.cloudfront.net/assets/skylight/docs/features/source-locations-popover-1181b5debba553a2b06bd914405997dce0334388b69fe3877c30acc21393ca25.png)

When you merge this PR, we will enable the feature flag for you on Skylight's servers. Then, once you deploy, you should begin seeing source locations data shortly after.

You can find documentation about the new feature at [https://www.skylight.io/support/source-locations](https://www.skylight.io/support/source-locations), and as always, if you have any questions or feedback, please get in touch with us either by responding here, emailing [support@skylight.io](mailto:support@skylight.io), or via the in-app communicator at the lower-right of your Skylight dashboard.