### PR TITLE
Chore: Add Lessons Foreign Key to Lesson Completions

### DIFF
--- a/db/migrate/20210326125315_add_lesson_foreign_key_to_lesson_completions.rb
+++ b/db/migrate/20210326125315_add_lesson_foreign_key_to_lesson_completions.rb
@@ -1,0 +1,5 @@
+class AddLessonForeignKeyToLessonCompletions < ActiveRecord::Migration[6.1]
+  def change
+    add_foreign_key :lesson_completions, :lessons, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_13_093419) do
+ActiveRecord::Schema.define(version: 2021_03_26_125315) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Because:
* It will ensure lesson completions are properly deleted when a lesson is removed.