### PR TITLE
Chore: Set Sentry User

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
   protect_from_forgery with: :exception
+  before_action :set_sentry_user, if: :current_user
 
   rescue_from ActiveRecord::RecordNotFound, with: :not_found_error
 
@@ -36,6 +37,10 @@ class ApplicationController < ActionController::Base
   end
 
   private
+
+  def set_sentry_user
+    Sentry.set_user(id: current_user.id, email: current_user.email)
+  end
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:username])


### PR DESCRIPTION
Because:
* Providing details about the users errors are occurring for will help us diagnose the issues quicker.