### PR TITLE
Chore: Remove Title Url

### DIFF
--- a/app/views/lessons/_lesson_buttons.html.erb
+++ b/app/views/lessons/_lesson_buttons.html.erb
@@ -1,5 +1,5 @@
 <%= link_to 'View Course',
-    course_path(course.title_url),
+    course_path(course),
     title: "Go back to '#{lesson.course.title}'",
     class: 'button button--secondary lesson-button-group__item lesson-button'
 %>

--- a/app/views/sitemap/index.xml.builder
+++ b/app/views/sitemap/index.xml.builder
@@ -34,14 +34,14 @@ xml.urlset(
   # Individual courses and lessons
   @courses.each do |course|
     xml.url do
-      xml.loc "#{course_url(course.title_url)}"
+      xml.loc "#{course_url(course)}"
       xml.changefreq("weekly")
       xml.priority(0.80)
     end
 
     course.lessons.each do |lesson|
       xml.url do
-        xml.loc "#{lesson_url(course.title_url, lesson.title_url)}"
+        xml.loc "#{course_lesson_url(course, lesson)}"
         xml.lastmod lesson.updated_at.strftime("%F")
         xml.changefreq("daily")
         xml.priority(1.00)

--- a/db/migrate/20210305002818_remove_title_url.rb
+++ b/db/migrate/20210305002818_remove_title_url.rb
@@ -1,0 +1,7 @@
+class RemoveTitleUrl < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :lessons, :title_url
+    remove_column :courses, :title_url
+    remove_column :sections, :title_url
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_29_134713) do
+ActiveRecord::Schema.define(version: 2021_03_05_002818) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,7 +41,6 @@ ActiveRecord::Schema.define(version: 2020_12_29_134713) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "title_url", limit: 255
     t.integer "position", null: false
     t.string "slug"
     t.index ["slug"], name: "index_courses_on_slug"
@@ -89,7 +88,6 @@ ActiveRecord::Schema.define(version: 2020_12_29_134713) do
     t.integer "section_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "title_url", limit: 255
     t.text "content"
     t.string "slug"
     t.string "repo"
@@ -158,11 +156,9 @@ ActiveRecord::Schema.define(version: 2020_12_29_134713) do
     t.integer "course_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "title_url", limit: 255
     t.text "description"
     t.index ["course_id"], name: "index_sections_on_course_id"
     t.index ["position"], name: "index_sections_on_position"
-    t.index ["title_url"], name: "index_sections_on_title_url"
   end
 
   create_table "success_stories", id: :serial, force: :cascade do |t|

--- a/db/seeds/01_foundations_seeds.rb
+++ b/db/seeds/01_foundations_seeds.rb
@@ -11,7 +11,6 @@ lesson_position = 0
 
 course = create_or_update_course(
   title: 'Foundations',
-  title_url: 'Foundations'.parameterize,
   description: "This is where it all begins! A hands-on introduction to all of the essential tools you'll need to build real, working websites. You'll learn what web developers actually do – the foundations you'll need for later courses.",
   position: course_position
 )
