### PR TITLE
Fix: All Submissions Url

### DIFF
--- a/app/controllers/lessons/project_submissions_controller.rb
+++ b/app/controllers/lessons/project_submissions_controller.rb
@@ -17,7 +17,7 @@ module Lessons
     end
 
     def set_lesson
-      @lesson = Lesson.friendly.find(params[:lesson_id])
+      @lesson = Lesson.find(params[:lesson_id])
     end
 
     def check_if_project_submitable

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -35,7 +35,7 @@
             course: @lesson.course.as_json,
             lesson: @lesson.as_json,
             submissions: @project_submissions.map { |submission| ProjectSubmissionSerializer.as_json(submission, current_user) },
-            allSubmissionsPath: lesson_project_submissions_path(@lesson),
+            allSubmissionsPath: lesson_project_submissions_path(@lesson.id),
             userSubmission: user_submission(current_user, @lesson)
           }
         ) %>


### PR DESCRIPTION
Because:
* It was using the title of the lesson instead of the lessons id to find it, many lessons can have the same title.