### PR TITLE
Chore: Enable preload_app in Puma Config

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -25,14 +25,14 @@ pidfile ENV.fetch('PIDFILE') { 'tmp/pids/server.pid' }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch('WEB_CONCURRENCY') { 2 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
 # before forking the application. This takes advantage of Copy On Write
 # process behavior so workers use less memory.
 #
-# preload_app!
+preload_app!
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart


### PR DESCRIPTION
Because:
* The app will use less memory: https://github.com/puma/puma#clustered-mode

resolves: https://github.com/TheOdinProject/theodinproject/issues/1678