### PR TITLE
Chore: Use Friendly ID Slug History.

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,14 +1,14 @@
 class Course < ApplicationRecord
   extend FriendlyId
 
+  friendly_id :title, use: %i[slugged history finders]
+
   has_many :path_courses
   has_many :paths, through: :path_courses
   has_many :sections, -> { order(:position) }
   has_many :lessons, through: :sections
 
   validates :position, presence: true
-
-  friendly_id :title, use: %i[slugged finders]
 
   def progress_for(user)
     user.progress_for(self)

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -1,7 +1,7 @@
 class Lesson < ApplicationRecord
   extend FriendlyId
 
-  friendly_id :slug_candidates, use: %i[slugged finders]
+  friendly_id :slug_candidates, use: %i[slugged history finders]
 
   belongs_to :section
   has_one :course, through: :section

--- a/app/models/path.rb
+++ b/app/models/path.rb
@@ -1,7 +1,7 @@
 class Path < ApplicationRecord
   extend FriendlyId
 
-  friendly_id :title, use: %i[slugged finders]
+  friendly_id :title, use: %i[slugged history finders]
 
   has_many :users
   has_many :path_courses, -> { order(:position) }, dependent: :destroy


### PR DESCRIPTION
Because:
* It will allow external links that contain an outdated url path for a lesson, course or path to still work as expected.