### PR TITLE
Fix: Lesson Complete System Test

### DIFF
--- a/app/views/lessons/_lesson_completion_button.html.erb
+++ b/app/views/lessons/_lesson_completion_button.html.erb
@@ -4,5 +4,6 @@
   <%= link_to 'Login to track progress',
       login_path,
       title: 'Go to login page',
-      class: 'button button--primary lesson-button-group__item lesson-button' %>
+      class: 'button button--primary lesson-button-group__item lesson-button',
+      data: { test_id: 'login_button' } %>
 <% end %>

--- a/spec/system/lesson_completion_spec.rb
+++ b/spec/system/lesson_completion_spec.rb
@@ -16,9 +16,7 @@ RSpec.describe 'Lesson Completions', type: :system do
 
   it 'cannot complete a lesson when not logged in' do
     visit path_course_lesson_path(path, course, lesson)
-    find(:test_id, 'complete_btn').click
 
-    expect(find(:test_id, 'complete_btn')).not_to be(nil)
-    expect(find(:test_id, 'incomplete_btn')).not_to be(nil)
+    expect(find(:test_id, 'login_button')).to have_content('Login to track progress')
   end
 end


### PR DESCRIPTION
Because:
* It wasn't running this spec since it didn't have `_spec` postfixed.

This commit:
* Adds _spec to the end of the lesson completions system spec file name.
* Fixes the logged out test for lesson completions.