### PR TITLE
Fix: "Completed!" Button bkg to comply with WCAG 2.0

### DIFF
--- a/app/assets/stylesheets/settings.scss
+++ b/app/assets/stylesheets/settings.scss
@@ -38,4 +38,4 @@ $button-primary: #6abfc3;
 $button-seconday: #cc9543;
 $github-brand-color: $text-primary;
 $google-brand-color: #4d90fe;
-$button-disabled: rgba(216, 216, 216, 0.8);
+$button-disabled: #4a4a4a


### PR DESCRIPTION
To comply with the contrast ratio requirement mentioned in WCAG 2.0 (min. 4.5:1) I propose a change to the background color of the "Completed!" button located in each lesson. 
I came across this as I was unable to read the "Completed!" text on the current button color. Kindly merge into the main branch!