### PR TITLE
add ability to track who resolved a flag

### DIFF
--- a/app/admin/flags.rb
+++ b/app/admin/flags.rb
@@ -67,7 +67,7 @@ ActiveAdmin.register Flag do
 
   controller do
     def ban_flagged_user
-      result = Admin::Flags::BanUser.call(flag: resource)
+      result = Admin::Flags::BanUser.call(current_user, flag: resource)
 
       if result.success?
         redirect_to resource_path(resource), notice: 'Success: User has been banned.'
@@ -77,7 +77,7 @@ ActiveAdmin.register Flag do
     end
 
     def dismiss
-      result = Admin::Flags::Dismiss.call(flag: resource)
+      result = Admin::Flags::Dismiss.call(current_user, flag: resource)
 
       if result.success?
         redirect_to resource_path(resource), notice: 'Success: Flag has been dismissed.'

--- a/app/services/admin/flags/ban_user.rb
+++ b/app/services/admin/flags/ban_user.rb
@@ -1,7 +1,8 @@
 module Admin
   module Flags
     class BanUser
-      def initialize(flag:)
+      def initialize(admin, flag:)
+        @admin = admin
         @flag = flag
         @success = false
       end
@@ -25,14 +26,14 @@ module Admin
 
       private
 
-      attr_reader :flag
+      attr_reader :flag, :admin
 
       def update_flag_for_ban(flag)
         flag.project_submission.update!(banned: true)
         flag.project_submission.user.update!(banned: true)
         flag.ban!
         flag.resolved!
-        flag.update!(resolved_by_id: flag.flagger.id)
+        flag.update!(resolved_by_id: admin.id)
       end
     end
   end

--- a/app/services/admin/flags/ban_user.rb
+++ b/app/services/admin/flags/ban_user.rb
@@ -13,7 +13,7 @@ module Admin
 
       def call
         flag.transaction do
-          update_flag_for_ban(flag)
+          update_flag_for_ban
           @success = true
         end
 
@@ -28,7 +28,7 @@ module Admin
 
       attr_reader :flag, :admin
 
-      def update_flag_for_ban(flag)
+      def update_flag_for_ban
         flag.project_submission.update!(banned: true)
         flag.project_submission.user.update!(banned: true)
         flag.ban!

--- a/app/services/admin/flags/ban_user.rb
+++ b/app/services/admin/flags/ban_user.rb
@@ -12,11 +12,7 @@ module Admin
 
       def call
         flag.transaction do
-          flag.project_submission.update!(banned: true)
-          flag.project_submission.user.update!(banned: true)
-          flag.ban!
-          flag.resolved!
-          flag.update!(resolved_by_id: flag.flagger.id)
+          update_flag_for_ban(flag)
           @success = true
         end
 
@@ -30,6 +26,14 @@ module Admin
       private
 
       attr_reader :flag
+
+      def update_flag_for_ban(flag)
+        flag.project_submission.update!(banned: true)
+        flag.project_submission.user.update!(banned: true)
+        flag.ban!
+        flag.resolved!
+        flag.update!(resolved_by_id: flag.flagger.id)
+      end
     end
   end
 end

--- a/app/services/admin/flags/ban_user.rb
+++ b/app/services/admin/flags/ban_user.rb
@@ -16,6 +16,7 @@ module Admin
           flag.project_submission.user.update!(banned: true)
           flag.ban!
           flag.resolved!
+          flag.update!(resolved_by_id: flag.flagger.id)
           @success = true
         end
 

--- a/app/services/admin/flags/dismiss.rb
+++ b/app/services/admin/flags/dismiss.rb
@@ -1,7 +1,8 @@
 module Admin
   module Flags
     class Dismiss
-      def initialize(flag:)
+      def initialize(admin, flag:)
+        @admin = admin
         @flag = flag
         @success = false
       end
@@ -13,7 +14,7 @@ module Admin
       def call
         flag.resolved!
         flag.dismiss!
-        flag.update!(resolved_by_id: flag.flagger.id)
+        flag.update!(resolved_by_id: admin.id)
         @success = true
 
         self
@@ -25,7 +26,7 @@ module Admin
 
       private
 
-      attr_reader :flag
+      attr_reader :flag, :admin
     end
   end
 end

--- a/app/services/admin/flags/dismiss.rb
+++ b/app/services/admin/flags/dismiss.rb
@@ -13,6 +13,7 @@ module Admin
       def call
         flag.resolved!
         flag.dismiss!
+        flag.update!(resolved_by_id: flag.flagger.id)
         @success = true
 
         self

--- a/db/migrate/20210428175951_add_resolved_by_id_to_flags.rb
+++ b/db/migrate/20210428175951_add_resolved_by_id_to_flags.rb
@@ -1,0 +1,5 @@
+class AddResolvedByIdToFlags < ActiveRecord::Migration[6.1]
+  def change
+    add_column :flags, :resolved_by_id, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20210428222030_add_resolved_by_id_to_flags.rb
+++ b/db/migrate/20210428222030_add_resolved_by_id_to_flags.rb
@@ -1,5 +1,5 @@
 class AddResolvedByIdToFlags < ActiveRecord::Migration[6.1]
   def change
