### PR TITLE
Feature: add name / short_name for PWA

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,5 +1,6 @@
 {
-    "name": "",
+    "name": "The Odin Project",
+    "short_name": "The Odin Project",
     "icons": [
         {
             "src": "/android-chrome-192x192.png",


### PR DESCRIPTION
Adds the Name / Short name to the manifest.json file in order for the PWA icon to display a name

For issue: #1596