### PR TITLE
Feature: Add Last Updated Link to Home Page

### DIFF
--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -10,6 +10,8 @@ class Lesson < ApplicationRecord
   has_many :lesson_completions
   has_many :completing_users, through: :lesson_completions, source: :student
 
+  scope :most_recent_updated_at, -> { maximum(:updated_at) }
+
   validates :position, presence: true
 
   def type

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -2,8 +2,12 @@
   <div class="hero gradient">
     <header>
       <h1 class="accent hero__main-heading"> Your Career in Web Development Starts Here </h1>
-      <p class="secondary hero__sub-heading"> Our full stack curriculum is free and supported by a passionate open source community.</p>
-        <%= link_to 'View Full Curriculum', paths_url,  class: 'button button--primary' %>
+      <div class="secondary hero__sub-heading">
+        <p class="push-down">Our full stack curriculum is free and supported by a passionate open source community.</p>
+        <%= link_to "Last Curriculum Update: #{time_ago_in_words(Lesson.most_recent_updated_at)} ago", github_link("curriculum/commits"), target: :_blank %>
+      </div>
+
+      <%= link_to 'View Full Curriculum', paths_url,  class: 'button button--primary' %>
     </header>
     <%= image_tag 'home-isometric.svg', class: 'hero__image', alt: 'home-page-banner' %>
   </div>

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -11,6 +11,24 @@ RSpec.describe Lesson do
 
   it { is_expected.to validate_presence_of(:position) }
 
+  describe '.most_recent_updated_at' do
+    before do
+      Timecop.freeze(Time.utc(2021, 4, 14))
+    end
+
+    after do
+      Timecop.return
+    end
+
+    it 'returns the most recently updated_at time stamp' do
+      create(:lesson, updated_at: 2.weeks.ago)
+      create(:lesson, updated_at: 1.week.ago)
+      create(:lesson, updated_at: Time.utc(2021, 4, 10, 15))
+
+      expect(described_class.most_recent_updated_at).to eql(Time.utc(2021, 4, 10, 15))
+    end
+  end
+
   describe '#position_in_section' do
     let(:section) { create(:section) }
     let(:first_lesson) { create(:lesson, position: 1, section: section) }


### PR DESCRIPTION
Because:
* Students often ask if the curriculum is up to date.

This commit:
* Adds a link to the latest commits on the curriculum.
* The link has the latest lesson updated_at time stamp as its label.
![Screenshot 2021-04-14 at 00 19 27](https://user-images.githubusercontent.com/7963776/114633697-f13aa500-9cb8-11eb-82ab-d12344140a1e.png)

