### PR TITLE
Chore: Only Report Errors Originating from TheOdinProject

### DIFF
--- a/app/javascript/packs/error_tracking.js
+++ b/app/javascript/packs/error_tracking.js
@@ -4,7 +4,13 @@ const {
   SENTRY_DSN, currentUserLoggedIn, currentUserId, currentUserEmail,
 } = window;
 
-Sentry.init({ dsn: SENTRY_DSN, environment: 'production' });
+Sentry.init({
+  dsn: SENTRY_DSN,
+  environment: 'production',
+  allowUrls: [
+    /https?:\/\/(www\.)?theodinproject\.com/,
+  ],
+});
 
 Sentry.configureScope((scope) => {
   if (currentUserLoggedIn) {


### PR DESCRIPTION
Because:
* We are seeing quite a few errors from extensions and external scripts reported.

This commit:
* Configures the sentry allowed urls list.