### PR TITLE
Changes order of webpack lessons in DB

### DIFF
--- a/db/fixtures/lessons/javascript_lessons.rb
+++ b/db/fixtures/lessons/javascript_lessons.rb
@@ -67,6 +67,13 @@ def javascript_lessons
       url: '/javascript/organizing-js/es6-modules.md',
       identifier_uuid: '0169e4d1-e381-49e0-897b-f9364ac10e51',
     },
+    'Webpack' => {
+      title: 'Webpack',
+      description: 'Webpack',
+      is_project: false,
+      url: '/javascript/organizing-js/webpack.md',
+      identifier_uuid: 'eedfa6c8-b041-497d-ab37-565708a1b075',
+    },
     'Restaurant Page' => {
       title: 'Restaurant Page',
       description: 'Restaurant Page',
@@ -112,13 +119,6 @@ def javascript_lessons
       is_project: false,
       url: '/javascript/js-in-the-real-world/forms.md',
       identifier_uuid: 'c95fe496-2223-4c96-bf3f-9d8e3796d233',
-    },
-    'Webpack' => {
-      title: 'Webpack',
-      description: 'Webpack',
-      is_project: false,
-      url: '/javascript/js-in-the-real-world/webpack.md',
-      identifier_uuid: 'eedfa6c8-b041-497d-ab37-565708a1b075',
     },
     'ES?' => {
       title: 'ES?',

--- a/db/fixtures/paths/full_stack_javascript/courses/1_javascript.rb
+++ b/db/fixtures/paths/full_stack_javascript/courses/1_javascript.rb
@@ -37,6 +37,7 @@ course.add_section do |section|
     javascript_lessons.fetch('Tic Tac Toe'),
     javascript_lessons.fetch('Classes'),
     javascript_lessons.fetch('ES6 Modules'),
+    javascript_lessons.fetch('Webpack'),
     javascript_lessons.fetch('Restaurant Page'),
     javascript_lessons.fetch('OOP Principles'),
     javascript_lessons.fetch('Todo List'),
@@ -55,7 +56,6 @@ course.add_section do |section|
     javascript_lessons.fetch('Linting'),
     javascript_lessons.fetch('Dynamic User Interface Interactions'),
     javascript_lessons.fetch('Forms'),
-    javascript_lessons.fetch('Webpack'),
     javascript_lessons.fetch('ES?'),
   )
 end

--- a/db/fixtures/paths/full_stack_rails/courses/5_javascript.rb
+++ b/db/fixtures/paths/full_stack_rails/courses/5_javascript.rb
@@ -37,6 +37,7 @@ course.add_section do |section|
     javascript_lessons.fetch('Tic Tac Toe'),
     javascript_lessons.fetch('Classes'),
     javascript_lessons.fetch('ES6 Modules'),
+    javascript_lessons.fetch('Webpack'),
     javascript_lessons.fetch('Restaurant Page'),
     javascript_lessons.fetch('OOP Principles'),
     javascript_lessons.fetch('Todo List'),
@@ -55,7 +56,6 @@ course.add_section do |section|
     javascript_lessons.fetch('Linting'),
     javascript_lessons.fetch('Dynamic User Interface Interactions'),
     javascript_lessons.fetch('Forms'),
-    javascript_lessons.fetch('Webpack'),
     javascript_lessons.fetch('ES?'),
   )
 end


### PR DESCRIPTION
#### Because:
<!--
If your pull request resolves an open issue, please provide a link to it. For example: Resolves: https://github.com/TheOdinProject/theodinproject/issues/1886
Otherwise, please briefly explain why these changes were made, what problem does it solve?.
-->
The Webpack lesson in the JS course needed to be re-ordered in the database. 

#### This commit
<!--
A bullet point list of one or more items outlining what was done in this pull request to solve the problem.
-->
- adds the lesson to the "Organizing JS" module and removes it from the "Javascript in the Real World" module

#### Checklist
 - [X] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [ ] You have verified the tests and linters all pass against your changes?
 - [ ] You have included automated tests for your changes where applicable?
