### PR TITLE
Chore: Add Lesson Navigation System Tests

### DIFF
--- a/app/views/courses/course/_banner.html.erb
+++ b/app/views/courses/course/_banner.html.erb
@@ -4,6 +4,6 @@
   </div>
 
   <%= link_to path_course_url(course.path, course), class: 'course-card-header__link' do %>
-    <h1 class="banner__title"><%= course.title %></h1>
+    <h1 class="banner__title" data-test-id="course_title_header"><%= course.title %></h1>
   <% end %>
 </div>

--- a/app/views/courses/course/_section-lessons.html.erb
+++ b/app/views/courses/course/_section-lessons.html.erb
@@ -1,4 +1,4 @@
-<div class="section-lessons">
+<div class="section-lessons" data-test-id="course_section">
   <% lessons.each_with_index do |lesson, lesson_index| %>
     <div class="section-lessons__item">
 

--- a/app/views/lessons/_lesson_buttons.html.erb
+++ b/app/views/lessons/_lesson_buttons.html.erb
@@ -1,7 +1,8 @@
 <%= link_to 'View Course',
     path_course_path(course.path, course),
     title: "Go back to '#{lesson.course.title}'",
-    class: 'button button--secondary lesson-button-group__item lesson-button'
+    class: 'button button--secondary lesson-button-group__item lesson-button',
+    data: { test_id: 'view_course_btn' }
 %>
 
 <%= render 'lessons/lesson_completion_button', lesson: lesson, user: user %>
@@ -10,6 +11,7 @@
   <%= link_to 'Next Lesson',
       path_course_lesson_path(course.path, course, lesson.next_lesson),
       title: "Move on to '#{lesson.next_lesson.title}'",
-      class: "button #{next_lesson_button_state(lesson)} lesson-button-group__item lesson-button"
+      class: "button #{next_lesson_button_state(lesson)} lesson-button-group__item lesson-button",
+      data: { test_id: 'next_lesson_btn' }
   %>
 <% end %>

--- a/app/views/lessons/_lesson_completion_state.html.erb
+++ b/app/views/lessons/_lesson_completion_state.html.erb
@@ -3,7 +3,7 @@
     <i class="lesson-button__icon far fa-check-circle" aria-hidden="true"></i>
   <% end %>
 <% elsif lesson.choose_path_lesson? %>
-  <%= link_to lesson_completions_path(lesson.id, redirect_url: paths_url), remote: true, method: :post, class: 'button button--primary lesson-button-group__item lesson-button', title: 'Mark lesson complete', data: { disable_with: "Submitting..." } do %>
+  <%= link_to lesson_completions_path(lesson.id, redirect_url: paths_url), remote: true, method: :post, class: 'button button--primary lesson-button-group__item lesson-button', title: 'Mark lesson complete', data: { disable_with: "Submitting...", test_id: "choose_path_lesson_btn" } do %>
     <i class="lesson-button__icon far fa-check-circle" aria-hidden="true"></i>Complete and Choose Path
   <% end %>
 <% else %>

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -5,7 +5,7 @@
     <div class="col-12">
       <div class="lesson-header">
         <%= render 'courses/course/banner', course: @lesson.course %>
-        <h2 class="lesson-header__title accent"><%= @lesson.title %></h2>
+        <h2 class="lesson-header__title accent" data-test-id="lesson_title_header"><%= @lesson.title %></h2>
       </div>
     </div>
 

--- a/spec/system/lesson_navigation_spec.rb
+++ b/spec/system/lesson_navigation_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe 'Navigating Lessons', type: :system do
+  let!(:user) { create(:user) }
+  let!(:path) { create(:path, default_path: true) }
+  let!(:course) { create(:course, path: path) }
+  let!(:section) { create(:section, course: course) }
+  let!(:lesson) { create(:lesson, section: section) }
+
+  describe 'the next lesson button' do
+    context 'within the same section' do
+      let!(:next_lesson) { create(:lesson, section: section) }
+
+      it 'moves to the next lesson in the section when clicked' do
+        visit path_course_lesson_path(path, course, lesson)
+        find(:test_id, 'next_lesson_btn').click
+
+        expect(find(:test_id, 'lesson_title_header')).to have_text(/#{next_lesson.title}/i)
+      end
+    end
+
+    context 'when on the last lesson of a section' do
+      let!(:next_section) { create(:section, course: course) }
+      let!(:next_section_lesson) { create(:lesson, section: section) }
+
+      it 'moves to the first lesson in the next section when clicked' do
+        visit path_course_lesson_path(path, course, lesson)
+        find(:test_id, 'next_lesson_btn').click
+
+        expect(find(:test_id, 'lesson_title_header')).to have_text(/#{next_section_lesson.title}/i)
+      end
+    end
+
+    context 'on last lesson in the course' do
+      it 'should not be present' do
+        visit path_course_lesson_path(path, course, lesson)
+
+        expect(page).to have_no_selector('[data-test-id="next_lesson_btn"]')
+      end
+    end
+  end
+
+  describe 'the View Course button' do
+    it 'directs to the course view' do
+      visit path_course_lesson_path(path, course, lesson)
+      find(:test_id, 'view_course_btn').click
+
+      expect(find(:test_id, 'course_title_header')).to have_text(/#{course.title}/i)
+
+      within '[data-test-id="course_section"]', match: :first do
+        expect(page).to have_text(/#{lesson.title}/i)
+      end
+    end
+  end
+
+  describe 'Choose Path Lesson button' do
+    let!(:choose_path_lesson) { create(:lesson, section: section, choose_path_lesson: true) }
+
+    before do
+      sign_in(user)
+    end
+
+    it 'directs the user to the path selection page' do
+      visit path_course_lesson_path(path, course, choose_path_lesson)
+      find(:test_id, 'choose_path_lesson_btn').click
+
+      expect(page).to have_current_path(paths_path)
+    end
+  end
+end


### PR DESCRIPTION
Because:

- We should test the lesson navigation buttons

This commit:

- tests clicking the next lesson button
- tests for clicking the next lesson button on the last lesson in a section
- tests the last lesson in a course has no next lesson button
- tests clicking the view course button
- tests clicking on a choose_path_lesson next lesson button directs users to the paths_page

resolves #1866 