### PR TITLE
Chore: Add Pull Request and Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+### Description
+<!-- Brief description of the bug -->
+
+#### Steps to Reproduce
+<!-- What steps need to be taken in order to reproduce this bug?
+
+Example:
+1. Log in
+2. Visit a lesson page
+3. Click the complete button
+4. The course progress bar does not increase
+-->
+
+
+#### Expected Behaviour
+<!-- What is the expected behaviour?
+
+Example:
+1. Log in
+2. Visit a lesson page
+3. Click the complete button
+4. The course progress bar will increase
+-->
+
+ #### Additional Information
+<!-- are there any additional details or links you can provide that may help resolve this bug? -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+#### Description
+<!-- Brief description of why this feature would be useful. What problems would it solve and what are the usecases? -->
+
+#### Acceptance Criteria:
+<!-- Description of how this feature should work or the steps that need to be taken by the user to meet the acceptance criteria:
+
+For example:
+1. Log in
+2. Visit a lesson page
+3. Click the complete button
+4. The course progress bar will increase
+-->
+
+#### Additional Information:
+<!-- Any helpful additional information or links go here -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+#### Because:
+<!--
+If your pull request resolves an open issue, please provide a link to it. For example: Resolves: https://github.com/TheOdinProject/theodinproject/issues/1886
+Otherwise, please briefly explain why these changes were made, what problem does it solve?.
+-->
+
+#### This commit
+<!--
+A bullet point list of one or more items outlining what was done in this pull request to solve the problem.
+-->
+
+#### Checklist
+ - [ ] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
+ - [ ] You have verified the tests and linters all pass against your changes?
+ - [ ] You have included automated tests for your changes where applicable?


### PR DESCRIPTION
Because:
* We should make it easier for contributors to know exactly what information we expect from them when they make issues and pull requests to this repo.

This commit:
* Adds a pull request template.
* Adds a feature request issue template.
* Adds a bug report issue template.

Resolves: https://github.com/TheOdinProject/theodinproject/issues/1886