### PR TITLE
Chore: Replace Static Pages Controller Tests with Request Tests

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,7 +1,7 @@
 class StaticPagesController < ApplicationController
-  before_action :redirect_if_logged_in, only: :home
-
-  def home; end
+  def home
+    redirect_to dashboard_path if user_signed_in?
+  end
 
   def about; end
 
@@ -13,11 +13,5 @@ class StaticPagesController < ApplicationController
 
   def success_stories
     @success_stories = SuccessStory.all
-  end
-
-  private
-
-  def redirect_if_logged_in
-    redirect_to dashboard_path if current_user
   end
 end

--- a/spec/requests/static_pages_spec.rb
+++ b/spec/requests/static_pages_spec.rb
@@ -1,27 +1,23 @@
 require 'rails_helper'
 
-RSpec.describe StaticPagesController do
+RSpec.describe 'Static Pages', type: :request do
   describe 'GET #home' do
-    context 'guest user' do
-      before do
-        allow(controller).to receive(:current_user).and_return(nil)
-      end
-
+    context 'when guest user' do
       it 'renders the home page' do
-        get :home
+        get home_path
+
+        expect(response).to have_http_status(200)
         expect(response).to render_template(:home)
       end
     end
 
-    context 'when user is logged in' do
-      let(:user) { build_stubbed(:user) }
+    context 'when user is signed in' do
+      it 'redirects to the users dashboard' do
+        user = create(:user)
 
-      before do
-        allow(controller).to receive(:current_user).and_return(user)
-      end
+        sign_in(user)
+        get home_path
 
-      it 'redirects to the dashboard' do
-        get :home
         expect(response).to redirect_to(dashboard_path)
       end
     end
@@ -29,21 +25,27 @@ RSpec.describe StaticPagesController do
 
   describe 'GET #about' do
     it 'renders the about page' do
-      get :about
+      get about_path
+
+      expect(response).to have_http_status(200)
       expect(response).to render_template(:about)
     end
   end
 
   describe 'GET #terms_of_use' do
     it 'renders the terms of use page' do
-      get :terms_of_use
+      get terms_of_use_path
+
+      expect(response).to have_http_status(200)
       expect(response).to render_template(:terms_of_use)
     end
   end
 
   describe 'GET #success stories' do
     it 'renders the success stories page' do
-      get :success_stories
+      get success_stories_path
+
+      expect(response).to have_http_status(200)
       expect(response).to render_template(:success_stories)
     end
   end


### PR DESCRIPTION
Because:
* Controller tests have been depreciated for request specs.

This commit:
* Refactor the home redirect into the home action instead of using a before action since it is only used in the home action.
* Replace static pages controller specs with request specs.

#### Checklist
 - [ ] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [ ] You have verified the tests and linters all pass against your changes?
 - [ ] You have included automated tests for your changes where applicable?
