### PR TITLE
Updated Node.js card and Express card title to include MongoDB

### DIFF
--- a/db/seeds/08_node_js_course_seeds.rb
+++ b/db/seeds/08_node_js_course_seeds.rb
@@ -77,7 +77,7 @@ section = create_or_update_section(
   title_url: 'Express'.parameterize,
   course_id: course.id,
   position: section_position,
-  description: 'Here we finally get to Express, the most popular back-end JavaScript framework.'
+  description: 'Here we finally get to Express, the most popular back-end JavaScript framework, and MongoDB, a non-relational database frequently paired with Node.',
 )
 
 lesson_position += 1

--- a/db/seeds/08_node_js_course_seeds.rb
+++ b/db/seeds/08_node_js_course_seeds.rb
@@ -77,7 +77,7 @@ section = create_or_update_section(
   title_url: 'Express'.parameterize,
   course_id: course.id,
   position: section_position,
-  description: 'Here we finally get to Express, the most popular back-end JavaScript framework, and MongoDB, a non-relational database frequently paired with Node.',
+  description: 'Here we finally get to Express, the most popular back-end JavaScript framework, and MongoDB, a non-relational database frequently paired with Node.'
 )
 
 lesson_position += 1

--- a/db/seeds/08_node_js_course_seeds.rb
+++ b/db/seeds/08_node_js_course_seeds.rb
@@ -12,7 +12,7 @@ lesson_position = 0
 course = create_or_update_course(
   title: 'NodeJS',
   title_url: 'NodeJS'.parameterize,
-  description: "You'll learn everything you need to take your JavaScript skills to the server-side.",
+  description: "Take your JavaScript skills to the server-side! Learn how to fully craft your site's backend using Express, the most popular back-end JavaScript framework! You will also learn how to use a non-relational database, MongoDB.",
   position: course_position
 )
 
@@ -73,7 +73,7 @@ create_or_update_lesson(
 
 section_position += 1
 section = create_or_update_section(
-  title: 'Express',
+  title: 'Express & MongoDB',
   title_url: 'Express'.parameterize,
   course_id: course.id,
   position: section_position,


### PR DESCRIPTION
This PR is because I have been noticing people in discord frequently questioning why the JS path has no Database section. The Node card description is lacking compared to the rails one. To remedy this I made the Node card more enticing and added mention of MongoDB so when people are browsing the overviews of both paths when deciding they see mention of databases on the Node path as well ass updating the "Express" section to "Express & MongoDB" so it is clear where Databases are introduced.

<img width="616" alt="Screen Shot 2021-02-05 at 1 10 27 PM" src="https://user-images.githubusercontent.com/59713017/107072842-8cdd0000-67b4-11eb-9d17-cbecece4b1b5.png">
<img width="616" alt="Screen Shot 2021-02-05 at 1 10 34 PM" src="https://user-images.githubusercontent.com/59713017/107072844-8cdd0000-67b4-11eb-8476-56b1aad2334c.png">
<img width="470" alt="Screen Shot 2021-02-05 at 1 17 35 PM" src="https://user-images.githubusercontent.com/59713017/107072846-8d759680-67b4-11eb-8286-d2b0f5e75d6a.png">
