### PR TITLE
Chore: Remove Repo Column From Lessons Table

### DIFF
--- a/app/services/lesson_content_importer.rb
+++ b/app/services/lesson_content_importer.rb
@@ -46,15 +46,11 @@ class LessonContentImporter
   end
 
   def github_response
-    Octokit.contents(repo, path: lesson.url)
+    Octokit.contents('theodinproject/curriculum', path: lesson.url)
   end
 
   def log_error(message)
     Rails.logger.error "Failed to import '#{lesson.title}' message: #{message}"
     false
-  end
-
-  def repo
-    "theodinproject/#{lesson.repo}"
   end
 end

--- a/db/migrate/20210306162015_remove_repo_column_from_lessons.rb
+++ b/db/migrate/20210306162015_remove_repo_column_from_lessons.rb
@@ -1,0 +1,5 @@
+class RemoveRepoColumnFromLessons < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :lessons, :repo
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_05_002818) do
+ActiveRecord::Schema.define(version: 2021_03_06_162015) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -90,7 +90,6 @@ ActiveRecord::Schema.define(version: 2021_03_05_002818) do
     t.datetime "updated_at", null: false
     t.text "content"
     t.string "slug"
-    t.string "repo"
     t.boolean "accepts_submission", default: false, null: false
     t.boolean "has_live_preview", default: false, null: false
     t.boolean "choose_path_lesson", default: false, null: false

--- a/db/seeds/01_foundations_seeds.rb
+++ b/db/seeds/01_foundations_seeds.rb
@@ -35,7 +35,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/foundations/introduction/how_this_course_will_work.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -46,7 +45,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/foundations/introduction/introduction_to_web_development.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -57,7 +55,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/foundations/introduction/motivation_and_mindset.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -68,7 +65,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/foundations/introduction/join_the_odin_community.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -79,7 +75,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/foundations/introduction/how_does_the_web_work.md',
-  repo: 'curriculum'
 )
 
 # ++++++++++++++++++++
@@ -102,7 +97,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/foundations/installations/installation_overview.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -113,7 +107,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/foundations/installations/prerequisites.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -124,7 +117,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/foundations/installations/text_editors.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -135,7 +127,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/foundations/installations/command_line_basics.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -146,7 +137,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/foundations/installations/setting_up_git.md',
-  repo: 'curriculum'
 )
 
 # +++++++++++
@@ -169,7 +159,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/foundations/git_basics/introduction_to_git.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -180,7 +169,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/foundations/git_basics/git_basics.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -191,7 +179,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/foundations/git_basics/project_practicing_git_basics.md',
-  repo: 'curriculum',
   accepts_submission: false,
   has_live_preview: false
 )
@@ -216,7 +203,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/foundations/the_front_end/introduction_to_the_front_end.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -227,7 +213,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/foundations/the_front_end/html_css_basics.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -238,7 +223,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/foundations/the_front_end/developer_tools.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -249,7 +233,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/foundations/the_front_end/project_html_css.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -274,7 +257,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/foundations/javascript_basics/fundamentals-1.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -285,7 +267,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/foundations/javascript_basics/fundamentals-2.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -296,7 +277,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/foundations/javascript_basics/developer_tools_2.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -307,7 +287,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/foundations/javascript_basics/fundamentals-3.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -317,7 +296,6 @@ create_or_update_lesson(
   position: lesson_position,
   description: 'In this lesson we will explore how to approach solving programming problems.',
   url: '/foundations/javascript_basics/problem_solving.md',
-  repo: 'curriculum',
   is_project: false
 )
 
@@ -329,7 +307,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/foundations/javascript_basics/project_rock_paper_scissors.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -342,7 +319,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/foundations/javascript_basics/clean_code.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -353,7 +329,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/foundations/javascript_basics/fundamentals-4.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -364,7 +339,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/foundations/javascript_basics/DOM-manipulation.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -375,7 +349,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/foundations/javascript_basics/project_etch_a_sketch.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -388,7 +361,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/foundations/javascript_basics/fundamentals-5.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -399,7 +371,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/foundations/javascript_basics/project_calculator.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -424,7 +395,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/foundations/the_back_end/introduction_to_the_backend_lesson.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -435,7 +405,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/foundations/the_back_end/introduction_to_frameworks.md',
-  repo: 'curriculum'
 )
 
 # +++++++++++
