### PR TITLE
Chore: Fix ActionText::ContentHelper and ActionText::TagHelper Depreciation Warning on Boot

### DIFF
--- a/config/initializers/smtp.rb
+++ b/config/initializers/smtp.rb
@@ -1,9 +1,11 @@
-ActionMailer::Base.smtp_settings = {
-  address: 'smtp.sendgrid.net',
-  port: '587',
-  authentication: :plain,
-  user_name: ENV['SENDGRID_USERNAME'],
-  password: ENV['SENDGRID_PASSWORD'],
-  domain: 'heroku.com',
-  enable_starttls_auto: true
-}
+Rails.application.config.after_initialize do
+  ActionMailer::Base.smtp_settings = {
+    address: 'smtp.sendgrid.net',
+    port: '587',
+    authentication: :plain,
+    user_name: ENV['SENDGRID_USERNAME'],
+    password: ENV['SENDGRID_PASSWORD'],
+    domain: 'heroku.com',
+    enable_starttls_auto: true
+  }
+end


### PR DESCRIPTION
Because:

- We were getting deprecation warnings when booting the app

This commit:

- Defers the initialization of ActionMailer until after Rails has been fully initialized.

Notes:

- There is a fix for this issue in the Rails repo that has not been shipped yet. When Rails is updated, please revert this change and check if the deprecation warning has been fixed. See #1844 for more information.

Resolves: #1844 