### PR TITLE
Chore: Run Seeds Task During CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,61 +17,59 @@ executors:
           POSTGRES_DB: theodinproject_test
     working_directory: ~/theodinproject
 
-jobs:
-  tests:
-    executor: rails-executor
+commands:
+  build-app:
+    description: Building app
     steps:
       - checkout
 
-      # Install bundler
       - run: gem install bundler
-
-      # Restore Cached Dependencies
       - restore_cache:
           name: Restore bundle cache
           key: theodinproject-bundle-{{ checksum "Gemfile.lock" }}
-
       - restore_cache:
           name: Restore yarn cache
           key: theodinproject-yarn-{{ checksum "yarn.lock" }}
-
-      # Bundle install dependencies
       - run: bundle install --path vendor/bundle
-
-      # yarn install dependencies
       - run: yarn install
-
-      # Cache Dependencies
       - save_cache:
           name: Store bundle cache
           key: theodinproject-bundle-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
-
       - save_cache:
           name: Store yarn cache
           key: theodinproject-yarn-{{ checksum "yarn.lock" }}
           paths:
             - ~/.yarn-cache
-
-      # Wait for DB
       - run: dockerize -wait tcp://localhost:5432 -timeout 1m
-
-      # Setup the database
       - run: bundle exec rake db:schema:load
 
-      # run linters
+jobs:
+  tests:
+    executor: rails-executor
+    steps:
+      - build-app
+      - run: yarn test
+      - run: bundle exec rspec
+  linters:
+    executor: rails-executor
+    steps:
+      - build-app
       - run: bundle exec rubocop
       - run: yarn run eslint
-
-      # Run JS Tests
-      - run: yarn test
-
-      # Run rspec
-      - run: bundle exec rspec
+  seeds:
+    executor: rails-executor
+    steps:
+      - build-app
+      - run:
+          name: Seeds
+          command: bin/rails db:seed
 
 workflows:
   version: 2
   build:
     jobs:
       - tests
+      - linters
+      - seeds


### PR DESCRIPTION
Because:
* It would be helpful for the reviewer to see if the seeds file runs without any issues during the CI build.

This commit:
* Runs the seed task in a CI job
* Moves linters into their own jobs.