### PR TITLE
Fix Naked Domain Not working

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem 'webpacker'
 
 group :production do
   gem 'rails_12factor', '~> 0.0.3'
-  gem 'skylight', '~> 5.0.0.beta5'
+  # gem 'skylight', '~> 5.0.0.beta5'
 end
 
 group :development, :test, :docker do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -454,8 +454,6 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.2)
-    skylight (5.0.0.beta5)
-      activesupport (>= 5.2.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -558,7 +556,6 @@ DEPENDENCIES
   shoulda-matchers
   sidekiq
   simplecov
-  skylight (~> 5.0.0.beta5)
   sprockets (~> 3.7.2)
   timecop
   turbolinks


### PR DESCRIPTION
Because:
The url without www is not working right now and we are seeing lots of skylight related logs.