### PR TITLE
Update slug when resource title is changed

### DIFF
--- a/config/initializers/friendly_id.rb
+++ b/config/initializers/friendly_id.rb
@@ -37,7 +37,7 @@ FriendlyId.defaults do |config|
   # performance because it will avoid Rails-internal code that makes runtime
   # calls to `Module.extend`.
   #
-  # config.use :finders
+  config.use :finders
   #
   # ## Slugs
   #
@@ -68,11 +68,11 @@ FriendlyId.defaults do |config|
   # FriendlyId adds to your model. The change below makes FriendlyId 5.0 behave
   # more like 4.0.
   #
-  # config.use Module.new {
-  #   def should_generate_new_friendly_id?
-  #     slug.blank? || <your_column_name_here>_changed?
-  #   end
-  # }
+  config.use Module.new {
+    def should_generate_new_friendly_id?
+      slug.blank? || title_changed?
+    end
+  }
   #
   # FriendlyId uses Rails's `parameterize` method to generate slugs, but for
   # languages that don't use the Roman alphabet, that's not usually sufficient.


### PR DESCRIPTION
Added friendly finders and custom should_generate_new_friendly_id?
method to friendly_id initializer to resolve bug where slug would
not update properly when a path, course, or lesson title was
changed in the rails console.

Issue #1710