### PR TITLE
Chore: Backfill lesson_identifier_uuids, course_ids and path_ids on L…

### DIFF
--- a/app/controllers/lesson_completions_controller.rb
+++ b/app/controllers/lesson_completions_controller.rb
@@ -5,7 +5,7 @@ class LessonCompletionsController < ApplicationController
   def create
     current_user.lesson_completions.create(
       lesson_id: lesson.id,
-      lesson_idenfier_uuid: lesson.identifier_uuid,
+      lesson_identifier_uuid: lesson.identifier_uuid,
       course_id: lesson.course.id,
       path_id: current_user.path.id,
     )

--- a/db/migrate/20210311200356_rename_lesson_completions_lesson_uuid.rb
+++ b/db/migrate/20210311200356_rename_lesson_completions_lesson_uuid.rb
@@ -1,0 +1,5 @@
+class RenameLessonCompletionsLessonUuid < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :lesson_completions, :lesson_idenfier_uuid, :lesson_identifier_uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_09_225335) do
+ActiveRecord::Schema.define(version: 2021_03_11_200356) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -77,12 +77,12 @@ ActiveRecord::Schema.define(version: 2021_03_09_225335) do
     t.integer "student_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string "lesson_idenfier_uuid", default: "", null: false
+    t.string "lesson_identifier_uuid", default: "", null: false
     t.integer "course_id"
     t.integer "path_id"
     t.index ["course_id"], name: "index_lesson_completions_on_course_id"
     t.index ["lesson_id", "student_id"], name: "index_lesson_completions_on_lesson_id_and_student_id", unique: true
-    t.index ["lesson_idenfier_uuid"], name: "index_lesson_completions_on_lesson_idenfier_uuid"
+    t.index ["lesson_identifier_uuid"], name: "index_lesson_completions_on_lesson_identifier_uuid"
     t.index ["path_id"], name: "index_lesson_completions_on_path_id"
     t.index ["student_id"], name: "index_lesson_completions_on_student_id"
   end

--- a/lib/tasks/data_migrations/backfill_course_ids.rake
+++ b/lib/tasks/data_migrations/backfill_course_ids.rake
@@ -1,0 +1,22 @@
+# rubocop:disable all
+namespace :data_migrations do
+  desc 'backfill course ids on lesson_completions'
+  task backfill_course_ids: :environment do
+    puts 'Back Filling course ids'
+
+    sql = %(
+      UPDATE lesson_completions
+      SET course_id = courses.id
+      FROM lessons
+      JOIN sections ON lessons.section_id = sections.id
+      JOIN courses ON sections.course_id = courses.id
+      WHERE lesson_completions.lesson_id = lessons.id
+      AND lesson_completions.course_id IS NULL;
+    )
+    puts sql
+
+    ActiveRecord::Base.connection.execute(sql)
+
+    puts 'Done'
+  end
+end

--- a/lib/tasks/data_migrations/backfill_foundation_path_ids.rake
+++ b/lib/tasks/data_migrations/backfill_foundation_path_ids.rake
@@ -1,0 +1,18 @@
+# rubocop:disable all
+namespace :data_migrations do
+  desc 'backfill foundations path ids on lesson_completions'
+  task backfill_foundation_path_ids: :environment do
+    puts 'Back Filling Foundation path ids'
+
+    sql = %(
+      UPDATE lesson_completions
+      SET path_id = 4
+      WHERE course_id = 30
+    )
+    puts sql
+
+    ActiveRecord::Base.connection.execute(sql)
+
+    puts 'Done'
+  end
+end

--- a/lib/tasks/data_migrations/backfill_identifier_uuids.rake
+++ b/lib/tasks/data_migrations/backfill_identifier_uuids.rake
@@ -1,0 +1,19 @@
+# rubocop:disable all
+namespace :data_migrations do
+  desc 'backfill lesson_identifier_uuids on lesson_completions'
+  task backfill_identifier_uuids: :environment do
+    puts 'Back Filling lesson identifier uuids'
+
+    sql = %(
+      UPDATE lesson_completions
+      SET lesson_identifier_uuid = lessons.identifier_uuid
+      FROM lessons
+      WHERE lesson_completions.lesson_id = lessons.id
+    )
+    puts sql
+
+    ActiveRecord::Base.connection.execute(sql)
+
+    puts 'Done'
+  end
+end

