### PR TITLE
Fix: lack of margin on like button

### DIFF
--- a/app/assets/stylesheets/components/project_submissions/submissions.scss
+++ b/app/assets/stylesheets/components/project_submissions/submissions.scss
@@ -143,7 +143,7 @@
     margin-right: 15px;
 
     :first-child {
-      margin-left: 5px;
+      margin-right: 5px;
     }
 
     .liked {


### PR DESCRIPTION
The margin was to the left instead of to the right

before:
![chrome-capture (75)](https://user-images.githubusercontent.com/36450233/116828334-b1275d80-aba6-11eb-9698-16d2acee0adb.jpg)
after:
![chrome-capture (76)](https://user-images.githubusercontent.com/36450233/116828332-aff63080-aba6-11eb-81c3-0942bfdf2ed2.jpg)