@@ -23,7 +22,6 @@ course = create_or_update_course(
 section_position += 1
 section = create_or_update_section(
   title: 'Introduction',
-  title_url: 'Introduction'.parameterize,
   course_id: course.id,
   position: section_position,
   description: "This section will cover the baseline knowledge you need before getting into the more 'programming' aspects of web development."
@@ -32,7 +30,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'How this Course Will Work',
-  title_url: 'How this Course Will Work'.parameterize,
   description: 'Before you dive in, get familiar with the lay of the land up ahead.',
   position: lesson_position,
   section_id: section.id,
@@ -44,7 +41,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Introduction to Web Development',
-  title_url: 'Introduction to Web Development'.parameterize,
   description: 'Learn a little about web development as a career.',
   position: lesson_position,
   section_id: section.id,
@@ -56,7 +52,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Motivation and Mindset',
-  title_url: 'Motivation and Mindset'.parameterize,
   description: 'Some advice about how to approach learning to program.',
   position: lesson_position,
   section_id: section.id,
@@ -68,7 +63,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Join the Odin Community',
-  title_url: 'Join the Odin Community'.parameterize,
   description: "Find out how to join Odin's community of new and veteran learners and how to get help with coding problems.",
   position: lesson_position,
   section_id: section.id,
@@ -80,7 +74,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'How Does the Web Work?',
-  title_url: 'How Does the Web Work?'.parameterize,
   description: "It's tough to program web sites without understanding how the web actually works!",
   position: lesson_position,
   section_id: section.id,
@@ -96,7 +89,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'Installations',
-  title_url: 'Installations'.parameterize,
   course_id: course.id,
   position: section_position,
   description: 'In this section you will configure your development environment and install some software necessary for web development.'
@@ -105,7 +97,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Installation Overview',
-  title_url: 'Installation Overview'.parameterize,
   description: "There are some things you'll need to install before you start getting your hands dirty",
   position: lesson_position,
   section_id: section.id,
@@ -117,7 +108,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Prerequisites',
-  title_url: 'Prerequisites'.parameterize,
   description: 'Before we can install Ruby and Rails...',
   position: lesson_position,
   section_id: section.id,
@@ -129,7 +119,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Text Editors',
-  title_url: 'Text Editors'.parameterize,
   description: 'The hottest debate in programming, VSCode or Sublime?',
   position: lesson_position,
   section_id: section.id,
@@ -141,7 +130,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Command Line Basics',
-  title_url: 'Command Line Basics'.parameterize,
   description: 'The command line: loved, hated, and feared... but no longer by you.',
   position: lesson_position,
   section_id: section.id,
@@ -153,7 +141,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Setting Up Git',
-  title_url: 'Setting Up Git'.parameterize,
   description: 'The Source Code Ambulance',
   position: lesson_position,
   section_id: section.id,
@@ -169,7 +156,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'Git Basics',
-  title_url: 'Git Basics'.parameterize,
   course_id: course.id,
   position: section_position,
   description: 'In this section you will learn the basics of Git and how you can upload your future projects to GitHub so you can share your work and collaborate with others on projects easily.'
@@ -178,7 +164,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Introduction to Git',
-  title_url: 'Introduction Git'.parameterize,
   description: "A high level overview of what Git is and why it's so useful",
   position: lesson_position,
   section_id: section.id,
@@ -190,7 +175,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Git Basics',
-  title_url: 'Git Basics'.parameterize,
   description: "Now that you know what Git is it's time to learn how to use it.",
   position: lesson_position,
   section_id: section.id,
@@ -202,7 +186,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Practicing Git Basics',
-  title_url: 'Practicing Git Basics'.parameterize,
   description: 'In this tutorial you will see how Git is used on a small project.',
   position: lesson_position,
   section_id: section.id,
@@ -220,7 +203,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'The Front End',
-  title_url: 'The Front End'.parameterize,
   course_id: course.id,
   position: section_position,
   description: "In this section you'll spend a good deal of time getting familiar with the major client-side (browser-based) languages like HTML, CSS, and JavaScript.  You'll get to build a webpage with HTML/CSS and learn some programming fundamentals with JavaScript."
@@ -229,7 +211,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Introduction to the Front End',
-  title_url: 'Introduction to the Front End'.parameterize,
   description: "An overview of what exactly the 'Front End' is",
   position: lesson_position,
   section_id: section.id,
@@ -241,7 +222,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'HTML and CSS Basics',
-  title_url: 'HTML and CSS Basics'.parameterize,
   description: "You'll learn all about how to build and style webpages with HTML and CSS",
   position: lesson_position,
   section_id: section.id,
@@ -253,7 +233,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Developer Tools',
-  title_url: 'Developer Tools'.parameterize,
   description: "Learn all about your browser's developer tools.",
   position: lesson_position,
   section_id: section.id,
@@ -265,7 +244,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Google Homepage',
-  title_url: 'Google Homepage'.parameterize,
   description: "It's time to put your knowledge to work in the Wild.  Go forth and build!",
   position: lesson_position,
   section_id: section.id,
@@ -283,7 +261,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'JavaScript Basics',
-  title_url: 'JavaScript Basics'.parameterize,
   course_id: course.id,
   position: section_position,
   description: 'Here we finally dig into JavaScript and learn how to make the web dynamic.'
@@ -292,7 +269,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Fundamentals Part 1',
-  title_url: 'JavaScript Fundamentals 1'.parameterize,
   description: "You'll get a chance to start picking up the programming fundamentals you need to make your webpages dynamic",
   position: lesson_position,
   section_id: section.id,
@@ -304,7 +280,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Fundamentals Part 2',
-  title_url: 'JavaScript Fundamentals 2'.parameterize,
   description: 'Continues where Fundamentals 2 leaves off!',
   position: lesson_position,
   section_id: section.id,
@@ -316,7 +291,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Developer Tools 2',
-  title_url: 'Developer Tools 2'.parameterize,
   description: 'covers using the dev tools from the perspective of a JS developer',
   position: lesson_position,
   section_id: section.id,
@@ -328,7 +302,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Fundamentals Part 3',
-  title_url: 'JavaScript Fundamentals Part 3'.parameterize,
   description: 'Part 3 of our JS fundamentals course.',
   position: lesson_position,
   section_id: section.id,
@@ -340,7 +313,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Problem Solving',
-  title_url: 'Problem Solving'.parameterize,
   section_id: section.id,
   position: lesson_position,
   description: 'In this lesson we will explore how to approach solving programming problems.',
@@ -352,7 +324,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Rock Paper Scissors',
-  title_url: 'Rock Paper Scissors'.parameterize,
   description: 'Rock Paper Scissors',
   position: lesson_position,
   section_id: section.id,
@@ -366,7 +337,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Clean Code',
-  title_url: 'Clean Code'.parameterize,
   description: 'tips for writing better looking and easier to maintain code.',
   position: lesson_position,
   section_id: section.id,
@@ -378,7 +348,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Fundamentals Part 4',
-  title_url: 'JavaScript Fundamentals Part 4'.parameterize,
   description: 'Part 4 of our JS fundamentals course.',
   position: lesson_position,
   section_id: section.id,
@@ -390,7 +359,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'DOM manipulation',
-  title_url: 'DOM manipulation'.parameterize,
   description: 'Finally, lets learn how to make your webpages move!',
   position: lesson_position,
   section_id: section.id,
@@ -402,7 +370,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Etch-a-Sketch',
-  title_url: 'etch-a-sketch'.parameterize,
   description: 'etch-a-sketch',
   position: lesson_position,
   section_id: section.id,
@@ -416,7 +383,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Fundamentals Part 5',
-  title_url: 'JavaScript Fundamentals Part 5'.parameterize,
   description: 'Part 5 of our JS fundamentals course.',
   position: lesson_position,
   section_id: section.id,
@@ -428,7 +394,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Calculator',
-  title_url: 'Calculator'.parameterize,
   description: 'Calculator',
   position: lesson_position,
   section_id: section.id,
@@ -446,7 +411,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'The Back End',
-  title_url: 'The Back End'.parameterize,
   course_id: course.id,
   position: section_position,
   description: "Here you'll learn about the back end, where we'll demystify what goes on behind the scenes on a web server."
@@ -455,7 +419,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Introduction to the Back End',
-  title_url: 'Introduction to the Back End'.parameterize,
   description: 'A brief introduction to the wonderful world of server-side programming',
   position: lesson_position,
   section_id: section.id,
@@ -467,7 +430,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Introduction to Frameworks',
-  title_url: 'Introduction to Frameworks'.parameterize,
   description: "Let's figure out what all the hubbub is all about.",
   position: lesson_position,
   section_id: section.id,
@@ -483,7 +445,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'Tying it All Together',
-  title_url: 'Tying it All Together'.parameterize,
   course_id: course.id,
   position: section_position,
   description: "Now that you've had a healthy taste of all the major components in a web application, we'll take a step back and remember where they all fit into the bigger picture."
@@ -492,7 +453,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Conclusion',
-  title_url: 'Conclusion'.parameterize,
   description: "How far you've come already!  But this ride's only just begun...",
   position: lesson_position,
   section_id: section.id,

--- a/db/seeds/02_ruby_course_seeds.rb
+++ b/db/seeds/02_ruby_course_seeds.rb
@@ -11,7 +11,6 @@ lesson_position = 0
 
 course = create_or_update_course(
   title: 'Ruby Programming',
-  title_url: 'Ruby Programming'.parameterize,
   description: "Time to dive deep into Ruby, the language 'designed for programmer happiness.' You'll cover object-oriented design, testing, and data structures – essential knowledge for learning other programming languages, too!",
   position: course_position,
 )
@@ -23,7 +22,6 @@ course = create_or_update_course(
 section_position += 1
 section = create_or_update_section(
   title: 'Introduction',
-  title_url: 'Introduction'.parameterize,
   course_id: course.id,
   position: section_position,
   description: "In this section, we'll look at the path ahead and install ruby."
@@ -32,7 +30,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'How this Course Will Work',
-  title_url: 'How this Course Will Work'.parameterize,
   description: "It's time to get acquainted with what this will look like from here on out.",
   position: lesson_position,
   section_id: section.id,
@@ -44,7 +41,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Installing Ruby',
-  title_url: 'Installing Ruby'.parameterize,
   description: "Let's get started with installing Ruby!",
   position: lesson_position,
   section_id: section.id,
@@ -60,7 +56,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'Basic Ruby',
-  title_url: 'Basic Ruby'.parameterize,
   course_id: course.id,
   position: section_position,
   description: "In this section, we'll cover the basic building blocks of Ruby so you have them down cold. Everything else you'll learn in programming builds on these concepts, so you'll be in a great place to take on additional projects and languages in the future."
@@ -69,7 +64,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Basic Data Types',
-  title_url: 'Basic Data Types'.parameterize,
   description: 'In this lesson we will explore the basic data types at your disposal in Ruby.',
   position: lesson_position,
   section_id: section.id,
@@ -81,7 +75,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Variables',
-  title_url: 'Variables'.parameterize,
   description: 'In this lesson we will explore how to use Variables in Ruby.',
   position: lesson_position,
   section_id: section.id,
@@ -93,7 +86,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Input and Output',
-  title_url: 'Input and Output'.parameterize,
   description: 'In this lesson we will explore how to input and output data in your Ruby programs.',
   position: lesson_position,
   section_id: section.id,
@@ -105,7 +97,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Conditional Logic',
-  title_url: 'Conditional Logic'.parameterize,
   description: 'In this lesson we will explore how to make decisions in Ruby so your programs can take different paths.',
   position: lesson_position,
   section_id: section.id,
@@ -117,7 +108,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Loops',
-  title_url: 'Loops'.parameterize,
   description: "In this lesson we will explore how to utilize loops in Ruby so you don't have to repeat yourself quite as much.",
   position: lesson_position,
   section_id: section.id,
@@ -129,7 +119,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Arrays',
-  title_url: 'Arrays'.parameterize,
   description: 'In this lesson we will explore how to use arrays in Ruby and start using lists of data.',
   position: lesson_position,
   section_id: section.id,
@@ -141,7 +130,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Hashes',
-  title_url: 'Arrays'.parameterize,
   description: 'In this lesson we will explore how to use hashes in Ruby and start using key, value pairs of data.',
   position: lesson_position,
   section_id: section.id,
@@ -153,7 +141,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Methods',
-  title_url: 'Methods'.parameterize,
   description: 'In this lesson we will explore how to make your code more modular with methods.',
   position: lesson_position,
   section_id: section.id,
@@ -165,7 +152,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Basic Enumerable Methods',
-  title_url: 'Basic Enumerable Methods'.parameterize,
   description: 'In this lesson we will explore Rubys secret weapon, its enumerable methods.',
   position: lesson_position,
   section_id: section.id,
@@ -177,7 +163,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Predicate Enumerable Methods',
-  title_url: 'Predicate Enumerable Methods'.parameterize,
   description: 'In this lesson we will explore more enumerable methods that return true or false against a collection of data.',
   position: lesson_position,
   section_id: section.id,
@@ -189,7 +174,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Debugging',
-  title_url: 'Debugging'.parameterize,
   description: 'In this lesson we will explore how to debug your code when things go wrong.',
   position: lesson_position,
   section_id: section.id,
@@ -205,7 +189,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'Basic Ruby Projects',
-  title_url: 'Basic Ruby Projects'.parameterize,
   course_id: course.id,
   position: section_position,
   description: 'In this section we will solidify your basic Ruby knowledge by practicing with a few small projects.'
@@ -214,7 +197,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Caesar Cipher',
-  title_url: 'Caesar Cipher'.parameterize,
   description: "In this project you will build you're very own message encryption program.",
   position: lesson_position,
   section_id: section.id,
@@ -228,7 +210,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Sub Strings',
-  title_url: 'Sub Strings'.parameterize,
   description: 'In this project you will build a program which identifies all the sub-strings in a larger string.',
   position: lesson_position,
   section_id: section.id,
@@ -242,7 +223,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Stock Picker',
-  title_url: 'Stock Picker'.parameterize,
   description: 'In this project you will build a simple program that will tell its user the best day to buy stocks.',
   position: lesson_position,
   section_id: section.id,
@@ -256,7 +236,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Bubble Sort',
-  title_url: 'Bubble Sort'.parameterize,
   description: 'In this project you will build a simple sorting algorithm.',
   position: lesson_position,
   section_id: section.id,
@@ -274,7 +253,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'Object Oriented Programming Basics',
-  title_url: 'Object Oriented Programming Basics'.parameterize,
   course_id: course.id,
   position: section_position,
   description: "You've got tools in your Ruby tool box and now it's time to combine them into more meaningful programs. In this section, you'll learn how to turn your spaghetti code into properly organized methods and classes."
@@ -283,7 +261,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Object Oriented Programming',
-  title_url: 'Object Oriented Programming'.parameterize,
   description: 'Fundamental concepts about object oriented programming that will help you with any programming language you learn from here on out.',
   position: lesson_position,
   section_id: section.id,
@@ -295,7 +272,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Tic Tac Toe',
-  title_url: 'Tic Tac Toe'.parameterize,
   description: "It's time to flex those new muscles a bit by building Tic Tac Toe",
   position: lesson_position,
   section_id: section.id,
@@ -309,7 +285,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Mastermind',
-  title_url: 'Mastermind'.parameterize,
   description: 'In this project you will build the classic code breaking game Mastermind',
   position: lesson_position,
   section_id: section.id,
@@ -327,7 +302,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'Files and Serialization',
-  title_url: 'Files and Serialization'.parameterize,
   course_id: course.id,
   position: section_position,
   description: "In this section you'll take your Ruby skills to the next level by discovering how to serialize code and save it into files."
@@ -336,7 +310,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Files and Serialization',
-  title_url: 'Files and Serialization'.parameterize,
   description: 'What if you want to save the state of your program?  How about loading in a file?  Some basic operations like these will be covered here.',
   position: lesson_position,
   section_id: section.id,
@@ -348,7 +321,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Event Manager',
-  title_url: 'Event Manager'.parameterize,
   description: 'Learn File I/O while becoming civically active',
   position: lesson_position,
   section_id: section.id,
@@ -362,7 +334,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'File I/O and Serialization',
-  title_url: 'File I/O and Serialization'.parameterize,
   description: "You'll get a chance to scrub an existing dataset and then work with dictionaries by building Hangman.",
   position: lesson_position,
   section_id: section.id,
@@ -380,7 +351,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'A Bit of Computer Science',
-  title_url: 'A Bit of Computer Science'.parameterize,
   course_id: course.id,
   position: section_position,
   description: "In this section, you'll learn some fundamental computer science concepts that will help you when solving problems with a bit more complexity than just simple web serving.  You get to try on your engineering hat and solve some pretty nifty problems."
@@ -389,7 +359,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'A Very Brief Intro to CS',
-  title_url: 'A Very Brief Intro to CS'.parameterize,
   description: "Get a taste of what's coming up ahead and what the bigger world of CS looks like beyond the scope of this course.",
   position: lesson_position,
   section_id: section.id,
@@ -401,7 +370,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Recursive Methods',
-  title_url: 'Recursive Methods'.parameterize,
   description: 'Learn how making a function call itself can be helpful for making big problems into smaller problems',
   position: lesson_position,
   section_id: section.id,
@@ -413,7 +381,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Recursion',
-  title_url: 'Recursion'.parameterize,
   description: 'Take your newfound knowledge and apply it to a couple of classic recursive problems',
   position: lesson_position,
   section_id: section.id,
@@ -427,7 +394,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Common Data Structures and Algorithms',
-  title_url: 'Common Data Structures and Algorithms'.parameterize,
   description: 'Learn why we use different data structures to handle our data and some classic algorithms for searching through them to help solve problems',
   position: lesson_position,
   section_id: section.id,
@@ -439,7 +405,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Linked Lists',
-  title_url: 'Linked Lists'.parameterize,
   description: 'Build one of the most fundamental data structures.',
   position: lesson_position,
   section_id: section.id,
@@ -453,7 +418,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Binary Search Trees',
-  title_url: 'Binary Search Trees'.parameterize,
   description: "In this project you'll get your hands dirty with one of the most common computer science problems, searching binary trees.",
   position: lesson_position,
   section_id: section.id,
@@ -467,7 +431,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Knights Travails',
-  title_url: 'Knights Travails'.parameterize,
   description: 'Lets build Knights Travails',
   position: lesson_position,
   section_id: section.id,
@@ -485,7 +448,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'Testing Ruby with RSpec',
-  title_url: 'Testing Ruby with RSpec'.parameterize,
   course_id: course.id,
   position: section_position,
   description: "You've been briefly introduced to testing in Ruby a couple of times before in the Foundations course, but now you're going to really learn why testing can be hugely helpful and how to apply it to your own projects."
@@ -494,7 +456,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Test Driven Development',
-  title_url: 'Test Driven Development'.parameterize,
   description: "In this lesson you will learn about what TDD is and why it's important.",
   position: lesson_position,
   section_id: section.id,
@@ -506,7 +467,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Introduction to RSpec',
-  title_url: 'Introduction to RSpec'.parameterize,
   description: 'In this lesson you will learn the basics of RSpec, the most popular testing framework in the Ruby world.',
   position: lesson_position,
   section_id: section.id,
@@ -518,7 +478,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Testing Your Ruby Code',
-  title_url: 'Testing Your Ruby Code'.parameterize,
   description: "The real way to learn is by doing, so you'll jump in the time machine and write some tests for prior projects.",
   position: lesson_position,
   section_id: section.id,
@@ -536,7 +495,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'Git',
-  title_url: 'Git'.parameterize,
   course_id: course.id,
   position: section_position,
   description: "You should be familiar with the basic Git workflow since you've been using it to save your projects along the way (right?!).  This section will start preparing you for for the more intermediate-level uses of Git that you'll find yourself doing ."
@@ -545,7 +503,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'A Deeper Look at Git',
-  title_url: 'A Deeper Look at Git'.parameterize,
   description: 'Beyond just `$ git add` and `$ git commit`...',
   position: lesson_position,
   section_id: section.id,
@@ -557,7 +514,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Using Git in the Real World',
-  title_url: 'Using Git in the Real World'.parameterize,
   description: "We've just scratched the surface, so here's what to be aware of as you start developing more and more using Git.",
   position: lesson_position,
   section_id: section.id,
@@ -573,7 +529,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'Conclusion',
-  title_url: 'Conclusion'.parameterize,
   course_id: course.id,
   position: section_position,
   description: "You've come an exceptional distance already, now there's just the matter of wrapping it all together into one coherant package and creating something real.  This is your Final Exam and a major feather in your cap.  Once you've completed this section, you should have the confidence to tackle pretty much anything."
@@ -582,7 +537,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Ruby Final Project',
-  title_url: 'Ruby Final Project'.parameterize,
   description: 'Now would be a good time to refresh your memory on how to play Chess. Building it is actually more fun (and more rewarding)!',
   position: lesson_position,
   section_id: section.id,
@@ -596,7 +550,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Conclusion',
-  title_url: 'Conclusion'.parameterize,
   description: "Woah! You made it! Let's take a minute to look back and put things in context for the next step ahead.",
   position: lesson_position,
   section_id: section.id,

--- a/db/seeds/03_database_course_seeds.rb
+++ b/db/seeds/03_database_course_seeds.rb
@@ -9,7 +9,6 @@ lesson_position = 0
 
 course = create_or_update_course(
   title: 'Databases',
-  title_url: 'Databases'.parameterize,
   description: ' Databases are used to organize and capture large amounts of data, typically by inputting, storing, retrieving and managing the information. This course will focus on relational databases, which are widely used to store data and SQL, the language used to query the database.',
   position: course_position,
 )
@@ -22,7 +21,6 @@ puts course.position
 section_position += 1
 section = create_or_update_section(
   title: 'Databases',
-  title_url: 'Databases'.parameterize,
   course_id: course.id,
   position: section_position,
   description: 'Rails does a lot of the heavy lifting with connecting and querying a database but there will be times you need to tweak a query to the database using raw SQL. Learning how to query efficiently will help your understanding of what Rails helps abstract away.'
@@ -31,7 +29,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Databases',
-  title_url: 'Databases'.parameterize,
   description: "Here you'll learn the basics of databases and how they store data.",
   position: lesson_position,
   section_id: section.id,
@@ -43,7 +40,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Databases and SQL',
-  title_url: 'Databases and SQL'.parameterize,
   description: "Data is the core of every major web app and here you'll learn how to speak SQL. Being able to properly query a database will go a long way to minimising any problems your website's users might encounter with slow response times.",
   position: lesson_position,
   section_id: section.id,
@@ -55,7 +51,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'SQL',
-  title_url: 'SQL'.parameterize,
   description: 'The best way to learn is by practice, so this project will give you plenty of opportunity to apply your new SQL powers (for good).',
   position: lesson_position,
   section_id: section.id,

--- a/db/seeds/04_rails_course_seeds.rb
+++ b/db/seeds/04_rails_course_seeds.rb
@@ -11,7 +11,6 @@ lesson_position = 0
 
 course = create_or_update_course(
   title: 'Ruby on Rails',
-  title_url: 'Ruby on Rails'.parameterize,
   description: "Take Ruby to the next level with the Ruby on Rails framework! Learn how to fully craft your site's backend using the Model-View-Controller design pattern. You'll gain the confidence to launch a website in under an hour.",
   position: course_position,
 )
@@ -23,7 +22,6 @@ course = create_or_update_course(
 section_position += 1
 section = create_or_update_section(
   title: 'Introduction',
-  title_url: 'Introduction'.parameterize,
   course_id: course.id,
   position: section_position,
   description: 'In this section, we will install Rails.'
@@ -32,7 +30,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'How this Course Will Work',
-  title_url: 'How this Course Will Work'.parameterize,
   description: "Let's get acquainted with what this will look like from here on out.",
   position: lesson_position,
   section_id: section.id,
@@ -44,7 +41,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Preparing for Deployment',
-  title_url: 'Preparing for Deployment'.parameterize,
   description: 'Get setup to use Heroku to deploy our web applications',
   position: lesson_position,
   section_id: section.id,
@@ -56,7 +52,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Installing Rails',
-  title_url: 'Installing Rails'.parameterize,
   description: 'Get setup for this course by installing Rails.',
   position: lesson_position,
   section_id: section.id,
@@ -74,7 +69,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'Rails Basics',
-  title_url: 'Rails Basics'.parameterize,
   course_id: course.id,
   position: section_position,
   description: "It's time to start looking carefully into the foundational pieces of the Rails framework. We'll cover the path of an HTTP request from entering your application to returning as an HTML page to the browser."
@@ -83,7 +77,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'A Railsy Web Refresher',
-  title_url: 'A Railsy Web Refresher'.parameterize,
   description: "We're not just using the Web, we're living it.  This lesson will get you up to speed on how.",
   position: lesson_position,
   section_id: section.id,
@@ -95,7 +88,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Routing',
-  title_url: 'Routing'.parameterize,
   description: "The router is the switchboard of your app, telling requests which controller action they're supposed to run. ",
   position: lesson_position,
   section_id: section.id,
@@ -107,7 +99,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Controllers',
-  title_url: 'Controllers'.parameterize,
   description: 'Controllers are the middle managers of the whole process -- they tell everyone else what to do and take all the credit.',
   position: lesson_position,
   section_id: section.id,
@@ -119,7 +110,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Views',
-  title_url: 'Views'.parameterize,
   description: "When the controller has figured out which data needs to be displayed, it's the View's job to turn that into some half-decent HTML.",
   position: lesson_position,
   section_id: section.id,
@@ -131,7 +121,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'The Asset Pipeline',
-  title_url: 'The Asset Pipeline'.parameterize,
   description: 'This lesson explains how Rails handles all the behind-the-scenes stuff to get your CSS, Image files and other assets served quickly and efficiently and how you can use that process.',
   position: lesson_position,
   section_id: section.id,
@@ -143,7 +132,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Webpacker',
-  title_url: 'Webpacker'.parameterize,
   description: 'This lesson explains how Rails handles Javascript using Webpack, how it builds the dependency graph, and how you can ensure the pack files only load what they need to keep file sizes minimal',
   position: lesson_position,
   section_id: section.id,
@@ -155,7 +143,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Deployment',
-  title_url: 'Deployment'.parameterize,
   description: "There's nothing quite like seeing your application on a real website.  We'll show you how it's done.",
   position: lesson_position,
   section_id: section.id,
@@ -167,7 +154,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Blog App',
-  title_url: 'Blog App'.parameterize,
   description: "You've learned the basics, now let's put them to work by building a basic blogging app.",
   position: lesson_position,
   section_id: section.id,
@@ -185,7 +171,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'Active Record Basics',
-  title_url: 'Active Record Basics'.parameterize,
   course_id: course.id,
   position: section_position,
   description: "This section covers the back end of Rails, which is the most important part of the framework.  You'll learn how to interface with databases using the fantastic Active Record gem."
@@ -194,7 +179,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Active Record Basics',
-  title_url: 'Active Record Basics'.parameterize,
   description: 'Active Record is the crown jewel of Rails because it turns all the bare metal database queries (like SQL) into nice clean Ruby methods.',
   position: lesson_position,
   section_id: section.id,
@@ -206,7 +190,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Building With Active Record',
-  title_url: 'Building With Active Record'.parameterize,
   description: "You'll start getting practice thinking data first before building something that acts a lot like Reddit.",
   position: lesson_position,
   section_id: section.id,
@@ -224,7 +207,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'Forms and Authentication',
-  title_url: 'Forms and Authentication'.parameterize,
   course_id: course.id,
   position: section_position,
   description: "This section gets into some of the areas of web apps that are less glamorous than they are important.  Forms are your user's window to interact with your application. Authentication is critical for many applications, and you'll build a couple of auth systems from the ground up."
@@ -233,7 +215,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Form Basics',
-  title_url: 'Form Basics'.parameterize,
   description: 'Half refresher, half expanding your mind, this will bridge the gap between the lowly web form and your server side logic.',
   position: lesson_position,
   section_id: section.id,
@@ -245,7 +226,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Forms',
-  title_url: 'Forms'.parameterize,
   description: "To understand the form, you must start from the beginning.  We'll start with HTML and then learn how Rails can really help you out.",
   position: lesson_position,
   section_id: section.id,
@@ -259,7 +239,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Sessions, Cookies, and Authentication',
-  title_url: 'Sessions, Cookies, and Authentication'.parameterize,
   description: "Learn how to store data in the user's browser and how that is used to sign in the user and keep them signed in across requests.",
   position: lesson_position,
   section_id: section.id,
@@ -271,7 +250,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Authentication',
-  title_url: 'Authentication'.parameterize,
   description: "You'll build a closed community for sharing embarrassing gossip with the world.",
   position: lesson_position,
   section_id: section.id,
@@ -289,7 +267,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'Advanced Forms and Active Record',
-  title_url: 'Advanced Forms and Active Record'.parameterize,
   course_id: course.id,
   position: section_position,
   description: "Now it's starting to get fun!  Learn how to do more than just find and show your users... you'll learn how to use relationships between models to greatly expand your abilities and how to build web forms with sufficient firepower to achieve your most ambitious goals."
@@ -298,7 +275,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Active Record Queries',
-  title_url: 'Active Record Queries'.parameterize,
   description: 'Learn how to take some of those advanced querying concepts you used in SQL and have Rails do them for you mathemagically.',
   position: lesson_position,
   section_id: section.id,
@@ -310,7 +286,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Active Record Associations',
-  title_url: 'Active Record Associations'.parameterize,
   description: 'Dive into some of the more interesting features of associations like special methods and polymorphism.',
   position: lesson_position,
   section_id: section.id,
@@ -322,7 +297,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Associations',
-  title_url: 'Associations'.parameterize,
   description: "Build a system to manage signups for you and your friends' special events.",
   position: lesson_position,
   section_id: section.id,
@@ -336,7 +310,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Active Record Callbacks',
-  title_url: 'Active Record Callbacks'.parameterize,
   description: 'A brief look at the life-cycle of an Active Record object, from birth to destruction, and how you can hook into that for profit.',
   position: lesson_position,
   section_id: section.id,
@@ -348,7 +321,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Advanced Forms',
-  title_url: 'Advanced Forms'.parameterize,
   description: "Take what you know about forms and put rocket boosters on it.  Don't be afraid to make a form for anything.",
   position: lesson_position,
   section_id: section.id,
@@ -360,7 +332,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Building Advanced Forms',
-  title_url: 'Building Advanced Forms'.parameterize,
   description: 'Build an airline flight signup system, which is a nest of interesting complexities',
   position: lesson_position,
   section_id: section.id,
@@ -378,7 +349,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'APIs',
-  title_url: 'APIs'.parameterize,
   course_id: course.id,
   position: section_position,
   description: 'In this penultimate section we will explore harnessing the powers of other apps via their APIs and creating our own.'
@@ -387,7 +357,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'APIs and Building Your Own',
-  title_url: 'APIs and Building Your Own'.parameterize,
   description: 'Rails is really just an API itself... learn about APIs and how to turn your app into one',
   position: lesson_position,
   section_id: section.id,
@@ -399,7 +368,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Working With External APIs',
-  title_url: 'Working With External APIs'.parameterize,
   description: "Lots of the power of APIs comes from interfacing with third-party applications, which we'll cover in this lesson.",
   position: lesson_position,
   section_id: section.id,
@@ -411,7 +379,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Kittens API',
-  title_url: 'Kittens API'.parameterize,
   description: "In this project, you'll both build your own API",
   position: lesson_position,
   section_id: section.id,
@@ -425,7 +392,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Using an API',
-  title_url: 'Using an API'.parameterize,
   description: "In this project, you'll work with a third-party API.",
   position: lesson_position,
   section_id: section.id,
@@ -443,7 +409,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'Mailers and Advanced Topics',
-  title_url: 'Mailers and Advanced Topics'.parameterize,
   course_id: course.id,
   position: section_position,
   description: 'This final section will take you into some of the more interesting sides of the Rails ecosystem which will help you reach beyond your own app and into the lives of your users via email.'
@@ -452,7 +417,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Mailers',
-  title_url: 'Mailers'.parameterize,
   description: "You don't often think about where your email comes from.  Here you'll learn how to send it from your app.",
   position: lesson_position,
   section_id: section.id,
@@ -464,7 +428,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Sending Confirmation Emails',
-  title_url: 'Sending Confirmation Emails'.parameterize,
   description: "Add email functionality to an existing project.  Just don't SPAM, it's frowned upon.",
   position: lesson_position,
   section_id: section.id,
@@ -478,7 +441,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Advanced Topics',
-  title_url: 'Advanced Topics'.parameterize,
   description: 'A mash-up of orphan topics like advanced routing, layouts, metaprogramming and design patterns.',
   position: lesson_position,
   section_id: section.id,
@@ -490,7 +452,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Websockets and Actioncable',
-  title_url: 'Websockets and Actioncable'.parameterize,
   description: 'A delve into the basics of websockets and how Actioncable brings them to Rails.',
   position: lesson_position,
   section_id: section.id,
@@ -502,7 +463,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Final Project',
-  title_url: 'Final Project'.parameterize,
   description: "There's a pretty popular social networking app you should build.  They may have made a movie about it.",
   position: lesson_position,
   section_id: section.id,
@@ -516,7 +476,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Conclusion',
-  title_url: 'Conclusion'.parameterize,
   description: "Holy cow, you've gotten to the end of the road!  ...Sort of.",
   position: lesson_position,
   section_id: section.id,

--- a/db/seeds/05_html_css_course_seeds.rb
+++ b/db/seeds/05_html_css_course_seeds.rb
@@ -11,7 +11,6 @@ lesson_position = 0
 
 course = create_or_update_course(
   title: 'HTML and CSS',
-  title_url: 'HTML and CSS'.parameterize,
   description: "Good web design doesn't happen by accident. This course takes a deeper look at front-end design and development, expanding on what is covered in Foundations. You'll learn how to design and develop websites that look great in any device and you'll be equipped to deeply understand and create your own responsive design framework!",
   position: course_position
 )
@@ -23,7 +22,6 @@ course = create_or_update_course(
 section_position += 1
 section = create_or_update_section(
   title: 'Basic HTML Page Structure',
-  title_url: 'Basic HTML Page Structure'.parameterize,
   course_id: course.id,
   position: section_position,
   description: "In this section, we'll cover the whole range of HTML so you'll be completely comfortable with putting the right elements in the right places on a page."
@@ -32,7 +30,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'How This Course Will Work',
-  title_url: 'How This Course Will Work'.parameterize,
   description: "Let's get acquainted with what this will look like from here on out.",
   position: lesson_position,
   section_id: section.id,
@@ -44,7 +41,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'HTML Basics',
-  title_url: 'HTML Basics'.parameterize,
   description: 'A brief refresher on the very basics of HTML.',
   position: lesson_position,
   section_id: section.id,
@@ -56,7 +52,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Linking Internal and External Pages',
-  title_url: 'Linking Internal and External Pages'.parameterize,
   description: 'When do you link to the relative URL versus the absolute?  How do you set up internal links?',
   position: lesson_position,
   section_id: section.id,
@@ -68,7 +63,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Working with Images, Video and Other Media',
-  title_url: 'Working with Images, Video and Other Media'.parameterize,
   description: "Rich media experiences make your pages come alive but there are some things you'll need to know to avoid slow load times.",
   position: lesson_position,
   section_id: section.id,
@@ -80,7 +74,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Embedding Images and Video',
-  title_url: 'Embedding Images and Video'.parameterize,
   description: "To get some practice with everything you've picked up so far, you'll rebuild YouTube's video page.",
   position: lesson_position,
   section_id: section.id,
@@ -94,7 +87,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: "What's New in HTML5",
-  title_url: "What's New in HTML5".parameterize,
   description: 'The transition to HTML5 has opened up several new elements and best practices which will make your life easier.',
   position: lesson_position,
   section_id: section.id,
@@ -110,7 +102,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'Displaying and Inputting Data',
-  title_url: 'Displaying and Inputting Data'.parameterize,
   course_id: course.id,
   position: section_position,
   description: "Displaying and inputting data are two of your chief duties as a web developer. We'll cover the tools at your disposal, including tables and lists for display and forms for input."
@@ -119,7 +110,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Tables in HTML',
-  title_url: 'Tables in HTML'.parameterize,
   description: "Tables aren't used as much as they once were but can still be a great way to display structured content.",
   position: lesson_position,
   section_id: section.id,
@@ -131,7 +121,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Ordered and Unordered Lists',
-  title_url: 'Ordered and Unordered Lists'.parameterize,
   description: 'Lists are used everywhere and even in some unexpected places like navigation bars.',
   position: lesson_position,
   section_id: section.id,
@@ -143,7 +132,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Forms for Collecting Data',
-  title_url: 'Forms for Collecting Data'.parameterize,
   description: 'Forms allow the user to submit data to your application and represent one of the trickiest parts of setting up your HTML structure.',
   position: lesson_position,
   section_id: section.id,
@@ -155,7 +143,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'HTML Forms',
-  title_url: 'HTML Forms'.parameterize,
   description: "Get some practice working with different form elements by building Mint.com's signup.",
   position: lesson_position,
   section_id: section.id,
@@ -173,7 +160,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'CSS',
-  title_url: 'CSS'.parameterize,
   course_id: course.id,
   position: section_position,
   description: "Here we'll cover each of the foundational CSS concepts in greater depth than you probably have before."
@@ -182,7 +168,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'CSS Basics',
-  title_url: 'CSS Basics'.parameterize,
   description: "Even though you're already comfortable with CSS, it's worth revisiting the basics.",
   position: lesson_position,
   section_id: section.id,
@@ -194,7 +179,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'The Box Model',
-  title_url: 'The Box Model'.parameterize,
   description: 'Even experienced developers often have trouble with the details of the box model, which governs how elements are displayed on the page.',
   position: lesson_position,
   section_id: section.id,
@@ -206,7 +190,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Floats and Positioning',
-  title_url: 'Floats and Positioning'.parameterize,
   description: 'Positioning elements on the page can give you fits, so learning how elements play together is well worth your time.',
   position: lesson_position,
   section_id: section.id,
@@ -218,7 +201,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Flexbox',
-  title_url: 'Flexbox'.parameterize,
   description: 'Flexbox layout distributes space along a single column or row. Like float layouts, but more versatile.',
   position: lesson_position,
   section_id: section.id,
@@ -230,7 +212,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Grid',
-  title_url: 'Grid'.parameterize,
   description: 'Grid divides elements into columns & rows. A modern, powerful way to setout your layout.',
   position: lesson_position,
   section_id: section.id,
@@ -242,7 +223,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Positioning and Floating Elements',
-  title_url: 'Positioning and Floating Elements'.parameterize,
   description: 'Long content pieces of yesteryear are being replaced with rich multimedia experiences and the Times has led the charge.  See if you can apply what you learned about positioning by cloning one of their articles.',
   position: lesson_position,
   section_id: section.id,
@@ -256,7 +236,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Best Practices',
-  title_url: 'Best Practices'.parameterize,
   description: "It's one thing to have the toolbox and a whole other to understand the best way to use it.  We'll explore some of these best practices in this section.",
   position: lesson_position,
   section_id: section.id,
@@ -268,7 +247,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Backgrounds and Gradients',
-  title_url: 'Backgrounds and Gradients'.parameterize,
   description: "Here you'll learn about placing and positioning background images and working with gradients.",
   position: lesson_position,
   section_id: section.id,
@@ -280,7 +258,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Building with Backgrounds and Gradients',
-  title_url: 'Building with Backgrounds and Gradients'.parameterize,
   description: 'Apple is a design leader and their homepage can teach you a lot about working with images and gradients.',
   position: lesson_position,
   section_id: section.id,
@@ -298,7 +275,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'Design and UX',
-  title_url: 'Design and UX'.parameterize,
   course_id: course.id,
   position: section_position,
   description: "If you want to make your websites stop looking like they came from the 1990's, you'll need to gain an understanding for at least the best practices of design and User Experience (UX).  Not knowing this stuff is like charging over the next hill without any idea of why you're doing it."
@@ -307,7 +283,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Introduction to Design and UX',
-  title_url: 'Introduction to Design and UX'.parameterize,
   description: 'A grounding in some fundamental design definitions and tenets will go a long way.',
   position: lesson_position,
   section_id: section.id,
@@ -319,7 +294,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Fonts and Typography',
-  title_url: 'Fonts and Typography'.parameterize,
   description: "Understanding fonts and typography is far from a design geek's domain -- they greatly affect the ease of use for your pages.",
   position: lesson_position,
   section_id: section.id,
@@ -331,7 +305,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Design Teardown',
-  title_url: 'Design Teardown'.parameterize,
   description: "The first step to understanding design is to train yourself to *see* design, so you'll get a chance to break down one of the hallmark Design publications, Smashing Magazine.",
   position: lesson_position,
   section_id: section.id,
@@ -349,7 +322,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'Responsive Design and CSS Frameworks',
-  title_url: 'Responsive Design and CSS Frameworks'.parameterize,
   course_id: course.id,
   position: section_position,
   description: 'These days you need to make sure your pages display easily on multiple viewport sizes by using fluid layouts and media queries.  Luckily there are CSS frameworks like Twitter Bootstrap that can save you a ton of time developing standard pages and which come with responsive functionality for free.'
@@ -358,7 +330,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Responsive Design',
-  title_url: 'Responsive Design'.parameterize,
   description: "Your websites will need to degrade gracefully as your users move from a full browser to an iPad to a mobile phone, and here you'll learn how.",
   position: lesson_position,
   section_id: section.id,
@@ -370,7 +341,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Building with Responsive Design',
-  title_url: 'Building with Responsive Design'.parameterize,
   description: "It's time to put your newfound responsive superpowers to use by building The Next Web's responsive homepage.",
   position: lesson_position,
   section_id: section.id,
@@ -384,7 +354,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'CSS Frameworks like Bootstrap and Foundation',
-  title_url: 'CSS Frameworks like Bootstrap and Foundation'.parameterize,
   description: "Now that you've mastered the fundamentals of HTML and CSS, it's time to make your workflow a whole lot easier with CSS frameworks.",
   position: lesson_position,
   section_id: section.id,
@@ -396,7 +365,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Using Bootstrap',
-  title_url: 'Using Bootstrap'.parameterize,
   description: 'Test out working with the Bootstrap framework.  It may feel a bit odd at first but it makes your life MUCH easier once you figure out the gist of it. ',
   position: lesson_position,
   section_id: section.id,
@@ -414,7 +382,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'Advanced CSS',
-  title_url: 'Advanced CSS'.parameterize,
   course_id: course.id,
   position: section_position,
   description: "We'll take you beyond the basics of CSS and into a variety of additional topics from how to add some stylistic flair to your elements to using tools like preprocessors to save time and reduce repetition in your code."
@@ -423,7 +390,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Animations, Subtle Effects and Compatibility',
-  title_url: 'Animations, Subtle Effects and Compatibility'.parameterize,
   description: 'Dive into some of the more interesting stylistic tools at your disposal like transitions and animations that use only CSS3.',
   position: lesson_position,
   section_id: section.id,
@@ -435,7 +401,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Using CSS Preprocessors to Save Time',
-  title_url: 'Using CSS Preprocessors to Save Time'.parameterize,
   description: "Learn about preprocessors like SASS which can make your CSS act more like real code... which is a good thing because it'll save you time and gray hairs.",
   position: lesson_position,
   section_id: section.id,
@@ -447,7 +412,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Design Your Own Grid-Based Framework',
-  title_url: 'Design Your Own Grid-Based Framework'.parameterize,
   description: "This final project will require you to apply almost everything you've learned up until now since you'll be building your own version of a grid-based CSS framework.  Luckily you can use it on your projects from here on out!",
   position: lesson_position,
   section_id: section.id,
@@ -461,7 +425,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Conclusion',
-  title_url: 'Conclusion'.parameterize,
   description: "You've found the light at the end of the tunnel.",
   position: lesson_position,
   section_id: section.id,

--- a/db/seeds/06_javascript_course_seeds.rb
+++ b/db/seeds/06_javascript_course_seeds.rb
@@ -11,7 +11,6 @@ lesson_position = 0
 
 course = create_or_update_course(
   title: 'JavaScript',
-  title_url: 'JavaScript'.parameterize,
   description: "Make your websites dynamic and interactive with JavaScript! You'll create features and stand-alone applications. This module includes projects where you will learn how to manipulate the DOM, use object-oriented programming principles, and build single page applications with React.",
   position: course_position
 )
@@ -25,7 +24,6 @@ course = create_or_update_course(
 section_position += 1
 section = create_or_update_section(
   title: 'Introduction',
-  title_url: 'Introduction'.parameterize,
   course_id: course.id,
   position: section_position,
   description: 'Welcome to the JavaScript course!  Start here!'
@@ -34,7 +32,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'How this course will work',
-  title_url: 'How this course will work'.parameterize,
   description: 'How this course will work',
   position: lesson_position,
   section_id: section.id,
@@ -46,7 +43,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'A quick review',
-  title_url: 'A quick review'.parameterize,
   description: 'A quick review',
   position: lesson_position,
   section_id: section.id,
@@ -62,7 +58,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'Organizing your JavaScript Code',
-  title_url: 'Organizing JavaScript'.parameterize,
   course_id: course.id,
   position: section_position,
   description: 'This series digs in to the things you need to write larger and larger applications with JavaScript.  This is where it gets real!'
@@ -71,7 +66,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Introduction',
-  title_url: 'organizing introduction'.parameterize,
   description: 'introduction',
   position: lesson_position,
   section_id: section.id,
@@ -83,7 +77,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Objects and Object Constructors',
-  title_url: 'Objects and Object Constructors'.parameterize,
   description: 'Covers plain old JavaScript objects and object constructors',
   position: lesson_position,
   section_id: section.id,
@@ -95,7 +88,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Library',
-  title_url: 'Library'.parameterize,
   description: 'Library',
   position: lesson_position,
   section_id: section.id,
@@ -109,7 +101,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Factory Functions and the Module Pattern',
-  title_url: 'Factory Functions and the Module Pattern'.parameterize,
   description: 'Factory Functions and the Module Pattern',
   position: lesson_position,
   section_id: section.id,
@@ -121,7 +112,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Tic Tac Toe',
-  title_url: 'Tic Tac Toe'.parameterize,
   description: 'Tic Tac Toe',
   position: lesson_position,
   section_id: section.id,
@@ -135,7 +125,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Classes',
-  title_url: 'JavaScript Classes'.parameterize,
   description: 'Classes',
   position: lesson_position,
   section_id: section.id,
@@ -147,7 +136,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'ES6 Modules',
-  title_url: 'ES6 Modules'.parameterize,
   description: 'ES6 Modules',
   position: lesson_position,
   section_id: section.id,
@@ -159,7 +147,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Restaurant Page',
-  title_url: 'Restaurant Page'.parameterize,
   description: 'Restaurant Page',
   position: lesson_position,
   section_id: section.id,
@@ -173,7 +160,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'OOP Principles',
-  title_url: 'OOP Principles'.parameterize,
   description: 'OOP Principles',
   position: lesson_position,
   section_id: section.id,
@@ -185,7 +171,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Todo List',
-  title_url: 'Todo List'.parameterize,
   description: 'Todo List',
   position: lesson_position,
   section_id: section.id,
@@ -203,7 +188,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'JavaScript in the Real World',
-  title_url: 'JavaScript in the Real World'.parameterize,
   course_id: course.id,
   position: section_position,
   description: "Let's look at a few more practical applications of JavaScript and learn about a few useful tools that are widely used in the industry."
@@ -212,7 +196,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Linting',
-  title_url: 'Linting'.parameterize,
   description: 'Linting',
   position: lesson_position,
   section_id: section.id,
@@ -224,7 +207,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Dynamic User Interface Interactions',
-  title_url: 'User Interface Interactions'.parameterize,
   description: 'UI Interactions',
   position: lesson_position,
   section_id: section.id,
@@ -236,7 +218,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Forms',
-  title_url: 'Forms'.parameterize,
   description: 'Forms',
   position: lesson_position,
   section_id: section.id,
@@ -248,7 +229,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Webpack',
-  title_url: 'Webpack'.parameterize,
   description: 'Webpack',
   position: lesson_position,
   section_id: section.id,
@@ -260,7 +240,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'ES?',
-  title_url: 'ES?'.parameterize,
   description: 'ES?',
   position: lesson_position,
   section_id: section.id,
@@ -276,7 +255,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'Asynchronous JavaScript and APIs',
-  title_url: 'Asynchronous JavaScript'.parameterize,
   course_id: course.id,
   position: section_position,
   description: 'Asynchronous JavaScript'
@@ -285,7 +263,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'JSON',
-  title_url: 'JSON'.parameterize,
   description: 'JSON',
   position: lesson_position,
   section_id: section.id,
@@ -297,7 +274,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Async',
-  title_url: 'Async'.parameterize,
   description: 'Async',
   position: lesson_position,
   section_id: section.id,
@@ -309,7 +285,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Working with APIs',
-  title_url: 'Working with APIs'.parameterize,
   description: 'Working with APIs',
   position: lesson_position,
   section_id: section.id,
@@ -321,7 +296,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Async and Await',
-  title_url: 'Async and Await'.parameterize,
   description: 'Async and Await',
   position: lesson_position,
   section_id: section.id,
@@ -333,7 +307,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Weather App',
-  title_url: 'Weather App'.parameterize,
   description: 'Weather App',
   position: lesson_position,
   section_id: section.id,
@@ -351,7 +324,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'React JS',
-  title_url: 'React JS'.parameterize,
   course_id: course.id,
   position: section_position,
   description: 'In this section you will learn the basics of the most popular frontend framework, React JS.'
@@ -360,7 +332,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'React Introduction',
-  title_url: 'React Introduction'.parameterize,
   description: 'React Introduction',
   position: lesson_position,
   section_id: section.id,
@@ -372,7 +343,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'State and Props',
-  title_url: 'State and Props'.parameterize,
   description: 'State and Props',
   position: lesson_position,
   section_id: section.id,
@@ -384,7 +354,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Handle Inputs and Render Lists',
-  title_url: 'Handle Inputs and Render Lists'.parameterize,
   description: 'Handle Inputs and Render Lists',
   position: lesson_position,
   section_id: section.id,
@@ -396,7 +365,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'CV Application',
-  title_url: 'CV Application'.parameterize,
   description: 'CV Application',
   position: lesson_position,
   section_id: section.id,
@@ -410,7 +378,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Lifecycle Methods',
-  title_url: 'Lifecycle Methods'.parameterize,
   description: 'Lifecycle Methods',
   position: lesson_position,
   section_id: section.id,
@@ -422,7 +389,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Hooks',
-  title_url: 'Hooks'.parameterize,
   description: 'Hooks',
   position: lesson_position,
   section_id: section.id,
@@ -434,7 +400,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Memory Card',
-  title_url: 'Memory Card'.parameterize,
   description: 'Memory Card',
   position: lesson_position,
   section_id: section.id,
@@ -448,7 +413,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Router',
-  title_url: 'Router'.parameterize,
   description: 'Router',
   position: lesson_position,
   section_id: section.id,
@@ -460,7 +424,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Shopping Cart',
-  title_url: 'Shopping Cart'.parameterize,
   description: 'Shopping Cart',
   position: lesson_position,
   section_id: section.id,
@@ -474,7 +437,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Advanced Concepts',
-  title_url: 'Advanced Concepts'.parameterize,
   description: 'Advanced Concepts',
   position: lesson_position,
   section_id: section.id,
@@ -490,7 +452,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'Testing JavaScript',
-  title_url: 'Testing JavaScript'.parameterize,
   course_id: course.id,
   position: section_position,
   description: "Test driven development is an important skill in today's dev world.  This section digs into the details of writing automated JavaScript tests."
@@ -499,7 +460,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Testing Basics',
-  title_url: 'Testing Basics'.parameterize,
   description: 'Testing Basics',
   position: lesson_position,
   section_id: section.id,
@@ -511,7 +471,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Testing Practice',
-  title_url: 'Testing Practice'.parameterize,
   description: 'Testing Practice',
   position: lesson_position,
   section_id: section.id,
@@ -525,7 +484,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'More Testing',
-  title_url: 'More Testing'.parameterize,
   description: 'More Testing',
   position: lesson_position,
   section_id: section.id,
@@ -537,7 +495,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Battleship',
-  title_url: 'Battleship'.parameterize,
   description: 'Battleship',
   position: lesson_position,
   section_id: section.id,
@@ -554,7 +511,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'JavaScript and the Backend',
-  title_url: 'JavaScript and the Backend'.parameterize,
   course_id: course.id,
   position: section_position,
   description: "A real web app needs a back end in order to persist its data and do sensitive operations. Here you'll learn how to use ajax to send data requests to your Rails back end or how to outsource your backend to a Backend-as-a-Service company like Firebase."
@@ -563,7 +519,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Using Ruby on Rails or BaaS For Your Back End',
-  title_url: 'Using Ruby on Rails or BaaS For Your Back End'.parameterize,
   description: "You've got experience working with APIs, now it's time to treat your app like one.",
   position: lesson_position,
   section_id: section.id,
@@ -575,7 +530,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: "Where's Waldo (A Photo Tagging App)",
-  title_url: "Where's Waldo (A Photo Tagging App)".parameterize,
   description: "Pull together everything you've learned so far to create a \"Where's Waldo?\" game.",
   position: lesson_position,
   section_id: section.id,
@@ -593,7 +547,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'Finishing Up with JavaScript',
-  title_url: 'Finishing Up with JavaScript'.parameterize,
   course_id: course.id,
   position: section_position,
   description: "You've learned everything you need and all that remains to do is apply that knowledge to a worthy task. In this section you will be working on your capstone project so you can show off your range of skills."
@@ -602,7 +555,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Final Project',
-  title_url: 'Final Project'.parameterize,
   description: "Tie everything you've learned from every course so far into one project where you'll build your favorite website from scratch.",
   position: lesson_position,
   section_id: section.id,
@@ -616,7 +568,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Conclusion',
-  title_url: 'Conclusion'.parameterize,
   description: 'Well, that was easy, right?',
   position: lesson_position,
   section_id: section.id,

--- a/db/seeds/07_getting_hired_course_seeds.rb
+++ b/db/seeds/07_getting_hired_course_seeds.rb
@@ -10,7 +10,6 @@ lesson_position = 0
 
 course = create_or_update_course(
   title: 'Getting Hired',
-  title_url: 'Getting Hired'.parameterize,
   description: "Web development is a lifelong journey of learning and growth. Continue that journey on a professional development team! You'll learn where to find jobs, how to do great interviews, and the best strategies to launch your career.",
   position: course_position,
 )
@@ -22,7 +21,6 @@ course = create_or_update_course(
 section_position += 1
 section = create_or_update_section(
   title: 'Preparing for Your Job Search',
-  title_url: 'Preparing for Your Job Search'.parameterize,
   course_id: course.id,
   position: section_position,
   description: 'Your job search begins long before you send out the first application, so be sure to adequately prepare by laying out a strategy and being honest with yourself about your goals, needs and expectations.'
@@ -31,7 +29,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'How This Course Will Work',
-  title_url: 'How This Course Will Work'.parameterize,
   description: "This course is a bit different than the others so it's worth getting acquainted with how it will work.",
   position: lesson_position,
   section_id: section.id,
@@ -43,7 +40,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Strategy',
-  title_url: 'Strategy'.parameterize,
   description: "You will need to develop a coherent strategy for how you'll approach the process or risk wasting time.",
   position: lesson_position,
   section_id: section.id,
@@ -55,7 +51,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'It Starts with YOU',
-  title_url: 'It Starts with YOU'.parameterize,
   description: "You won't get hired anywhere you want to be unless you have an honest conversation with yourself.",
   position: lesson_position,
   section_id: section.id,
@@ -67,7 +62,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'What Companies Want',
-  title_url: 'What Companies Want'.parameterize,
   description: 'An important step to selling yourself is realizing what the companies doing the hiring really want.',
   position: lesson_position,
   section_id: section.id,
@@ -79,7 +73,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'What You Can Do To Prepare',
-  title_url: 'What You Can Do To Prepare'.parameterize,
   description: 'There are many things you can do ahead of time to prepare for your job hunt that will greatly help your odds of getting hired.',
   position: lesson_position,
   section_id: section.id,
@@ -91,7 +84,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Building Your Personal Website',
-  title_url: 'Building Your Personal Website'.parameterize,
   description: "Nothing shows off your work quite as effectively as a website you've built yourself. Just be careful not to go overboard with it.",
   position: lesson_position,
   section_id: section.id,
@@ -109,7 +101,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'Applying to and Interviewing for Jobs',
-  title_url: 'Applying to and Interviewing for Jobs'.parameterize,
   course_id: course.id,
   position: section_position,
   description: "This is an odds game, so you've got to structure your plan and focus on highest probability approaches and targets.  In this section we'll cover how the process typically works and the best way to increase your odds of success. Go get 'em."
@@ -118,7 +109,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Collecting Job Leads',
-  title_url: 'Collecting Job Leads'.parameterize,
   description: 'Your first step to finding that perfect job is knowing where to look and collecting good leads.',
   position: lesson_position,
   section_id: section.id,
@@ -130,7 +120,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Qualifying Job Leads',
-  title_url: 'Qualifying Job Leads'.parameterize,
   description: 'You will need to have a rigorous process for evaluating leads or you will end up wasting your time.',
   position: lesson_position,
   section_id: section.id,
@@ -142,7 +131,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Building Your Resume',
-  title_url: 'Building Your Resume'.parameterize,
   description: 'Even in this day and age, the resume is still the primary way people get information about you.',
   position: lesson_position,
   section_id: section.id,
@@ -156,7 +144,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Applying for Web Development Jobs',
-  title_url: 'Applying for Web Development Jobs'.parameterize,
   description: 'Some tips for increasing your odds during the application process itself.',
   position: lesson_position,
   section_id: section.id,
@@ -168,7 +155,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Preparing to Interview and Interviewing',
-  title_url: 'Preparing to Interview and Interviewing'.parameterize,
   description: "Interviewing is annoying and difficult but you'll have to do it.  We'll help point you to the best resources for preparing yourself.",
   position: lesson_position,
   section_id: section.id,
@@ -180,7 +166,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Handling a Job Offer',
-  title_url: 'Handling a Job Offer'.parameterize,
   description: 'Woohoo! Now what??',
   position: lesson_position,
   section_id: section.id,
@@ -192,7 +177,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Conclusion',
-  title_url: 'Conclusion'.parameterize,
   description: 'Wrapping up The Odin Project and what you can do to have a strong career.',
   position: lesson_position,
   section_id: section.id,

--- a/db/seeds/08_node_js_course_seeds.rb
+++ b/db/seeds/08_node_js_course_seeds.rb
@@ -11,7 +11,6 @@ lesson_position = 0
 
 course = create_or_update_course(
   title: 'NodeJS',
-  title_url: 'NodeJS'.parameterize,
   description: "Take your JavaScript skills to the server-side! Learn how to fully craft your site's backend using Express, the most popular back-end JavaScript framework! You will also learn how to use a non-relational database, MongoDB.",
   position: course_position
 )
@@ -23,7 +22,6 @@ course = create_or_update_course(
 section_position += 1
 section = create_or_update_section(
   title: 'Introduction to NodeJS',
-  title_url: 'Introduction to NodeJS'.parameterize,
   course_id: course.id,
   position: section_position,
   description: "In this section you'll learn what NodeJS is and get your first taste of writing server-side JavaScript."
@@ -32,7 +30,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Introduction: What is NodeJs',
-  title_url: 'What is NodeJS'.parameterize,
   description: 'Lets take a look at what Node is, and what it means to write code for a server.',
   position: lesson_position,
   section_id: section.id,
@@ -44,7 +41,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Getting Started',
-  title_url: 'Getting Started'.parameterize,
   description: "You'll go through a basic Node tutorial and write some real server-side code.",
   position: lesson_position,
   section_id: section.id,
@@ -56,7 +52,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Basic Informational Site',
-  title_url: 'Basic Site'.parameterize,
   description: "Use what you've learned to build a very simple website skeleton",
   position: lesson_position,
   section_id: section.id,
@@ -74,7 +69,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'Express & MongoDB',
-  title_url: 'Express'.parameterize,
   course_id: course.id,
   position: section_position,
   description: 'Here we finally get to Express, the most popular back-end JavaScript framework, and MongoDB, a non-relational database frequently paired with Node.'
@@ -83,7 +77,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Introduction to Express',
-  title_url: 'Introduction to Express'.parameterize,
   description: 'We look at Express for the first time and learn what it does for us',
   position: lesson_position,
   section_id: section.id,
@@ -95,7 +88,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Express 101',
-  title_url: 'Express 101'.parameterize,
   description: "It's time to dive into the main tutorial and actually write some code using the express-generator",
   position: lesson_position,
   section_id: section.id,
@@ -107,7 +99,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Express 102: CRUD and MVC',
-  title_url: 'Express 102'.parameterize,
   description: 'Here you learn how to set up a database in your Express projects',
   position: lesson_position,
   section_id: section.id,
@@ -119,7 +110,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Preparing for Deployment',
-  title_url: 'Preparing for Deployment'.parameterize,
   description: 'Get setup to use Heroku to deploy our web applications',
   position: lesson_position,
   section_id: section.id,
@@ -131,7 +121,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Mini Message Board',
-  title_url: 'Mini-message-board'.parameterize,
   description: 'We take a break from the main tutorial and create a simple message board.',
   position: lesson_position,
   section_id: section.id,
@@ -145,7 +134,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Express 103: Routes and Controllers',
-  title_url: 'Express 103'.parameterize,
   description: 'We learn how to use the express router and use the MVC pattern to set up controllers for our Library tutorial',
   position: lesson_position,
   section_id: section.id,
@@ -157,7 +145,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Express 104: View Templates',
-  title_url: 'Express 104'.parameterize,
   description: 'This lesson shows you how to set up view templates.',
   position: lesson_position,
   section_id: section.id,
@@ -169,7 +156,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Express 105: Forms and Deployment',
-  title_url: 'Express 105".parameterize',
   description: 'Here we learn how to use forms to create the data-entry portions of the Library Tutorial and finish the project by learning about deployment',
   position: lesson_position,
   section_id: section.id,
@@ -183,7 +169,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Inventory Application',
-  title_url: 'project: inventory application'.parameterize,
   description: "We put together everything you've learned so far by building an inventory management app for an imaginary store.",
   position: lesson_position,
   section_id: section.id,
@@ -201,7 +186,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'Authentication',
-  title_url: 'Express Authentication'.parameterize,
   course_id: course.id,
   position: section_position,
   description: 'We learn how to create authentication strategies that allow us to securely sign users into our applications.'
@@ -210,7 +194,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Authentication Basics',
-  title_url: 'express authentication basics'.parameterize,
   description: 'Learn the basics of authentication with passportJS and bcrypt',
   position: lesson_position,
   section_id: section.id,
@@ -222,7 +205,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Security Configuration',
-  title_url: 'Security Configuration'.parameterize,
   description: 'We learn how to use configuration modules to secure our apps',
   position: lesson_position,
   section_id: section.id,
@@ -234,7 +216,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Members Only',
-  title_url: 'project members only'.parameterize,
   description: "We create a private online clubhouse to practice using the auth strategies we've learned",
   position: lesson_position,
   section_id: section.id,
@@ -252,7 +233,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'APIs',
-  title_url: 'express APIs'.parameterize,
   course_id: course.id,
   position: section_position,
   description: "We use what we've learned to create API-only backends that can serve JSON to any front-end we want."
@@ -261,7 +241,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'API basics',
-  title_url: 'express api basics'.parameterize,
   description: 'You already know most of what you need to create robust APIs. This lesson fills in the blanks for you.',
   position: lesson_position,
   section_id: section.id,
@@ -273,7 +252,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'API Security',
-  title_url: 'Express API Security'.parameterize,
   description: 'We learn how to secure our APIs using JSON web tokens',
   position: lesson_position,
   section_id: section.id,
@@ -285,7 +263,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Blog API',
-  title_url: 'project express blog api'.parameterize,
   description: 'You create the backend for a blog and then plug it into multiple frontend applications',
   position: lesson_position,
   section_id: section.id,
@@ -303,7 +280,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'Testing Express',
-  title_url: 'testing express'.parameterize,
   course_id: course.id,
   position: section_position,
   description: 'We learn what it takes to write tests for our Express projects'
@@ -312,7 +288,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Testing Routes and Controllers',
-  title_url: 'testing routes and controllers'.parameterize,
   description: 'We learn how to use Supertest to write tests for our routes and controllers',
   position: lesson_position,
   section_id: section.id,
@@ -324,7 +299,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Testing database operations',
-  title_url: 'testing database operations'.parameterize,
   description: 'we learn how to use mongodb-memory-server to write tests for routes that manipulate a database',
   position: lesson_position,
   section_id: section.id,
@@ -340,7 +314,6 @@ create_or_update_lesson(
 section_position += 1
 section = create_or_update_section(
   title: 'FINAL PROJECT',
-  title_url: 'nodeJS final project'.parameterize,
   course_id: course.id,
   position: section_position,
   description: "This is it!  Create your final project and prove to the world you're a node/express master"
@@ -349,7 +322,6 @@ section = create_or_update_section(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Odin-Book',
-  title_url: 'project odin-book'.parameterize,
   description: "You'll use everything you've learned so far to replicate Facebook!",
   position: lesson_position,
   section_id: section.id,
@@ -363,7 +335,6 @@ create_or_update_lesson(
 lesson_position += 1
 create_or_update_lesson(
   title: 'Conclusion',
-  title_url: 'Conclusion'.parameterize,
   description: 'Wow you\'ve gotten to the last lesson!',
   position: lesson_position,
   section_id: section.id,

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :course do
     sequence(:title) { |n| "test course#{n}" }
-    title_url { title.parameterize }
     sequence(:position) { |n| n }
   end
 end

--- a/spec/factories/sections.rb
+++ b/spec/factories/sections.rb
@@ -2,7 +2,6 @@ FactoryBot.define do
   factory :section do
     course
     sequence(:title) { |n| "test section#{n}" }
-    title_url { title.parameterize }
     sequence(:position) { |n| n }
   end
 end


### PR DESCRIPTION
Because:
* We don't need to be storing this attribute as rails route helpers will generate urls using the title for us.

This commit:
* Removes the title_url attribute from the lessons, sections and courses tables.
* Removes setting the title_url in the seeds files.
* Updates the few instances we were using title_url to use rails route helpers instead.