### PR TITLE
Add whitespace on sign in modal

### DIFF
--- a/app/javascript/components/project-submissions/components/create-form.jsx
+++ b/app/javascript/components/project-submissions/components/create-form.jsx
@@ -23,6 +23,7 @@ const CreateForm = ({ onClose, onSubmit, userId }) => {
         <h1 className="bold">Please Sign in</h1>
         <p>
           Please
+          {' '}
           <a href="/login">sign in</a>
           {' '}
           to add a project submission.

--- a/app/javascript/components/project-submissions/components/flag-form.jsx
+++ b/app/javascript/components/project-submissions/components/flag-form.jsx
@@ -13,6 +13,7 @@ const FlagForm = ({ onSubmit, submission, userId }) => {
         <h1 className="bold">Please Sign in</h1>
         <p>
           Please
+          {' '}
           <a href="/login">sign in</a>
           {' '}
           to flag this project submission.


### PR DESCRIPTION
Added missing whitespace between paragraph text and login anchor
to sign in modals on create-form.jsx and flag-form.jsx

Issue #1667