### PR TITLE
Clicking AllPaths does not select Community

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -22,7 +22,7 @@
           <%= link_to 'All Paths', paths_url, class: 'nav-link' %>
         </li>
 
-        <li class="nav-item <%= active_class(paths_url) %>">
+        <li class="nav-item <%= active_class(chat_link) %>">
           <%= link_to "Community", chat_link, class: 'nav-link', target: '_blank', rel: 'noreferrer' %>
         </li>
 
@@ -39,7 +39,7 @@
           <%= link_to 'All Paths', paths_url, class: 'nav-link' %>
         </li>
 
-         <li class="nav-item <%= active_class(paths_url) %>">
+         <li class="nav-item <%= active_class(chat_link) %>">
           <%= link_to "Community", chat_link, class: 'nav-link', target: '_blank', rel: 'noreferrer' %>
         </li>
 


### PR DESCRIPTION
Fixed issue where clicking "All Paths" causes the "Community" tab to highlight. #1832 

Attached is a photo of the working fix both logged out and logged in. Below is the rspec test in which two failures related to welcome email job occur. I can only assume this is because I did not set up the mail chimp integration. If these failures are a problem I can go back and look for errors but I was getting these before making changes so I don't believe they will be.
![loggedOut](https://user-images.githubusercontent.com/56554110/116178685-09acb580-a6e4-11eb-9abf-667df9243242.png)
![LoggedIn](https://user-images.githubusercontent.com/56554110/116178689-0c0f0f80-a6e4-11eb-808a-c059a7c4a15c.png)
![rspec](https://user-images.githubusercontent.com/56554110/116178559-c8b4a100-a6e3-11eb-8a4e-9b00a779ebe6.png)
