### PR TITLE
Chore: Fix Url Validator Deprecation Warning

### DIFF
--- a/app/validators/url_validator.rb
+++ b/app/validators/url_validator.rb
@@ -1,6 +1,7 @@
 class UrlValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    record.errors[attribute] << (options[:message] || 'Must be a valid URL') unless url_valid?(value)
+    message = options[:message] || 'Must be a valid URL'
+    record.errors.add(attribute, message) unless url_valid?(value)
   end
 
   # rubocop:disable Style/RescueModifier


### PR DESCRIPTION
Because:
* Using the shovel `<<` operator to add an error to an ActiveModel::Errors message array is deprecated.
* A warning was appearing everytime we ran the tests.