### PR TITLE
Chore: Rename Development Database to theodinproject_development

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -12,7 +12,7 @@ default: &default
 
 development: &development
   <<: *default
-  database: <%= ENV['POSTGRES_DEV_DB'] || 'theodinproject' %>
+  database: theodinproject_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,10 +16,10 @@ services:
       - "3000:3000"
     depends_on:
       - db
-    environment: 
+    environment:
       POSTGRES_USERNAME: postgres
       POSTGRES_PASSWORD: theodinproject
-      POSTGRES_DEV_DB: theodinproject
+      POSTGRES_DEV_DB: theodinproject_development
       POSTGRES_HOST: db
 
 volumes:


### PR DESCRIPTION
Because:
* It is convention to append the environment name to the db name.