### PR TITLE
Chore: Remove Timecop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,6 @@ group :development, :test, :docker do
   gem 'rspec-rails'
   gem 'shoulda-matchers'
   gem 'simplecov', require: false
-  gem 'timecop'
   gem 'vcr', '~> 6.0'
   gem 'webmock', '~> 3.13'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -499,7 +499,6 @@ GEM
     thor (1.1.0)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    timecop (0.9.4)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -602,7 +601,6 @@ DEPENDENCIES
   sidekiq
   simplecov
   sprockets (~> 3.7.2)
-  timecop
   turbolinks
   uglifier (~> 4.2)
   vcr (~> 6.0)

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe Lesson do
 
   describe '.most_recent_updated_at' do
     before do
-      Timecop.freeze(Time.utc(2021, 4, 14))
+      travel_to Time.utc(2021, 4, 14)
     end
 
     after do
-      Timecop.return
+      travel_back
     end
 
     it 'returns the most recently updated_at time stamp' do

--- a/spec/services/notifications/daily_summary_spec.rb
+++ b/spec/services/notifications/daily_summary_spec.rb
@@ -5,11 +5,11 @@ RSpec.describe Notifications::DailySummary do
 
   describe '#message' do
     before do
-      Timecop.freeze(Time.utc(2020, 4, 10))
+      travel_to Time.utc(2020, 4, 10)
     end
 
     after do
-      Timecop.return
+      travel_back
     end
 
     it 'returns the daily summary message' do

--- a/spec/support/time_helpers.rb
+++ b/spec/support/time_helpers.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include ActiveSupport::Testing::TimeHelpers
+end


### PR DESCRIPTION
Because:
* We can replace it with the built in rails time helpers.

This commit:
* Removes the timecop gem.
* Configures rails time helpers for the test suite.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
