### PR TITLE
Chore: Capture JavaScript Exceptions in Sentry

### DIFF
--- a/app/javascript/packs/error_tracking.js
+++ b/app/javascript/packs/error_tracking.js
@@ -1,0 +1,18 @@
+import * as Sentry from '@sentry/browser';
+
+const {
+  SENTRY_DSN, currentUserLoggedIn, currentUserId, currentUserEmail,
+} = window;
+
+Sentry.init({ dsn: SENTRY_DSN, environment: 'production' });
+
+Sentry.configureScope((scope) => {
+  if (currentUserLoggedIn) {
+    scope.setUser({
+      id: currentUserId,
+      email: currentUserEmail,
+    });
+  }
+});
+
+window.Sentry = Sentry;

--- a/app/views/layouts/_error_tracking.html.erb
+++ b/app/views/layouts/_error_tracking.html.erb
@@ -1,0 +1,14 @@
+
+  <% if Rails.env.production? %>
+    <script type='text/javascript'>
+      window.SENTRY_DSN = "<%= ENV['SENTRY_DSN'] %>"
+      window.currentUserLoggedIn = "<%= user_signed_in? %>"
+
+      <% if defined?(current_user) && current_user.present? %>
+        window.currentUserId = "<%= current_user.id %>"
+        window.currentUserEmail = "<%= current_user.email %>"
+      <% end %>
+    </script>
+
+    <%= javascript_pack_tag 'error_tracking' %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,5 +12,6 @@
     <%= render 'shared/sidecar' %>
     <%= render 'shared/ga' %>
     <%= render 'shared/fb' %>
+    <%= render 'layouts/error_tracking' %>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@hookform/resolvers": "^0.1.1",
     "@rails/ujs": "^6.1.3",
     "@rails/webpacker": "5.2.1",
+    "@sentry/browser": "^6.2.5",
     "axios": "^0.21.1",
     "babel-plugin-prismjs": "^2.0.1",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1215,6 +1215,58 @@
     webpack-cli "^3.3.12"
     webpack-sources "^1.4.3"
 
+"@sentry/browser@^6.2.5":
+  version "6.2.5"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-6.2.5.tgz#35e259e16521d26f348a06b31eb495e0033111d6"
+  integrity sha512-nlvaE+D7oaj4MxoY9ikw+krQDOjftnDYJQnOwOraXPk7KYM6YwmkakLuE+x/AkaH3FQVTQF330VAa9d6SWETlA==
+  dependencies:
+    "@sentry/core" "6.2.5"
+    "@sentry/types" "6.2.5"
+    "@sentry/utils" "6.2.5"
+    tslib "^1.9.3"
+
+"@sentry/core@6.2.5":
+  version "6.2.5"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.2.5.tgz#e75093f8598becc0a4a0be927f32f7ac49e8588f"
+  integrity sha512-I+AkgIFO6sDUoHQticP6I27TT3L+i6TUS03in3IEtpBcSeP2jyhlxI8l/wdA7gsBqUPdQ4GHOOaNgtFIcr8qag==
+  dependencies:
+    "@sentry/hub" "6.2.5"
+    "@sentry/minimal" "6.2.5"
+    "@sentry/types" "6.2.5"
+    "@sentry/utils" "6.2.5"
+    tslib "^1.9.3"
+
+"@sentry/hub@6.2.5":
+  version "6.2.5"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.2.5.tgz#324cae0c90d736cd1032e94104bf3f18becec4d6"
+  integrity sha512-YlEFdEhcfqpl2HC+/dWXBsBJEljyMzFS7LRRjCk8QANcOdp9PhwQjwebUB4/ulOBjHPP2WZk7fBBd/IKDasTUg==
+  dependencies:
+    "@sentry/types" "6.2.5"
+    "@sentry/utils" "6.2.5"
+    tslib "^1.9.3"
+
+"@sentry/minimal@6.2.5":
+  version "6.2.5"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.2.5.tgz#3e963e868bfa68e97581403521fd4e09a8965b02"
+  integrity sha512-RKP4Qx3p7Cv0oX1cPKAkNVFYM7p2k1t32cNk1+rrVQS4hwlJ7Eg6m6fsqsO+85jd6Ne/FnyYsfo9cDD3ImTlWQ==
+  dependencies:
+    "@sentry/hub" "6.2.5"
+    "@sentry/types" "6.2.5"
+    tslib "^1.9.3"
+
+"@sentry/types@6.2.5":
+  version "6.2.5"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.2.5.tgz#34b75285b149e0b9bc5fd54fcc2c445d978c7f2e"
+  integrity sha512-1Sux6CLYrV9bETMsGP/HuLFLouwKoX93CWzG8BjMueW+Di0OGxZphYjXrGuDs8xO8bAKEVGCHgVQdcB2jevS0w==
+
+"@sentry/utils@6.2.5":
+  version "6.2.5"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.2.5.tgz#be90d056b09ed1216097d7a29e3e81ba39238e1b"
+  integrity sha512-fJoLUZHrd5MPylV1dT4qL74yNFDl1Ur/dab+pKNSyvnHPnbZ/LRM7aJ8VaRY/A7ZdpRowU+E14e/Yeem2c6gtQ==
+  dependencies:
+    "@sentry/types" "6.2.5"
+    tslib "^1.9.3"
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.1.tgz#e7df00f98a203324f6dc7cc606cad9d4a8ab2217"
@@ -9793,7 +9845,7 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.9.0:
+tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==


### PR DESCRIPTION
Because:
* We want to track JS errors in sentry too.