### PR TITLE
Create a FlagNotification class

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ApplicationJob < ActiveJob::Base
+end

--- a/app/notifications/flag_notification.rb
+++ b/app/notifications/flag_notification.rb
@@ -1,0 +1,5 @@
+class FlagNotification < Noticed::Base
+  deliver_by :database
+
+  param :flag
+end

--- a/spec/notifications/flag_notification_spec.rb
+++ b/spec/notifications/flag_notification_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe FlagNotification do
+  subject(:flag_notification) { described_class }
+  let(:flag) { create(:flag) }
+  let(:recipient) { create(:user) }
+
+  describe 'database delivery' do
+    it 'allows a valid FlagNotification to be saved' do
+      expect { flag_notification.with(flag: flag).deliver(recipient) }.to change { Notification.count }.by(1)
+    end
+  end
+
+  describe 'param' do
+    it 'requires the flag attribute to be set in the params attribute' do
+      expect { flag_notification.with({}).deliver(recipient) }.to raise_error(Noticed::ValidationError)
+    end
+  end
+end

--- a/spec/notifications/flag_notification_spec.rb
+++ b/spec/notifications/flag_notification_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe FlagNotification do
 
   describe 'database delivery' do
     it 'allows a valid FlagNotification to be saved' do
-      expect { flag_notification.with(flag: flag).deliver(recipient) }.to change { Notification.count }.by(1)
+      expect { flag_notification.with(flag: flag).deliver(recipient) }.to change { Notification.count }.from(0).to(1)
     end
   end
 


### PR DESCRIPTION
Because: we need to notify a user when their project submission has been
deleted

This commit: Creates a FlagNotification class that can be used to save
flag specific notifications to the notifications table

The default JobApplication class has also been created as the noticed
gem relies on it.