### PR TITLE
fix: project submissions list descriptor

### DIFF
--- a/app/javascript/components/project-submissions/components/submissions-list.jsx
+++ b/app/javascript/components/project-submissions/components/submissions-list.jsx
@@ -56,21 +56,21 @@ const SubmissionsList = ({
 
       { allSubmissionsPath
         && (
-        <p className="submissions__view-more">
-          <span>
-            Showing
+          <p className="submissions__view-more">
+            <span>
+              Showing
+              {' '}
+              {submissions.length}
+              {' '}
+              most liked submissions -
+              {' '}
+            </span>
+            <a href={allSubmissionsPath}> View full list of solutions</a>
             {' '}
-            {submissions.length}
+            or
             {' '}
-            most recent submissions -
-            {' '}
-          </span>
-          <a href={allSubmissionsPath}> View full list of solutions</a>
-          {' '}
-          or
-          {' '}
-          <a href={legacySubmissionsUrl} target="_blank" rel="noreferrer">View old submissions</a>
-        </p>
+            <a href={legacySubmissionsUrl} target="_blank" rel="noreferrer">View old submissions</a>
+          </p>
         )}
     </div>
   );


### PR DESCRIPTION
Because:

Currently the `submissions-list` sorted in decreasing order by number of likes. The description of the submissions-list indicates that they are the "most recent submissions"

This commit:
- Fixes the verbiage to be accurate.
- Updates the spacing to meet the current ESLint configuration.