### PR TITLE
Chore: Remove Warnings

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,2 @@
 --color
---require spec_helper
+--require rails_helper

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,8 +12,7 @@ AllCops:
     - 'bin/*'
     - 'node_modules/**/*'
     - db/schema.rb
-
-
+  NewCops: enable
 
 Layout/LineLength:
   Max: 120

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,7 +42,7 @@ class User < ApplicationRecord
   end
 
   def inactive_message
-    !banned? ? super : :banned
+    banned? ? :banned : super
   end
 
   def dismissed_flags

--- a/app/services/lesson_duration.rb
+++ b/app/services/lesson_duration.rb
@@ -18,7 +18,7 @@ class LessonDuration
 
   # rubocop:disable Style/RescueModifier
   def average_duration
-    durations.reduce(0) { |sum, duration| sum + duration } / durations.size rescue 0
+    durations.sum / durations.size rescue 0
   end
   # rubocop:enable Style/RescueModifier
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-require 'cancan/matchers'
-
-describe Ability do
-end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,0 @@
-RSpec.configure do |config|
-end


### PR DESCRIPTION
Because:
* We were getting quite a few warnings about adding new cops to our Rubocop.yml file and the warning list grew everytime we bumped Rubocop.

This commit:
* Enables all new cops to get rid of the warnings now and in the future.