@@ -458,6 +427,5 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/foundations/tying_it_all_together/conclusion.md',
-  repo: 'curriculum',
   choose_path_lesson: true
 )

--- a/db/seeds/02_ruby_course_seeds.rb
+++ b/db/seeds/02_ruby_course_seeds.rb
@@ -35,7 +35,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/ruby_programming/introduction/how_this_course_will_work.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -46,7 +45,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/ruby_programming/introduction/installing_ruby.md',
-  repo: 'curriculum'
 )
 
 # +++++++++++
@@ -69,7 +67,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/ruby_programming/basic_ruby/basic_data_types.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -80,7 +77,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/ruby_programming/basic_ruby/variables.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -91,7 +87,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/ruby_programming/basic_ruby/input_and_output.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -102,7 +97,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/ruby_programming/basic_ruby/conditional_logic.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -113,7 +107,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/ruby_programming/basic_ruby/loops.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -124,7 +117,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/ruby_programming/basic_ruby/arrays.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -135,7 +127,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/ruby_programming/basic_ruby/hashes.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -146,7 +137,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/ruby_programming/basic_ruby/methods.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -157,7 +147,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/ruby_programming/basic_ruby/basic_enumerable_methods.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -168,7 +157,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/ruby_programming/basic_ruby/predicate_enumerable_methods.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -179,7 +167,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/ruby_programming/basic_ruby/debugging.md',
-  repo: 'curriculum'
 )
 
 # +++++++++++
@@ -202,7 +189,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/ruby_programming/basic_ruby_projects/caesar_cipher.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: false
 )
@@ -215,7 +201,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/ruby_programming/basic_ruby_projects/sub_strings.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: false
 )
@@ -228,7 +213,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/ruby_programming/basic_ruby_projects/stock_picker.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: false
 )
@@ -241,7 +225,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/ruby_programming/basic_ruby_projects/bubble_sort.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: false
 )
@@ -266,7 +249,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/ruby_programming/object_oriented_programming_basics/lesson_oop.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -277,7 +259,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/ruby_programming/object_oriented_programming_basics/project_tic_tac_toe.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -290,7 +271,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/ruby_programming/object_oriented_programming_basics/project_mastermind.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -315,7 +295,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/ruby_programming/files_and_serialization/lesson_serialization.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -326,7 +305,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/ruby_programming/files_and_serialization/project_event_manager.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: false
 )
@@ -339,7 +317,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/ruby_programming/files_and_serialization/project_file_io.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -364,7 +341,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/ruby_programming/computer_science/lesson_a_very_brief_intro_to_cs.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -375,7 +351,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/ruby_programming/computer_science/lesson_recursion.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -386,7 +361,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/ruby_programming/computer_science/project_recursion.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: false
 )
@@ -399,7 +373,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/ruby_programming/computer_science/lesson_common_data_structures_algorithms.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -410,7 +383,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/ruby_programming/computer_science/project_linked_lists.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: false
 )
@@ -423,7 +395,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/ruby_programming/computer_science/project_binary_search_trees.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: false
 )
@@ -436,7 +407,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/ruby_programming/computer_science/project_knights_travails.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: false
 )
@@ -461,7 +431,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/ruby_programming/testing_with_rspec/test_driven_development.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -472,7 +441,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/ruby_programming/testing_with_rspec/introduction_to_rspec.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -483,7 +451,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/ruby_programming/testing_with_rspec/project_testing_your_ruby_code.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -508,7 +475,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/ruby_programming/git/lesson_a_deeper_look_at_git.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -519,7 +485,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/ruby_programming/git/lesson_using_git_in_the_real_world.md',
-  repo: 'curriculum'
 )
 
 # +++++++++++
@@ -542,7 +507,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/ruby_programming/conclusion/project_ruby_final.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -555,5 +519,4 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/ruby_programming/conclusion/lesson_conclusion.md',
-  repo: 'curriculum'
 )

--- a/db/seeds/03_database_course_seeds.rb
+++ b/db/seeds/03_database_course_seeds.rb
@@ -34,7 +34,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/databases/database_basics_lesson.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -45,7 +44,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/databases/databases.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -56,7 +54,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/databases/project_databases.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: false
 )

--- a/db/seeds/04_rails_course_seeds.rb
+++ b/db/seeds/04_rails_course_seeds.rb
@@ -35,7 +35,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/rails_programming/introduction/introduction.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -46,7 +45,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/rails_programming/introduction/preparing_for_deployment.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -57,7 +55,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/rails_programming/introduction/installing_rails.md',
-  repo: 'curriculum',
   accepts_submission: false,
   has_live_preview: false,
 )
