### PR TITLE
Fix: Lesson Completion Buttons Sometimes Cannot Find The Lesson.

### DIFF
--- a/app/views/courses/course/_lesson_completion_button.html.erb
+++ b/app/views/courses/course/_lesson_completion_button.html.erb
@@ -1,5 +1,5 @@
 <% if current_user.completed?(lesson) %>
-  <%= link_to lesson_completions_path(lesson), method: :delete, remote: true do %>
+  <%= link_to lesson_completions_path(lesson.id), method: :delete, remote: true do %>
     <i class="far fa-check-circle section-lessons__item__icon section-lessons__item__icon--completed"></i>
   <% end %>
 <% else %>

--- a/app/views/lessons/_lesson_completion_state.html.erb
+++ b/app/views/lessons/_lesson_completion_state.html.erb
@@ -1,13 +1,13 @@
 <% if current_user.completed?(lesson) %>
-  <%= link_to lesson_completions_path(lesson), method: :delete, remote: true, class: 'button button--complete lesson-button-group__item lesson-button lesson-button--complete', title: 'Mark lesson incomplete', data: { disable_with: "Submitting..." } do %>
+  <%= link_to lesson_completions_path(lesson.id), method: :delete, remote: true, class: 'button button--complete lesson-button-group__item lesson-button lesson-button--complete', title: 'Mark lesson incomplete', data: { disable_with: "Submitting..." } do %>
     <i class="lesson-button__icon far fa-check-circle" aria-hidden="true"></i>
   <% end %>
 <% elsif lesson.choose_path_lesson? %>
-  <%= link_to lesson_completions_path(lesson, redirect_url: paths_url), remote: true, method: :post, class: 'button button--primary lesson-button-group__item lesson-button', title: 'Mark lesson complete', data: { disable_with: "Submitting..." } do %>
+  <%= link_to lesson_completions_path(lesson.id, redirect_url: paths_url), remote: true, method: :post, class: 'button button--primary lesson-button-group__item lesson-button', title: 'Mark lesson complete', data: { disable_with: "Submitting..." } do %>
     <i class="lesson-button__icon far fa-check-circle" aria-hidden="true"></i>Complete and Choose Path
   <% end %>
 <% else %>
-  <%= link_to lesson_completions_path(lesson), remote: true, method: :post, class: 'button button--primary lesson-button-group__item lesson-button', title: 'Mark lesson complete', data: { disable_with: "Submitting..." } do %>
+  <%= link_to lesson_completions_path(lesson.id), remote: true, method: :post, class: 'button button--primary lesson-button-group__item lesson-button', title: 'Mark lesson complete', data: { disable_with: "Submitting..." } do %>
     <i class="lesson-button__icon far fa-check-circle" aria-hidden="true"></i>Complete
   <% end %>
 <% end %>


### PR DESCRIPTION
Because:
* It was using the friendly id and relying on the friendly id finder which seems to be a bit flaky.

This commit:
* Passes the lesson id to the lesson completions controller every-time instead.