--- a/lib/tasks/data_migrations/backfill_js_path_ids.rake
+++ b/lib/tasks/data_migrations/backfill_js_path_ids.rake
@@ -1,0 +1,18 @@
+# rubocop:disable all
+namespace :data_migrations do
+  desc 'backfill js path ids on lesson_completions'
+  task backfill_js_path_ids: :environment do
+    puts 'Back Filling JS path ids'
+
+    sql = %(
+      UPDATE lesson_completions
+      SET path_id = 2
+      WHERE course_id = 41
+    )
+    puts sql
+
+    ActiveRecord::Base.connection.execute(sql)
+
+    puts 'Done'
+  end
+end

--- a/lib/tasks/data_migrations/backfill_ruby_path_ids.rake
+++ b/lib/tasks/data_migrations/backfill_ruby_path_ids.rake
@@ -1,0 +1,20 @@
+# rubocop:disable all
+namespace :data_migrations do
+  desc 'backfill ruby path ids on lesson_completions'
+  task backfill_ruby_path_ids: :environment do
+    puts 'Back Filling Ruby path ids'
+
+    sql = %(
+      UPDATE lesson_completions
+      SET path_id = 1
+      WHERE course_id = 31
+      OR course_id = 32
+      OR course_id = 40;
+    )
+    puts sql
+
+    ActiveRecord::Base.connection.execute(sql)
+
+    puts 'Done'
+  end
+end

--- a/lib/tasks/data_migrations/backfill_shared_courses_path_ids.rake
+++ b/lib/tasks/data_migrations/backfill_shared_courses_path_ids.rake
@@ -1,0 +1,73 @@
+# rubocop:disable all
+namespace :data_migrations do
+  desc 'backfill shared courses path ids on lesson_completions'
+  task backfill_shared_courses_path_ids: :environment do
+    puts 'Back Filling Getting hired path ids'
+
+    sql = %(
+      UPDATE lesson_completions
+      SET path_id = users.path_id
+      FROM users
+      WHERE lesson_completions.course_id = 38
+      AND lesson_completions.student_id = users.id
+      AND lesson_completions.path_id IS NULL;
+    )
+    puts sql
+    ActiveRecord::Base.connection.execute(sql)
+
+    sql = %(
+      UPDATE lesson_completions
+      SET path_id = 2
+      WHERE course_id = 38
+      AND path_id = 4;
+    )
+    puts sql
+    ActiveRecord::Base.connection.execute(sql)
+
+    puts 'Back Filling JS course path ids'
+
+    sql = %(
+      UPDATE lesson_completions
+      SET path_id = users.path_id
+      FROM users
+      WHERE lesson_completions.course_id = 39
+      AND lesson_completions.student_id = users.id
+      AND lesson_completions.path_id IS NULL;
+    )
+    puts sql
+    ActiveRecord::Base.connection.execute(sql)
+
+    sql = %(
+      UPDATE lesson_completions
+      SET path_id = 2
+      WHERE course_id = 39
+      AND path_id = 4;
+    )
+    puts sql
+    ActiveRecord::Base.connection.execute(sql)
+
+    puts 'Back Filling HTML course path ids'
+
+    sql = %(
+      UPDATE lesson_completions
+      SET path_id = users.path_id
+      FROM users
+      WHERE lesson_completions.course_id = 36
+      AND lesson_completions.student_id = users.id
+      AND lesson_completions.path_id IS NULL;
+    )
+    puts sql
+    ActiveRecord::Base.connection.execute(sql)
+
+    sql = %(
+      UPDATE lesson_completions
+      SET path_id = 2
+      WHERE course_id = 36
+      AND path_id = 4;
+    )
+    puts sql
+    ActiveRecord::Base.connection.execute(sql)
+
+    puts 'Done'
+  end
+end


### PR DESCRIPTION
…esson Completions Table.

Because:
* We have started to store these ids against new lesson completions and should backfill the legacy lesson completions to ensure data integrity.

This commit:
* Adds a data migration for backfilling lesson_identifier_uuids.
* Adds a data migration for backfilling course_ids.
* Adds data migrations for backfilling path_ids.
  * The path_id of lessons completions for lessons in courses that are in more than one path are set to the path the user is currently enrolled in.
  * If the user is enrolled in the foundations path any lesson completions for shared lessons have been set to the Full Stack JS Course.