@@ -82,7 +79,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/rails_programming/rails_basics/web_refresher.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -93,7 +89,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/rails_programming/rails_basics/routing.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -104,7 +99,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/rails_programming/rails_basics/controller_basics.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -115,7 +109,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/rails_programming/rails_basics/views.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -126,7 +119,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/rails_programming/rails_basics/asset_pipeline.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -137,7 +129,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/rails_programming/rails_basics/webpacker.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -148,7 +139,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/rails_programming/rails_basics/deployment.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -159,7 +149,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/rails_programming/rails_basics/project_blog_app.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true,
 )
@@ -184,7 +173,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/rails_programming/databases_and_activerecord/active_record_basics.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -195,7 +183,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/rails_programming/databases_and_activerecord/project_ar_basics.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: false
 )
@@ -220,7 +207,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/rails_programming/forms_and_authentication/form_basics.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -231,7 +217,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/rails_programming/forms_and_authentication/project_forms.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: false
 )
@@ -244,7 +229,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/rails_programming/forms_and_authentication/sessions_cookies_authentication.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -255,7 +239,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/rails_programming/forms_and_authentication/project_auth.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -280,7 +263,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/rails_programming/advanced_forms_and_activerecord/active_record_queries.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -291,7 +273,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/rails_programming/advanced_forms_and_activerecord/active_record_associations.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -302,7 +283,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/rails_programming/advanced_forms_and_activerecord/project_associations.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -315,7 +295,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/rails_programming/advanced_forms_and_activerecord/active_record_callbacks.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -326,7 +305,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/rails_programming/advanced_forms_and_activerecord/forms_advanced.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -337,7 +315,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/rails_programming/advanced_forms_and_activerecord/project_forms_advanced.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -362,7 +339,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/rails_programming/apis/api_basics.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -373,7 +349,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/rails_programming/apis/api_interfacing.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -384,7 +359,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/rails_programming/apis/project_kittens_api.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -397,7 +371,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/rails_programming/apis/project_using_an_api.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -422,7 +395,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/rails_programming/mailers_advanced_topics/mailers.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -433,7 +405,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/rails_programming/mailers_advanced_topics/project_mailers.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -446,7 +417,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/rails_programming/mailers_advanced_topics/advanced_topics.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -457,7 +427,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/rails_programming/mailers_advanced_topics/websockets_and_actioncable.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -468,7 +437,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/rails_programming/mailers_advanced_topics/project_final.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -481,5 +449,4 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/rails_programming/mailers_advanced_topics/conclusion.md',
-  repo: 'curriculum'
 )

--- a/db/seeds/05_html_css_course_seeds.rb
+++ b/db/seeds/05_html_css_course_seeds.rb
@@ -35,7 +35,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/html_css/introduction.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -46,7 +45,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/html_css/html5_basics.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -57,7 +55,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/html_css/links.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -68,7 +65,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/html_css/images.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -79,7 +75,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/html_css/project_media.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -92,7 +87,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/html_css/new_html5.md',
-  repo: 'curriculum'
 )
 
 # +++++++++++
@@ -115,7 +109,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/html_css/tables.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -126,7 +119,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/html_css/lists.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -137,7 +129,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/html_css/html_forms.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -148,7 +139,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/html_css/project_html_forms.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -173,7 +163,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/html_css/css_basics.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -184,7 +173,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/html_css/box_model.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -195,7 +183,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/html_css/floats_positioning.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -206,7 +193,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/html_css/flexbox_layout.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -217,7 +203,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/html_css/grid_layout.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -228,7 +213,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/html_css/project_positioning.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -241,7 +225,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/html_css/best_practices.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -252,7 +235,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/html_css/backgrounds.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -263,7 +245,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/html_css/project_backgrounds.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -288,7 +269,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/html_css/design_ux.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -299,7 +279,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/html_css/typography.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -310,7 +289,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/html_css/project_design.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -335,7 +313,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/html_css/responsive_design.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -346,7 +323,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/html_css/project_responsive.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -359,7 +335,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/html_css/css_frameworks.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -370,7 +345,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/html_css/project_bootstrap.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -395,7 +369,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/html_css/stylings.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -406,7 +379,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/html_css/preprocessors.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -417,7 +389,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/html_css/project_css_frameworks.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -430,5 +401,4 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/html_css/conclusion.md',
-  repo: 'curriculum'
 )

