### PR TITLE
Fix: Broken Path Courses Url Should Redirect to Path Page

### DIFF
--- a/config/routes/old_route_redirects.rb
+++ b/config/routes/old_route_redirects.rb
@@ -3,10 +3,12 @@
 # these redirects are needed while we move over to an interlaced path structure. They can be removed after the interlaced paths are out for a while.
 Rails.application.routes.draw do
   # redirect old foundation path routes
+  get '/paths/foundations/courses', to: redirect('/paths/foundations')
   get '/courses/foundations', to: redirect('/paths/foundations/courses/foundations')
   get '/courses/foundations/lessons/:id', to: redirect('/paths/foundations/courses/foundations/lessons/%{id}')
 
   # redirect old rails path routes
+  get '/paths/full-stack-ruby-on-rails/courses', to: redirect('/paths/full-stack-ruby-on-rails')
   get '/courses/ruby-programming', to: redirect('/paths/full-stack-ruby-on-rails/courses/ruby-programming')
   get '/courses/ruby-programming/lessons/:id',
       to: redirect('/paths/full-stack-ruby-on-rails/courses/ruby-programming/lessons/%{id}')
@@ -19,6 +21,7 @@ Rails.application.routes.draw do
       to: redirect('/paths/full-stack-ruby-on-rails/courses/ruby-on-rails/lessons/%{id}')
 
   # redirect old js pathroutes
+  get '/paths/full-stack-javascript/courses', to: redirect('/paths/full-stack-javascript')
   get '/courses/nodejs', to: redirect('/paths/full-stack-javascript/courses/nodejs')
   get '/courses/nodejs/lessons/:id', to: redirect('/paths/full-stack-javascript/courses/nodejs/lessons/%{id}')
 

--- a/spec/requests/old_course_route_redirects_spec.rb
+++ b/spec/requests/old_course_route_redirects_spec.rb
@@ -2,6 +2,11 @@ require 'rails_helper'
 
 RSpec.describe 'Old Course Route Redirects', type: :request do
   context 'when a request is made for the old foundations path' do
+    it 'redirects the old foundations path courses page route' do
+      get '/paths/foundations/courses'
+      expect(response).to redirect_to('/paths/foundations')
+    end
+
     it 'redirects the old foundations course page route' do
       get '/courses/foundations'
       expect(response).to redirect_to('/paths/foundations/courses/foundations')
@@ -14,6 +19,11 @@ RSpec.describe 'Old Course Route Redirects', type: :request do
   end
 
   context 'when a request is made for the old full stack ruby on rails path' do
+    it 'redirects the old full stack rails path courses page route' do
+      get '/paths/full-stack-ruby-on-rails/courses'
+      expect(response).to redirect_to('/paths/full-stack-ruby-on-rails')
+    end
+
     it 'redirects the old ruby course page route' do
       get '/courses/ruby-programming'
       expect(response).to redirect_to('/paths/full-stack-ruby-on-rails/courses/ruby-programming')
@@ -45,6 +55,11 @@ RSpec.describe 'Old Course Route Redirects', type: :request do
     end
 
     context 'when full stack javascript path' do
+      it 'redirects the old full stack javascript path courses page route' do
+        get '/paths/full-stack-javascript/courses'
+        expect(response).to redirect_to('/paths/full-stack-javascript')
+      end
+
       it 'redirects the old node js course page route' do
         get '/courses/nodejs'
         expect(response).to redirect_to('/paths/full-stack-javascript/courses/nodejs')


### PR DESCRIPTION
Because:
* We are getting a lot of traffic to these routes from an external source and they currently return the 404 page.

This commit:
* Redirects the old depreciated `/paths/path-name/courses` route to `/paths/path-name` instead.

Resolves: https://github.com/TheOdinProject/theodinproject/issues/1857