### PR TITLE
Fix: Switching Paths

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
   acts_as_voter
-  before_validation :enroll_in_foundations
+  before_create :enroll_in_foundations
 
   devise :database_authenticatable, :registerable, :recoverable,
          :rememberable, :trackable, :validatable,
@@ -16,7 +16,7 @@ class User < ApplicationRecord
   has_many :user_providers, dependent: :destroy
   has_many :flags, foreign_key: :flagger_id, dependent: :destroy
   has_many :notifications, as: :recipient
-  belongs_to :path
+  belongs_to :path, optional: true
 
   def progress_for(course)
     @progress ||= Hash.new { |hash, c| hash[c] = CourseProgress.new(c, self) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe User do
   it { is_expected.to have_many(:user_providers).dependent(:destroy) }
   it { is_expected.to have_many(:flags).dependent(:destroy) }
   it { is_expected.to have_many(:notifications) }
-  it { is_expected.to belong_to(:path) }
+  it { is_expected.to belong_to(:path).optional(true) }
 
   context 'when user is created' do
     let!(:default_path) { create(:path, default_path: true) }


### PR DESCRIPTION
Because:
* It was setting the users path to foundations on every user update instead of just on create.

This commit:
* Only set the users path to foundations when they register for an account.