### PR TITLE
Chore: Denormalize Lesson Completions Table

### DIFF
--- a/app/controllers/lesson_completions_controller.rb
+++ b/app/controllers/lesson_completions_controller.rb
@@ -1,13 +1,20 @@
 class LessonCompletionsController < ApplicationController
   before_action :authenticate_user!
 
+  # rubocop: disable Metrics/AbcSize
   def create
-    current_user.lesson_completions.create(lesson_id: lesson.id)
+    current_user.lesson_completions.create(
+      lesson_id: lesson.id,
+      lesson_idenfier_uuid: lesson.identifier_uuid,
+      course_id: lesson.course.id,
+      path_id: current_user.path.id,
+    )
 
     if redirect_url.present?
       redirect_to redirect_url
     end
   end
+  # rubocop: enable Metrics/AbcSize
 
   def destroy
     lesson_completion = current_user.lesson_completions.find_by_lesson_id(lesson.id)

--- a/app/views/courses/course/_lesson_completion_button.html.erb
+++ b/app/views/courses/course/_lesson_completion_button.html.erb
@@ -2,7 +2,7 @@
   <%= link_to lesson_completions_path(lesson), method: :delete, remote: true do %>
     <i class="far fa-check-circle section-lessons__item__icon section-lessons__item__icon--completed"></i>
   <% end %>
-<% else %>
+<% elsif lesson.course.paths.include?(current_user.path) %>
   <%= link_to lesson_completions_path(lesson), method: :post, remote: true do %>
     <i class="far fa-check-circle section-lessons__item__icon"></i>
   <% end %>

--- a/app/views/lessons/_lesson_completion_state.html.erb
+++ b/app/views/lessons/_lesson_completion_state.html.erb
@@ -2,6 +2,8 @@
   <%= link_to lesson_completions_path(lesson), method: :delete, remote: true, class: 'button button--complete lesson-button-group__item lesson-button lesson-button--complete', title: 'Mark lesson incomplete', data: { disable_with: "Submitting..." } do %>
     <i class="lesson-button__icon far fa-check-circle" aria-hidden="true"></i>
   <% end %>
+<% elsif !lesson.course.paths.include?(current_user.path) %>
+  <%= link_to 'Switch Paths', paths_url, class: 'button button--primary lesson-button-group__item lesson-button', title: 'View Paths' %>
 <% elsif lesson.choose_path_lesson? %>
   <%= link_to lesson_completions_path(lesson, redirect_url: paths_url), remote: true, method: :post, class: 'button button--primary lesson-button-group__item lesson-button', title: 'Mark lesson complete', data: { disable_with: "Submitting..." } do %>
     <i class="lesson-button__icon far fa-check-circle" aria-hidden="true"></i>Complete and Choose Path

--- a/db/migrate/20210309225335_denormalize_lesson_completions.rb
+++ b/db/migrate/20210309225335_denormalize_lesson_completions.rb
@@ -1,0 +1,21 @@
+class DenormalizeLessonCompletions < ActiveRecord::Migration[6.1]
+  def up
+    add_column :lesson_completions, :lesson_idenfier_uuid, :string, null: false, default: ''
+    add_column :lesson_completions, :course_id, :integer
+    add_column :lesson_completions, :path_id, :integer
+
+    add_index :lesson_completions, :lesson_idenfier_uuid
+    add_index :lesson_completions, :course_id
+    add_index :lesson_completions, :path_id
+  end
+
+  def down
+    remove_column :lesson_completions, :lesson_idenfier_uuid
+    remove_column :lesson_completions, :course_id
+    remove_column :lesson_completions, :path_id
+
+    remove_index :lesson_completions, :lesson_idenfier_uuid
+    remove_index :lesson_completions, :course_id
+    remove_index :lesson_completions, :path_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_09_212304) do
+ActiveRecord::Schema.define(version: 2021_03_09_225335) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -77,7 +77,13 @@ ActiveRecord::Schema.define(version: 2021_03_09_212304) do
     t.integer "student_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string "lesson_idenfier_uuid", default: "", null: false
+    t.integer "course_id"
+    t.integer "path_id"
+    t.index ["course_id"], name: "index_lesson_completions_on_course_id"
     t.index ["lesson_id", "student_id"], name: "index_lesson_completions_on_lesson_id_and_student_id", unique: true
+    t.index ["lesson_idenfier_uuid"], name: "index_lesson_completions_on_lesson_idenfier_uuid"
+    t.index ["path_id"], name: "index_lesson_completions_on_path_id"
     t.index ["student_id"], name: "index_lesson_completions_on_student_id"
   end
 


### PR DESCRIPTION
Because:
* We will need the course and path ids to map lesson completions to the new lessons that will be created when we stop allowing shared courses between paths in the database. This is needed to allow an interlacing structure of lessons throughout many different courses that we are aiming for.

* These ids can also be used to scope the users completions to courses and paths, which will make it easy and performant to calculate the users progress through a course or path.

This commit:
* Adds lesson_identifier_uuid, course_id and path_id columns to the lesson_completions table.
* Stores these values when new lesson completions are created - older records will be backfilled with data migrations in the next few days.
* Disallow users to mark lessons as completed on paths they are not enrolled in - this behaviour will be reverted when we move over to the new structure. But its needed until then so we don't end up with wrong lesson, course and path combinations for lesson completions.