### PR TITLE
adds clarifying copy to path descriptions

### DIFF
--- a/db/fixtures/paths/full_stack_javascript/seed.rb
+++ b/db/fixtures/paths/full_stack_javascript/seed.rb
@@ -3,7 +3,7 @@
 # *****************************
 @path = Seeds::PathSeeder.create do |path|
   path.title = 'Full Stack JavaScript'
-  path.description = "This path takes you through our entire JavaScript curriculum. You'll learn everything you need to know to create beautiful responsive websites from scratch using JavaScript and NodeJs."
+  path.description = "This path takes you through our entire JavaScript curriculum. The courses should be taken in the order that they are displayed. You'll learn everything you need to know to create beautiful responsive websites from scratch using JavaScript and NodeJs."
   path.identifier_uuid = '624d152c-b522-4f7a-86aa-8f2d9c84b951'
   path.position = 3
 end

--- a/db/fixtures/paths/full_stack_rails/seed.rb
+++ b/db/fixtures/paths/full_stack_rails/seed.rb
@@ -3,7 +3,7 @@
 # ***************************
 @path = Seeds::PathSeeder.create do |path|
   path.title = 'Full Stack Ruby on Rails'
-  path.description = "This path takes you through our entire Ruby on Rails curriculum. You'll learn everything you need to know to create beautiful responsive websites from scratch."
+  path.description = "This path takes you through our entire Ruby on Rails curriculum. The courses should be taken in the order that they are displayed. You'll learn everything you need to know to create beautiful responsive websites from scratch."
   path.identifier_uuid = '16109529-1526-4800-be11-0f655bcfb4cc'
   path.position = 2
 end


### PR DESCRIPTION
There were a significant amount of questions about the order courses in a path should be taken. This change aims to improve student clarity and outlines that courses in the paths should be taken in the order that they are displayed.