-    add_column :flags, :resolved_by_id, :integer, default: 0, null: false
+    add_column :flags, :resolved_by_id, :integer
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_28_175951) do
+ActiveRecord::Schema.define(version: 2021_04_28_222030) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,7 +58,7 @@ ActiveRecord::Schema.define(version: 2021_04_28_175951) do
     t.integer "taken_action", default: 0, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.integer "resolved_by_id", default: 0, null: false
+    t.integer "resolved_by_id"
     t.index ["flagger_id"], name: "index_flags_on_flagger_id"
     t.index ["project_submission_id"], name: "index_flags_on_project_submission_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_26_125315) do
+ActiveRecord::Schema.define(version: 2021_04_28_175951) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,6 +58,7 @@ ActiveRecord::Schema.define(version: 2021_03_26_125315) do
     t.integer "taken_action", default: 0, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "resolved_by_id", default: 0, null: false
     t.index ["flagger_id"], name: "index_flags_on_flagger_id"
     t.index ["project_submission_id"], name: "index_flags_on_project_submission_id"
   end

--- a/spec/services/admin/flags/ban_user_spec.rb
+++ b/spec/services/admin/flags/ban_user_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Admin::Flags::BanUser do
   let(:admin) { create(:user, admin: true) }
-  
+
   subject(:service) { described_class.call(admin, flag: flag) }
 
   let(:flag) { create(:flag, project_submission: project_submission) }

--- a/spec/services/admin/flags/ban_user_spec.rb
+++ b/spec/services/admin/flags/ban_user_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe Admin::Flags::BanUser do
     it 'sets the flags status to resolved' do
       expect { service }.to change { flag.status }.from('active').to('resolved')
     end
+
+    it 'sets the resolved_by_id to the id of the current admin user' do
+      expect { service }.to change { flag.resolved_by_id }.from(0).to(admin.id)
+    end
   end
 
   describe '#success?' do

--- a/spec/services/admin/flags/ban_user_spec.rb
+++ b/spec/services/admin/flags/ban_user_spec.rb
@@ -1,7 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Admin::Flags::BanUser do
-  subject(:service) { described_class.call(flag: flag) }
+  let(:admin) { create(:user, admin: true) }
+  
+  subject(:service) { described_class.call(admin, flag: flag) }
 
   let(:flag) { create(:flag, project_submission: project_submission) }
   let(:project_submission) { create(:project_submission, user: user) }

--- a/spec/services/admin/flags/ban_user_spec.rb
+++ b/spec/services/admin/flags/ban_user_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Admin::Flags::BanUser do
     end
 
     it 'sets the resolved_by_id to the id of the current admin user' do
-      expect { service }.to change { flag.resolved_by_id }.from(0).to(admin.id)
+      expect { service }.to change { flag.resolved_by_id }.from(nil).to(admin.id)
     end
   end
 

--- a/spec/services/admin/flags/dismiss_spec.rb
+++ b/spec/services/admin/flags/dismiss_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Admin::Flags::Dismiss do
     end
 
     it 'sets the resolved_by_id to the id of the current admin user' do
-      expect { service }.to change { flag.resolved_by_id }.from(0).to(admin.id)
+      expect { service }.to change { flag.resolved_by_id }.from(nil).to(admin.id)
     end
   end
 

--- a/spec/services/admin/flags/dismiss_spec.rb
+++ b/spec/services/admin/flags/dismiss_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe Admin::Flags::Dismiss do
     it 'sets the flags status to resolved' do
       expect { service }.to change { flag.status }.from('active').to('resolved')
     end
+
+    it 'sets the resolved_by_id to the id of the current admin user' do
+      expect { service }.to change { flag.resolved_by_id }.from(0).to(admin.id)
+    end
   end
 
   describe '#success?' do

--- a/spec/services/admin/flags/dismiss_spec.rb
+++ b/spec/services/admin/flags/dismiss_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Admin::Flags::Dismiss do
   let(:admin) { create(:user, admin: true) }
-  
+
   subject(:service) { described_class.call(admin, flag: flag) }
 
   let(:flag) { create(:flag) }

--- a/spec/services/admin/flags/dismiss_spec.rb
+++ b/spec/services/admin/flags/dismiss_spec.rb
@@ -1,7 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Admin::Flags::Dismiss do
-  subject(:service) { described_class.call(flag: flag) }
+  let(:admin) { create(:user, admin: true) }
+  
+  subject(:service) { described_class.call(admin, flag: flag) }
 
   let(:flag) { create(:flag) }
 


### PR DESCRIPTION
This pull request addresses https://github.com/TheOdinProject/theodinproject/issues/1884

I hope this is an okay way to do it. 

Steps I took to add this feature:

1. Generated the migration AddResolvedByIdToFlags
2. Added `flag.update!(resolved_by_id: flag.flagger.id)` to `call` method of `Admin::Flags::Dismiss`
3. Added `flag.update!(resolved_by_id: flag.flagger.id)` to `call` method of `Admin::Flags::BanUser`
