### PR TITLE
Chore: Notify Users of the Game Jam.

### DIFF
--- a/lib/tasks/data_migrations/game_jam_message.rake
+++ b/lib/tasks/data_migrations/game_jam_message.rake
@@ -1,0 +1,14 @@
+# rubocop:disable all
+namespace :data_migrations do
+
+  desc "Create Game Jam Admin Flash"
+  task create_game_jam_message: :environment do
+
+    puts "Creating Message"
+
+    AdminFlash.create!(
+      message: "The Odin Project is hosting a game jam! <a href='https://itch.io/jam/top-jam-1'>Check it out here</a>. More information in the discord server, which can be found in the community tab, check the #announcements channel and the associated jam channels!",
+      expires: 41.days.from_now,
+    )
+  end
+end


### PR DESCRIPTION
Because:
* We want to notify users that don't visit discord about the game jam.

This commit:
* Creates an admin flash message about the game jam.

<img width="1422" alt="Screenshot 2021-05-29 at 01 44 16" src="https://user-images.githubusercontent.com/7963776/120053273-2f014c00-c021-11eb-9018-eb168fbcd9da.png">

