### PR TITLE
Revert "Upgrade: Bump postcss from 7.0.35 to 8.3.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "jquery": "^3.6.0",
     "js-base64": "^3.6.1",
     "popper.js": "^1.16.1",
-    "postcss": "^8",
+    "postcss": "^7",
     "prismjs": "^1.23.0",
     "prop-types": "^15.7.2",
     "react": "^16.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8450,7 +8450,7 @@ postcss@^7, postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17, po
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-postcss@^8, postcss@^8.2.1:
+postcss@^8.2.1:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.3.0.tgz#b1a713f6172ca427e3f05ef1303de8b65683325f"
   integrity sha512-+ogXpdAjWGa+fdYY5BQ96V/6tAo+TdSSIMP5huJBIygdWwKtVoB5JWZ7yUd4xZ8r+8Kvvx4nyg/PQ071H4UtcQ==


### PR DESCRIPTION
Because:
* Tailwind requires Postcss 7 to compile.

This commit:
* Reverts TheOdinProject/theodinproject#1991