### PR TITLE
Feature: Path Lesson Completion Button Submitting State

### DIFF
--- a/app/assets/stylesheets/components/courses/section_lessons.scss
+++ b/app/assets/stylesheets/components/courses/section_lessons.scss
@@ -20,6 +20,8 @@
       color: $pale-grey;
       opacity: 0.3;
       padding-left: 10px;
+      background-color: transparent;
+      display: flex;
 
       &--completed {
         color: $success-color;

--- a/app/assets/stylesheets/components/lesson/lesson_button.scss
+++ b/app/assets/stylesheets/components/lesson/lesson_button.scss
@@ -7,6 +7,20 @@
     font-size: 1.7rem;
     padding-right: 0.4rem;
     align-self: center;
+
+    &--loading {
+      border: 4px solid $pale-grey;
+      border-top: 4px solid transparent;
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+      height: 32px;
+      width: 32px;
+    }
+
+    @keyframes spin {
+      0% { transform: rotate(0deg); }
+      100% { transform: rotate(360deg); }
+    }
   }
 
   &--complete {

--- a/app/views/courses/course/_lesson_completion_button.html.erb
+++ b/app/views/courses/course/_lesson_completion_button.html.erb
@@ -1,9 +1,9 @@
 <% if current_user.completed?(lesson) %>
-  <%= link_to lesson_completions_path(lesson.id), method: :delete, remote: true do %>
-    <i class="far fa-check-circle section-lessons__item__icon section-lessons__item__icon--completed"></i>
+  <%= button_to lesson_completions_path(lesson.id), method: :delete, remote: true, data: { disable_with: "<div class='lesson-button__icon lesson-button__icon--loading'></div>" }, class: 'section-lessons__item__icon section-lessons__item__icon--completed' do %>
+    <i class="far fa-check-circle lesson-button__icon--completed"></i>
   <% end %>
 <% else %>
-  <%= link_to lesson_completions_path(lesson.id), method: :post, remote: true do %>
-    <i class="far fa-check-circle section-lessons__item__icon"></i>
+  <%= button_to lesson_completions_path(lesson.id), method: :post, remote: true, data: { disable_with: "<div class='lesson-button__icon lesson-button__icon--loading'></div>" }, class: 'section-lessons__item__icon' do %>
+    <i class="far fa-check-circle"></i>
   <% end %>
 <% end %>


### PR DESCRIPTION
Because:
* We should disable these buttons and give visual feedback to show the request is still submitting when they are clicked. This will help users avoid submitting multiple times at once.

This commit:
* Disables the lesson completion button on the path page with a loading spinner when clicked.

Resolves: https://github.com/TheOdinProject/theodinproject/issues/1856