### PR TITLE
Chore: Set Up Sentry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,8 @@ gem 'react-rails'
 gem 'ruby-progressbar', '~> 1.11.0'
 gem 'sass-rails', '~> 6.0'
 gem 'seed-fu', '~> 2.3.9'
+gem 'sentry-rails', '~> 4.3.4'
+gem 'sentry-ruby', '~> 4.3.2'
 gem 'sidekiq'
 gem 'sprockets', '~> 3.7.2'
 gem 'turbolinks'
@@ -41,7 +43,6 @@ gem 'webpacker'
 
 group :production do
   gem 'rails_12factor', '~> 0.0.3'
-  # gem 'skylight', '~> 5.0.0.beta5'
 end
 
 group :development, :test, :docker do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -443,6 +443,16 @@ GEM
       activesupport (>= 3.1)
     select2-rails (4.0.13)
     semantic_range (2.3.0)
+    sentry-rails (4.3.4)
+      railties (>= 5.0)
+      sentry-ruby-core (~> 4.3.0)
+    sentry-ruby (4.3.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      faraday (>= 1.0)
+      sentry-ruby-core (= 4.3.2)
+    sentry-ruby-core (4.3.2)
+      concurrent-ruby
+      faraday
     shoulda-matchers (4.5.1)
       activesupport (>= 4.2.0)
     sidekiq (6.2.1)
@@ -556,6 +566,8 @@ DEPENDENCIES
   ruby-progressbar (~> 1.11.0)
   sass-rails (~> 6.0)
   seed-fu (~> 2.3.9)
+  sentry-rails (~> 4.3.4)
+  sentry-ruby (~> 4.3.2)
   shoulda-matchers
   sidekiq
   simplecov

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,13 @@
+Sentry.init do |config|
+  config.dsn = ENV['SENTRY_DSN']
+  config.breadcrumbs_logger = [:active_support_logger]
+
+  config.enabled_environments = %w[production]
+
+  filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
+  config.before_send = lambda { |event, _|
+    filter.filter(event.to_hash)
+  }
+
+  config.send_default_pii = true
+end


### PR DESCRIPTION
Because:
* We currently use NewRelic for error tracking but that has been limited and not very accessible.

This commit:
* Adds Sentry to the app.