### PR TITLE
Chore: Run Seed and Import Lesson Content Tasks After Release

### DIFF
--- a/app.json
+++ b/app.json
@@ -25,9 +25,6 @@
           "description": "This is a staging environment",
           "value": "true"
         }
-      },
-      "scripts": {
-        "postdeploy": "bundle exec rails db:seed curriculum:update_content"
       }
     }
   }

--- a/bin/heroku_release
+++ b/bin/heroku_release
@@ -19,9 +19,21 @@ fi
 if [ "$schema_version" -eq "0" ]; then
   printf "\n⏳${YELLOW}   [Release Phase]: Loading the database schema.${NO_COLOR}\n"
   bin/rails db:schema:load
+
+  printf "\n⏳${YELLOW}   [Release Phase]: Running database seeds.${NO_COLOR}\n"
+  bin/rails db:seed
+
+  printf "\n⏳${YELLOW}   [Release Phase]: Importing lesson content.${NO_COLOR}\n"
+  bin/rails curriculum:content:import
 else
   printf "\n⏳${YELLOW}   [Release Phase]: Running database migrations.${NO_COLOR}\n"
   bin/rails db:migrate
+
+  printf "\n⏳${YELLOW}   [Release Phase]: Running database seeds.${NO_COLOR}\n"
+  bin/rails db:seed
+
+  printf "\n⏳${YELLOW}   [Release Phase]: Importing lesson content.${NO_COLOR}\n"
+  bin/rails curriculum:content:import
 fi
 
 printf "\n🎉${GREEN}   [Release Phase]: Database is up to date.${NO_COLOR}\n"


### PR DESCRIPTION
Because:
* We no longer need to manually run the seeds task now that the seeds task correctly updates changed seeds and deletes removed seeds from the db.

This commit:
* Adds running the seeds task to the heroku release phase script.
* Adds running the content import task to the heroku release phase script.
* Removes the post deploy script for review apps as the release script now handles these tasks.