### PR TITLE
Feature: "Select" a Path instead of "Switching" to a Path

### DIFF
--- a/app/assets/stylesheets/paths.scss
+++ b/app/assets/stylesheets/paths.scss
@@ -2,7 +2,7 @@
   margin-bottom: 1.2rem;
 }
 
-.switch-container {
+.select-container {
   display: flex;
   align-items: center;
   justify-content: center;

--- a/app/controllers/users/paths_controller.rb
+++ b/app/controllers/users/paths_controller.rb
@@ -5,9 +5,9 @@ module Users
 
     def create
       if current_user.update(path: path)
-        redirect_to path, notice: "You have switched to the #{path.title} path"
+        redirect_to path, notice: "You have selected the #{path.title} path"
       else
-        redirect_to :back, notice: "Unable to switch you to the #{path.title} path"
+        redirect_to :back, notice: "Unable to select the #{path.title} path"
       end
     end
 

--- a/app/views/paths/index.html.erb
+++ b/app/views/paths/index.html.erb
@@ -15,7 +15,7 @@
             <% elsif current_user.path === path %>
               <%= button_to 'Resume', path_url(path), method: :get, class: 'button button--primary card-main__button', data: { test_id: "#{path.title.downcase}-resume-path-btn"  } %>
             <% else %>
-              <%= button_to 'Switch', users_paths_path(path_id: path.id), class: 'button button--secondary card-main__button', remote: false, method: :post, data: { disable_with: 'Switching...' } %>
+              <%= button_to 'Select', users_paths_path(path_id: path.id), class: 'button button--secondary card-main__button', remote: false, method: :post, data: { disable_with: 'Selecting...' } %>
             <% end %>
           </div>
           <div class="card-main__description">
@@ -44,7 +44,7 @@
               <% elsif current_user.path === path %>
                 <%= button_to 'Resume', path_url(path), method: :get, class: 'button button--primary card-main__button' %>
               <% else %>
-                <%= button_to 'Switch', users_paths_path(path_id: path.id), class: 'button button--secondary card-main__button', remote: false, method: :post, data: { disable_with: 'Switching...', test_id: "#{path.title.downcase}-switch-path-btn" } %>
+                <%= button_to 'Select', users_paths_path(path_id: path.id), class: 'button button--secondary card-main__button', remote: false, method: :post, data: { disable_with: 'Selecting...', test_id: "#{path.title.downcase}-select-path-btn" } %>
               <% end %>
             </div>
             <div class="card-main__description">

--- a/app/views/paths/show.html.erb
+++ b/app/views/paths/show.html.erb
@@ -1,8 +1,8 @@
 <div class="container">
   <h1 class="text-center camel light curriculum-title"><%= @path.title %></h1>
   <% if user_signed_in? && current_user.path != @path %>
-    <div class="switch-container">
-      <%= button_to 'Switch Path', users_paths_path(path_id: @path.id), class: 'button button--secondary card-main__button', remote: false, method: :post, data: { disable_with: 'Switching...', test_id: "#{@path.title.downcase}-switch-path-btn" } %>
+    <div class="select-container">
+      <%= button_to 'Selecting Path', users_paths_path(path_id: @path.id), class: 'button button--secondary card-main__button', remote: false, method: :post, data: { disable_with: 'Selecting...', test_id: "#{@path.title.downcase}-select-path-btn" } %>
     </div>
   <% end %>
   <p class="text-center path-description push-down-2x"><%= @path.description %></p>

--- a/spec/system/select_path_spec.rb
+++ b/spec/system/select_path_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Switching Paths', type: :system do
+RSpec.describe 'Selecting Paths', type: :system do
   let!(:default_path) { create(:path, title: 'Foundations', default_path: true) }
   let!(:rails_path) { create(:path, title: 'Rails') }
   let!(:user) { create(:user, path: default_path) }
@@ -10,27 +10,27 @@ RSpec.describe 'Switching Paths', type: :system do
   end
 
   context 'on the paths index page' do
-    it 'allows a user to switch paths' do
+    it 'allows a user to select a path' do
       visit paths_path
 
       expect(find(:test_id, 'foundations-resume-path-btn').value).to eq('Resume')
-      expect(find(:test_id, 'rails-switch-path-btn').value).to eq('Switch')
+      expect(find(:test_id, 'rails-select-path-btn').value).to eq('Select')
 
-      find(:test_id, 'rails-switch-path-btn').click
+      find(:test_id, 'rails-select-path-btn').click
 
       expect(page).to have_css '.alert-success'
-      expect(find(:test_id, 'flash')).to have_text 'You have switched to the Rails path'
+      expect(find(:test_id, 'flash')).to have_text 'You have selected the Rails path'
       expect(user.reload.path).to eq rails_path
     end
   end
 
   context 'on the path show page' do
-    it 'allows a user to switch to that path' do
+    it 'allows a user to select to that path' do
       visit path_path(rails_path)
-      find(:test_id, 'rails-switch-path-btn').click
+      find(:test_id, 'rails-select-path-btn').click
 
       expect(page).to have_css '.alert-success'
-      expect(find(:test_id, 'flash')).to have_text 'You have switched to the Rails path'
+      expect(find(:test_id, 'flash')).to have_text 'You have selected the Rails path'
       expect(user.reload.path).to eq rails_path
     end
   end

--- a/spec/system/user_dashboard/start_course_spec.rb
+++ b/spec/system/user_dashboard/start_course_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Starting Course from User Dashboard', type: :system do
     end
   end
 
-  context 'when user switches to start new path' do
+  context 'when user selected a new path' do
     let!(:rails_path) { create(:path, title: 'Rails') }
     let!(:ruby_course) { create(:course, title: 'Ruby', path: rails_path) }
     let!(:ruby_intro_section) { create(:section, course: ruby_course) }
@@ -33,7 +33,7 @@ RSpec.describe 'Starting Course from User Dashboard', type: :system do
     before do
       sign_in(user)
       visit paths_path
-      find(:test_id, 'rails-switch-path-btn').click
+      find(:test_id, 'rails-select-path-btn').click
       visit dashboard_path
     end
 


### PR DESCRIPTION
#### Because:
Feedback from Ada:
> The wording of "switch" is confusing because once you’re prompted to pick a path, you essentially have not entered into either path yet so maybe the word "select" sounds more direct. "Switch" sounds like the user is already in something (which they are not)

#### This commit
* Replaces the "switch" copy with "select" which works for both cases of when a user has not chosen a path yet or decided to take the other path in the future.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
