### PR TITLE
Fix: Broken Admin Flag Links For Removed Submissions

### DIFF
--- a/app/helpers/lessons_helper.rb
+++ b/app/helpers/lessons_helper.rb
@@ -14,7 +14,7 @@ module LessonsHelper
   def user_submission(current_user, lesson)
     return if current_user.blank?
 
-    project_submission = current_user.project_submissions.find_by(lesson_id: lesson.id)
+    project_submission = current_user.project_submissions.viewable.find_by(lesson_id: lesson.id)
     ProjectSubmissionSerializer.as_json(project_submission, current_user) if project_submission.present?
   end
 end

--- a/app/models/project_submission.rb
+++ b/app/models/project_submission.rb
@@ -1,9 +1,7 @@
 class ProjectSubmission < ApplicationRecord
   include Discard::Model
-  default_scope -> { kept }
 
   acts_as_votable
-
   paginates_per 15
 
   belongs_to :user
@@ -14,6 +12,6 @@ class ProjectSubmission < ApplicationRecord
   validates :live_preview_url, allow_blank: true, url: true
   validates :repo_url, presence: { message: 'Required' }
 
-  scope :viewable, -> { where(is_public: true, banned: false) }
+  scope :viewable, -> { where(is_public: true, banned: false, discarded_at: nil) }
   scope :created_today, -> { where('created_at >= ?', Time.zone.now.beginning_of_day) }
 end


### PR DESCRIPTION
#### Because:
* The default scope for returning kept project submissions was causing the flags project submission association to return nil after it is soft deleted.

#### This commit
* Removes the default kept scope from project submissions.
* Adds a discarded_at nil condition to the viewable project submissions scope.
* Uses the viewable scope when finding the users submission for a project.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
