### PR TITLE
Add stimulus js

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,5 +21,12 @@
   "rules": {
     "react/forbid-prop-types": 0,
     "jsx-a11y/no-autofocus": 0
+  },
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "paths": ["app/javascript"]
+      }
+    }
   }
 }

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,0 +1,9 @@
+// Load all the controllers within this directory and all subdirectories.
+// Controller files must be named *_controller.js.
+
+import { Application } from 'stimulus';
+import { definitionsFromContext } from 'stimulus/webpack-helpers';
+
+const application = Application.start();
+const context = require.context('controllers', true, /_controller\.js$/);
+application.load(definitionsFromContext(context));

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -32,6 +32,8 @@ import '../src/js/admin_flash';
 import '../src/js/odinDropDownMenu';
 import '../src/js/scrollspy.min';
 
+import 'controllers';
+
 require('@rails/ujs').start();
 require('turbolinks').start();
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "regenerator-runtime": "^0.13.7",
     "stickyfilljs": "^2.1.0",
     "tailwindcss": "npm:@tailwindcss/postcss7-compat",
+    "stimulus": "^2.0.0",
     "toaster": "^0.1.2",
     "turbolinks": "^5.2.0",
     "validate.js": "^0.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1582,6 +1582,30 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@stimulus/core@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@stimulus/core/-/core-2.0.0.tgz#140c85318d6a8a8210c0faf182223b8459348877"
+  integrity sha512-ff70GafKtzc8zQ1/cG+UvL06GcifPWovf2wBEdjLMh9xO2GOYURO3y2RYgzIGYUIBefQwyfX2CLfJdZFJrEPTw==
+  dependencies:
+    "@stimulus/mutation-observers" "^2.0.0"
+
+"@stimulus/multimap@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@stimulus/multimap/-/multimap-2.0.0.tgz#420cfa096ed6538df4a91dbd2b2842c1779952b2"
+  integrity sha512-pMBCewkZCFVB3e5mEMoyO9+9aKzHDITmf3OnPun51YWxlcPdHcwbjqm1ylK63fsoduIE+RowBpFwFqd3poEz4w==
+
+"@stimulus/mutation-observers@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@stimulus/mutation-observers/-/mutation-observers-2.0.0.tgz#3dbe37453bda47a6c795a90204ee8d77a799fb87"
+  integrity sha512-kx4VAJdPhIGBQKGIoUDC2tupEKorG3A+ckc2b1UiwInKTMAC1axOHU8ebcwhaJIxRqIrs8//4SJo9YAAOx6FEg==
+  dependencies:
+    "@stimulus/multimap" "^2.0.0"
+
+"@stimulus/webpack-helpers@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@stimulus/webpack-helpers/-/webpack-helpers-2.0.0.tgz#54296d2a2dffd4f962d2e802d99a3fdd84b8845f"
+  integrity sha512-D6tJWsAC024MwGEIKlUVYU8Ln87mlrmiwHvYAjipg+s8H4eLxUMQ3PZkWyPevfipH+oR3leuHsjYsK1gN5ViQA==
+
 "@testing-library/dom@^7.28.1":
   version "7.28.1"
   resolved "https://registry.npmjs.org/@testing-library/dom/-/dom-7.28.1.tgz"
@@ -9618,6 +9642,14 @@ stickyfilljs@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/stickyfilljs/-/stickyfilljs-2.1.0.tgz"
   integrity sha512-LkG0BXArL5HbW2O09IAXfnBQfpScgGqJuUDUrI3Ire5YKjRz/EhakIZEJogHwgXeQ4qnTicM9sK9uYfWN11qKg==
+
+stimulus@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/stimulus/-/stimulus-2.0.0.tgz#713c8b91a72ef90914b90955f0e705f004403047"
+  integrity sha512-xipy7BS5TVpg4fX6S8LhrYZp7cmHGjmk09WSAiVx1gF5S5g43IWsuetfUhIk8HfHUG+4MQ9nY0FQz4dRFLs/8w==
+  dependencies:
+    "@stimulus/core" "^2.0.0"
+    "@stimulus/webpack-helpers" "^2.0.0"
 
 stream-browserify@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
Because:

- Stimulus has been selected for use within the app

This commit:

- Installs the stimulus package and sets up the minimum required files
- Formats stimulus index.js file to follow linting guidelines

resolves #1965 

