### PR TITLE
Navbar avatar alignment

### DIFF
--- a/app/assets/stylesheets/components/navbar.scss
+++ b/app/assets/stylesheets/components/navbar.scss
@@ -79,7 +79,7 @@
       line-height: 78px;
     }
     .avatar {
-      margin-top: 37.8px;
+      margin-top: 33.8px;
       width: 30px;
       height: 30px;
       @include border-radius(50%);


### PR DESCRIPTION
Avatar position alignment

Because: It was too low

Before:
![chrome-capture (45)](https://user-images.githubusercontent.com/36450233/109521416-f69bb180-7ab5-11eb-8c2b-efbe38b12069.jpg)
After:
![chrome-capture (46)](https://user-images.githubusercontent.com/36450233/109521420-f7ccde80-7ab5-11eb-8e0d-0f56d7f50015.jpg)