--- a/db/seeds/06_javascript_course_seeds.rb
+++ b/db/seeds/06_javascript_course_seeds.rb
@@ -37,7 +37,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/javascript/introduction/introduction.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -48,7 +47,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/javascript/introduction/js101-review.md',
-  repo: 'curriculum'
 )
 
 # +++++++++++
@@ -71,7 +69,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/javascript/organizing-js/organizing-introduction.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -82,7 +79,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/javascript/organizing-js/objects-constructors.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -93,7 +89,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/javascript/organizing-js/library-project.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -106,7 +101,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/javascript/organizing-js/factory-functions.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -117,7 +111,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/javascript/organizing-js/tic-tac-toe-project.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -130,7 +123,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/javascript/organizing-js/classes.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -141,7 +133,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/javascript/organizing-js/es6-modules.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -152,7 +143,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/javascript/organizing-js/restaurant-project.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -165,7 +155,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/javascript/organizing-js/oop-concepts.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -176,7 +165,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/javascript/organizing-js/todo-project.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -201,7 +189,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/javascript/js-in-the-real-world/linting.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -212,7 +199,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/javascript/js-in-the-real-world/ui-Interactions.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -223,7 +209,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/javascript/js-in-the-real-world/forms.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -234,7 +219,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/javascript/js-in-the-real-world/webpack.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -245,7 +229,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/javascript/js-in-the-real-world/es6-features.md',
-  repo: 'curriculum'
 )
 
 # +++++++++++
@@ -268,7 +251,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/javascript/async-apis/json.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -279,7 +261,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/javascript/async-apis/promises-async.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -290,7 +271,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/javascript/async-apis/APIs.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -301,7 +281,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/javascript/async-apis/async-await.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -312,7 +291,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/javascript/async-apis/project.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -337,7 +315,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/javascript/react-js/react-introduction.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -348,7 +325,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/javascript/react-js/state-and-props.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -359,7 +335,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/javascript/react-js/inputs-and-lists.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -370,7 +345,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/javascript/react-js/project-cv.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -383,7 +357,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/javascript/react-js/lifecycle-methods.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -394,7 +367,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/javascript/react-js/hooks.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -405,7 +377,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/javascript/react-js/project-memory-card.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -418,7 +389,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/javascript/react-js/router.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -429,7 +399,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/javascript/react-js/project-shopping-chart.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -442,7 +411,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/javascript/react-js/advanced-concepts.md',
-  repo: 'curriculum',
 )
 
 # +++++++++++
@@ -465,7 +433,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/javascript/testing/testing-1.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -476,7 +443,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/javascript/testing/testing-practice.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -489,7 +455,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/javascript/testing/testing-2.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -500,7 +465,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/javascript/testing/battleship-project.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -524,7 +488,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/javascript/js-rails/rails_backend.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -535,7 +498,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/javascript/js-rails/project_rails_backend.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true,
 )
@@ -560,7 +522,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/javascript/finishing-up/project_final_js.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -573,5 +534,4 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/javascript/finishing-up/conclusion.md',
-  repo: 'curriculum'
 )

--- a/db/seeds/07_getting_hired_course_seeds.rb
+++ b/db/seeds/07_getting_hired_course_seeds.rb
@@ -34,7 +34,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/getting_hired/introduction.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -45,7 +44,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/getting_hired/strategy.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -56,7 +54,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/getting_hired/starts_with_you.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -67,7 +64,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/getting_hired/what_companies_want.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -78,7 +74,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/getting_hired/preparation.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -89,7 +84,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/getting_hired/project_portfolio.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -114,7 +108,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/getting_hired/collect_leads.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -125,7 +118,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/getting_hired/qualify_leads.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -136,7 +128,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/getting_hired/project_resume.md',
-  repo: 'curriculum',
   accepts_submission: false,
   has_live_preview: false
 )
@@ -149,7 +140,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/getting_hired/applying.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -160,7 +150,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/getting_hired/preparing_to_interview.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -171,7 +160,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/getting_hired/handling_an_offer.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -182,5 +170,4 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/getting_hired/conclusion.md',
-  repo: 'curriculum'
 )

