### PR TITLE
Chore: Remove rails_12factor gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,10 +43,6 @@ gem 'turbolinks'
 gem 'uglifier', '~> 4.2'
 gem 'webpacker'
 
-group :production do
-  gem 'rails_12factor', '~> 0.0.3'
-end
-
 group :development, :test, :docker do
   gem 'capybara'
   gem 'climate_control'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -370,11 +370,6 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (6.1.3.2)
       actionpack (= 6.1.3.2)
       activesupport (= 6.1.3.2)
@@ -588,7 +583,6 @@ DEPENDENCIES
   rack-attack
   rails (= 6.1.3.2)
   rails-controller-testing
-  rails_12factor (~> 0.0.3)
   rake (~> 13.0)
   react-rails
   reek


### PR DESCRIPTION
#### Because:
* This used to be required for deploying to Heroku on Rails 4 and below apps, we're currently on Rails 6.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
