### PR TITLE
fix: persist md preview code highlight #1652

### DIFF
--- a/app/javascript/components/lesson-preview/index.jsx
+++ b/app/javascript/components/lesson-preview/index.jsx
@@ -17,22 +17,23 @@ const LessonPreview = () => {
   const [convertedContent, setConvertedContent] = useState('');
   const [copied, setCopied] = useState(false);
   const [link, setLink] = useState(window.location.href);
+  const [onPreviewTab, setOnPreviewTab] = useState(false);
 
   const fetchLessonPreview = async () => {
+    if (onPreviewTab) return;
+
     const response = await axios.post('/lessons/preview', { content });
 
     if (response.status === 200) {
       setConvertedContent(response.data.content);
+      setOnPreviewTab(true);
+      Prism.highlightAll();
     }
   };
 
   const handleClick = () => {
     navigator.clipboard.writeText(link).then(() => setCopied(true));
   };
-
-  useEffect(() => {
-    Prism.highlightAll();
-  }, [convertedContent]);
 
   useEffect(() => {
     const query = window.location.search;
@@ -57,7 +58,7 @@ const LessonPreview = () => {
   return (
     <Tabs>
       <TabList>
-        <Tab>Write</Tab>
+        <Tab onClick={() => setOnPreviewTab(false)}>Write</Tab>
         <Tab onClick={fetchLessonPreview}>Preview</Tab>
       </TabList>
 


### PR DESCRIPTION
Because:

https://github.com/TheOdinProject/theodinproject/issues/1652

The code block highlighting does not currently persist on tab-switch when the `content` is the same due to only being triggered by the `convertedContent` state.

This commit:
fixes #1652 

- Removes the `useEffect` previously triggering the code highlighting
- Adds highlighting to Preview tab click handler.
- Adds state to track if the user is on the preview tab (to prevent preview requests being fired by repeatedly clicking on the preview tab)

I wasn't sure how critical the last point really was, but it seemed reasonable to prevent that behavior even if it's abnormal with minimal code added.