### PR TITLE
Fix: Deleting a Lesson on Production Hangs

### DIFF
--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -6,7 +6,7 @@ class Lesson < ApplicationRecord
   belongs_to :section
   has_one :course, through: :section
   has_many :project_submissions
-  has_many :lesson_completions, dependent: :destroy
+  has_many :lesson_completions
   has_many :completing_users, through: :lesson_completions, source: :student
 
   validates :position, presence: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -224,6 +224,7 @@ ActiveRecord::Schema.define(version: 2021_03_06_162015) do
 
   add_foreign_key "flags", "project_submissions"
   add_foreign_key "flags", "users", column: "flagger_id"
+  add_foreign_key "lesson_completions", "lessons", on_delete: :cascade
   add_foreign_key "path_prerequisites", "paths"
   add_foreign_key "path_prerequisites", "paths", column: "prerequisite_id"
   add_foreign_key "project_submissions", "lessons"

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Lesson do
   it { is_expected.to belong_to(:section) }
   it { is_expected.to have_one(:course).through(:section) }
   it { is_expected.to have_many(:project_submissions) }
-  it { is_expected.to have_many(:lesson_completions).dependent(:destroy) }
+  it { is_expected.to have_many(:lesson_completions) }
   it { is_expected.to have_many(:completing_users).through(:lesson_completions) }
 
   it { is_expected.to validate_presence_of(:position) }


### PR DESCRIPTION
Because:
* Deleting a lesson loads all lesson_completions for that lesson into memory to delete them as well.

This commit:
* Adds a foreign key with a delete cascade so the database can handle deleting lesson completions associated with a lesson instead of Ruby.