### PR TITLE
Feature: Display a Link to the Lesson on Admin Flags

### DIFF
--- a/app/admin/flags.rb
+++ b/app/admin/flags.rb
@@ -31,6 +31,9 @@ ActiveAdmin.register Flag do
       row :submission_ower do
         flag.project_submission.user.username
       end
+      row :lesson do
+        link_to flag.project_submission.lesson.title, flag.project_submission.lesson, target: '_blank'
+      end
       row :repo_url do
         link_to flag.project_submission.repo_url, flag.project_submission.repo_url, target: '_blank'
       end


### PR DESCRIPTION
Because:
* We should provide an easy way to view the lesson the flagged submission belongs to.