### PR TITLE
move testing lesson before react in js curriculum

### DIFF
--- a/db/fixtures/paths/full_stack_javascript/courses/1_javascript.rb
+++ b/db/fixtures/paths/full_stack_javascript/courses/1_javascript.rb
@@ -77,6 +77,22 @@ course.add_section do |section|
   )
 end
 
+# ++++++++++++++++++++++++++++
+# SECTION - Testing JavaScript
+# ++++++++++++++++++++++++++++
+course.add_section do |section|
+  section.title = 'Testing JavaScript'
+  section.description = "Test driven development is an important skill in today's dev world. This section digs into the details of writing automated JavaScript tests."
+  section.identifier_uuid = 'def99a36-0705-4b03-8aee-0aa0ae2b447c'
+
+  section.add_lessons(
+    javascript_lessons.fetch('Testing Basics'),
+    javascript_lessons.fetch('Testing Practice'),
+    javascript_lessons.fetch('More Testing'),
+    javascript_lessons.fetch('Battleship'),
+  )
+end
+
 # ++++++++++++++++++
 # SECTION - React JS
 # ++++++++++++++++++
@@ -96,22 +112,6 @@ course.add_section do |section|
     react_lessons.fetch('Router'),
     react_lessons.fetch('Shopping Cart'),
     react_lessons.fetch('Advanced Concepts'),
-  )
-end
-
-# ++++++++++++++++++++++++++++
-# SECTION - Testing JavaScript
-# ++++++++++++++++++++++++++++
-course.add_section do |section|
-  section.title = 'Testing JavaScript'
-  section.description = "Test driven development is an important skill in today's dev world. This section digs into the details of writing automated JavaScript tests."
-  section.identifier_uuid = 'def99a36-0705-4b03-8aee-0aa0ae2b447c'
-
-  section.add_lessons(
-    javascript_lessons.fetch('Testing Basics'),
-    javascript_lessons.fetch('Testing Practice'),
-    javascript_lessons.fetch('More Testing'),
-    javascript_lessons.fetch('Battleship'),
   )
 end
 


### PR DESCRIPTION
#### Because:
<!--
If your pull request resolves an open issue, please provide a link to it. For example: Resolves: https://github.com/TheOdinProject/theodinproject/issues/1886
Otherwise, please briefly explain why these changes were made, what problem does it solve?.
-->
I've been thinking about TDD and Battleship in the JS curriculum for a few days now, and more specifically how our students are approaching it in light of having just finished the react section.

The Battleship project is fantastic. In terms of its focus on testing and how it teaches the students to use tests to develop an application, it works very well. Using objects and methods to control the game logic, and testing those methods before creating a UI definitely helped me to refine the way I wrote object oriented code and separate logic from view.

However, there is one major flaw with the project, and that's the fact that it comes right after the react section of the course. Simply put, a beginner's understanding and mastery over react does not play well with this method of game logic without some significant workarounds. Using methods to mutate game logic objects almost invariably leads to directly mutating state, which has cause a number of issues with our students trying to figure out how to do this project right. You can see evidence of this by searching through #react-help  for "battleship" or just looking at the code of project submissions (mine included).

I know we don't explicitly tell students they should use react for this project, but almost all of them do because let's be real, writing react is a lot more fun than writing JS and compiling it with webpack yourself.

I've been thinking about how we can improve this for a few days now, and I'd like to recommend we move this section of the curriculum to just before react. Doing so, we would not need to modify the lesson at all to get around the pitfalls I mentioned. I think it actually fits well for other reasons too, in that it teaches about testing (a concept that is important to vanilla JS as much as frameworks) before hitting a framework (like many others, I believe JS should be learned rather thoroughly before diving into react).

#### This commit
<!--
A bullet point list of one or more items outlining what was done in this pull request to solve the problem.
-->

* Moves testing lessons and Battleship project to before the react section.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
