### PR TITLE
Fix: Lesson Nav and Content Alignment

### DIFF
--- a/app/assets/stylesheets/components/lesson/_navigation.scss
+++ b/app/assets/stylesheets/components/lesson/_navigation.scss
@@ -1,6 +1,7 @@
 .lesson-nav-wrapper {
   display: flex;
   justify-content: center;
+  padding-top: 6px;
 }
 
 .lesson-navigation {

--- a/app/assets/stylesheets/components/lesson/lesson_content.scss
+++ b/app/assets/stylesheets/components/lesson/lesson_content.scss
@@ -1,16 +1,16 @@
 .lesson-content {
   padding-bottom: 60px;
 
-  h3:nth-child(2) {
-    margin-top: 0;
-  }
-
   h3 {
     margin-bottom: 20px;
     margin-top: 50px;
     font-weight: bold;
     color: $text-primary;
     font-size: 1.5em;
+
+    &:first-child {
+      margin-top: 0;
+    }
 
     @include media-breakpoint-down(md) {
       &:before {


### PR DESCRIPTION
Because:
* There was a large space between the end of the lesson header and lesson content causing the top of the nav and content to be out of alignment.

This commit:
* Removes the top margin from the first lesson content heading to get rid of the redundant spacing and fix most of the alignment issue.
* Adds a little bit of padding to the top of the lesson nav wrapper so aligns better with the first heading in the lesson content.

---
Before: 
![Screenshot 2021-02-27 at 17 10 15](https://user-images.githubusercontent.com/7963776/109394420-d38ac980-791e-11eb-8256-4d5452e6a34b.png)

After:
![Screenshot 2021-02-27 at 17 13 07](https://user-images.githubusercontent.com/7963776/109394471-1187ed80-791f-11eb-85fa-1ac05531899f.png)

