### PR TITLE
Chore: Use Identifier UUID Columns to Find Paths, Courses, Sections a…

### DIFF
--- a/db/migrate/20210309212304_unique_constraints_for_identifier_uuid.rb
+++ b/db/migrate/20210309212304_unique_constraints_for_identifier_uuid.rb
@@ -1,0 +1,15 @@
+class UniqueConstraintsForIdentifierUuid < ActiveRecord::Migration[6.1]
+  def up
+    add_index :paths, :identifier_uuid, unique: true
+    add_index :courses, :identifier_uuid, unique: true
+    add_index :sections, :identifier_uuid, unique: true
+    add_index :lessons, %i[identifier_uuid section_id], unique: true
+  end
+
+  def down
+    remove_index :paths, :identifier_uuid, unique: true
+    remove_index :courses, :identifier_uuid, unique: true
+    remove_index :sections, :identifier_uuid, unique: true
+    remove_index :lessons, %i[identifier_uuid section_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_08_211447) do
+ActiveRecord::Schema.define(version: 2021_03_09_212304) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 2021_03_08_211447) do
     t.integer "position", null: false
     t.string "slug"
     t.string "identifier_uuid", default: "", null: false
+    t.index ["identifier_uuid"], name: "index_courses_on_identifier_uuid", unique: true
     t.index ["slug"], name: "index_courses_on_slug"
   end
 
@@ -95,6 +96,7 @@ ActiveRecord::Schema.define(version: 2021_03_08_211447) do
     t.boolean "has_live_preview", default: false, null: false
     t.boolean "choose_path_lesson", default: false, null: false
     t.string "identifier_uuid", default: "", null: false
+    t.index ["identifier_uuid", "section_id"], name: "index_lessons_on_identifier_uuid_and_section_id", unique: true
     t.index ["position"], name: "index_lessons_on_position"
     t.index ["slug", "section_id"], name: "index_lessons_on_slug_and_section_id", unique: true
     t.index ["url"], name: "index_lessons_on_url"
@@ -139,6 +141,7 @@ ActiveRecord::Schema.define(version: 2021_03_08_211447) do
     t.string "slug"
     t.boolean "default_path", default: false, null: false
     t.string "identifier_uuid", default: "", null: false
+    t.index ["identifier_uuid"], name: "index_paths_on_identifier_uuid", unique: true
     t.index ["slug"], name: "index_paths_on_slug", unique: true
   end
 
@@ -173,6 +176,7 @@ ActiveRecord::Schema.define(version: 2021_03_08_211447) do
     t.text "description"
     t.string "identifier_uuid", default: "", null: false
     t.index ["course_id"], name: "index_sections_on_course_id"
+    t.index ["identifier_uuid"], name: "index_sections_on_identifier_uuid", unique: true
     t.index ["position"], name: "index_sections_on_position"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,9 +9,8 @@
 # courses/sections/lessons, since that's currently what's used to uniquely
 # identify them!
 
-# rubocop:disable Metrics/AbcSize
 def create_or_update_path(path_attrs)
-  path = Path.where(title: path_attrs[:title]).first
+  path = Path.find_by(identifier_uuid: path_attrs.fetch(:identifier_uuid))
 
   if path.nil?
     path = Path.create!(path_attrs)
@@ -27,7 +26,7 @@ def create_or_update_path(path_attrs)
 end
 
 def create_or_update_course(course_attrs)
-  course = Course.where(title: course_attrs[:title]).first
+  course = Course.find_by(identifier_uuid: course_attrs.fetch(:identifier_uuid))
 
   if course.nil?
     course = Course.create!(course_attrs)
@@ -43,7 +42,7 @@ def create_or_update_course(course_attrs)
 end
 
 def create_or_update_section(section_attrs)
-  section = Section.where(title: section_attrs[:title], course_id: section_attrs[:course_id]).first
+  section = Section.find_by(identifier_uuid: section_attrs.fetch(:identifier_uuid))
 
   if section.nil?
     section = Section.create!(section_attrs)
@@ -59,7 +58,7 @@ def create_or_update_section(section_attrs)
 end
 
 def create_or_update_lesson(lesson_attrs)
-  lesson = Lesson.where(title: lesson_attrs[:title], section_id: lesson_attrs[:section_id]).first
+  lesson = Lesson.find_by(identifier_uuid: lesson_attrs.fetch(:identifier_uuid))
 
   if lesson.nil?
     lesson = Lesson.create!(lesson_attrs)
@@ -73,8 +72,6 @@ def create_or_update_lesson(lesson_attrs)
 
   lesson
 end
-# rubocop:enable Metrics/AbcSize
-
 load './db/seeds/01_foundations_seeds.rb'
 load './db/seeds/02_ruby_course_seeds.rb'
 load './db/seeds/03_database_course_seeds.rb'

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :course do
     sequence(:title) { |n| "test course#{n}" }
     sequence(:position) { |n| n }
+    identifier_uuid { SecureRandom.uuid }
   end
 end

--- a/spec/factories/lessons.rb
+++ b/spec/factories/lessons.rb
@@ -6,5 +6,6 @@ FactoryBot.define do
     sequence(:position) { |n| n }
     url { '/lesson_course/lesson_title.md' }
     content { 'content' }
+    identifier_uuid { SecureRandom.uuid }
   end
 end

--- a/spec/factories/paths.rb
+++ b/spec/factories/paths.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     sequence(:title) { |n| "test path#{n}" }
     sequence(:position) { |n| n }
     description { 'A Path' }
+    identifier_uuid { SecureRandom.uuid }
   end
 end

--- a/spec/factories/sections.rb
+++ b/spec/factories/sections.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     course
     sequence(:title) { |n| "test section#{n}" }
     sequence(:position) { |n| n }
+    identifier_uuid { SecureRandom.uuid }
   end
 end


### PR DESCRIPTION
…nd Lessons in Seeds File

Because:
* It will allow us to change an entities title without duplicating it.

This commit:
* Update create_or_update methods in the seeds file to use identifier_uuid in the finders.
* Add unique contraints to all the identifier_uuid columns so they are safer to work with.