--- a/db/seeds/08_node_js_course_seeds.rb
+++ b/db/seeds/08_node_js_course_seeds.rb
@@ -35,7 +35,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/nodeJS/getting-started/Introduction.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -46,7 +45,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/nodeJS/getting-started/Getting-Started.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -57,7 +55,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/nodeJS/getting-started/Getting-Started-Project.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -82,7 +79,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/nodeJS/express-basics/Express-Introduction.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -93,7 +89,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/nodeJS/express-basics/Express-Lesson-1.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -104,7 +99,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/nodeJS/express-basics/Express-Lesson-2.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -115,7 +109,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/rails_programming/introduction/preparing_for_deployment.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -126,7 +119,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/nodeJS/express-basics/Express-Mini-Message-Board.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -139,7 +131,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/nodeJS/express-basics/Express-Lesson-3.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -150,7 +141,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/nodeJS/express-basics/Express-Lesson-4.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -161,7 +151,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/nodeJS/express-basics/Express-Lesson-5.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -174,7 +163,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/nodeJS/express-basics/Express-Inventory-Application.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -199,7 +187,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/nodeJS/authentication/Authentication.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -210,7 +197,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/nodeJS/authentication/Security-Configuration.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -221,7 +207,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/nodeJS/authentication/Members-Only.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -246,7 +231,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/nodeJS/APIs/APIs.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -257,7 +241,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/nodeJS/APIs/API-Security.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -268,7 +251,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/nodeJS/APIs/Blog-Project.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -293,7 +275,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/nodeJS/testing/Testing.md',
-  repo: 'curriculum'
 )
 
 lesson_position += 1
@@ -304,7 +285,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/nodeJS/testing/Testing-Mongo.md',
-  repo: 'curriculum'
 )
 
 # +++++++++++
@@ -327,7 +307,6 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: true,
   url: '/nodeJS/Odin-Book.md',
-  repo: 'curriculum',
   accepts_submission: true,
   has_live_preview: true
 )
@@ -340,5 +319,4 @@ create_or_update_lesson(
   section_id: section.id,
   is_project: false,
   url: '/nodeJS/conclusion.md',
-  repo: 'curriculum'
 )

--- a/spec/factories/lessons.rb
+++ b/spec/factories/lessons.rb
@@ -6,6 +6,5 @@ FactoryBot.define do
     sequence(:position) { |n| n }
     url { '/lesson_course/lesson_title.md' }
     content { 'content' }
-    repo { 'curriculum' }
   end
 end

--- a/spec/services/lesson_content_importer_spec.rb
+++ b/spec/services/lesson_content_importer_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe LessonContentImporter do
       'Lesson',
       content: lesson_content,
       title: 'Ruby Basics',
-      repo: 'ruby_course',
       url: '/ruby_basics/variables'
     )
   end
@@ -26,7 +25,7 @@ RSpec.describe LessonContentImporter do
 
   before do
     allow(Octokit).to receive(:contents)
-      .with('theodinproject/ruby_course', path: '/ruby_basics/variables')
+      .with('theodinproject/curriculum', path: '/ruby_basics/variables')
       .and_return(lesson_content_from_github)
 
     allow(Base64).to receive_message_chain(:decode64, :force_encoding)
@@ -70,7 +69,7 @@ RSpec.describe LessonContentImporter do
     context 'when there is an error with octokit' do
       before do
         allow(Octokit).to receive(:contents)
-          .with('theodinproject/ruby_course', path: '/ruby_basics/variables')
+          .with('theodinproject/curriculum', path: '/ruby_basics/variables')
           .and_raise(
             Octokit::Error.new(
               method: 'GET',
@@ -92,7 +91,6 @@ RSpec.describe LessonContentImporter do
       let(:lesson) do
         Lesson.new(
           title: 'Ruby Basics',
-          repo: 'ruby_course',
           url: '/ruby_basics/variables',
           section: Section.new
         )

--- a/spec/tasks/curriculum_spec.rb
+++ b/spec/tasks/curriculum_spec.rb
@@ -13,7 +13,6 @@ describe ':curriculum' do
         :lesson,
         url: '/README.md',
         content: nil,
-        repo: 'curriculum',
       )
     end
 


### PR DESCRIPTION
Because:
* In the past we had the curriculum split up into different repos "javascript_course", "ruby_course" etc. We have since moved to a single repository so the repo column on every lesson is now redundant.

This Commit:
* Updates lesson content importer service to use "curriculum" as the repo by default.
* Removes the repo attribute from all lessons in the seeds files.