### PR TITLE
Remove bootstrap lesson

### DIFF
--- a/db/fixtures/lessons/html_and_css_lessons.rb
+++ b/db/fixtures/lessons/html_and_css_lessons.rb
@@ -187,15 +187,6 @@ def html_and_css_lessons
       url: '/html_css/css_frameworks.md',
       identifier_uuid: '54229a00-02f2-4aa8-87b3-0d471beb734d',
     },
-    'Using Bootstrap' => {
-      title: 'Using Bootstrap',
-      description: 'Test out working with the Bootstrap framework.  It may feel a bit odd at first but it makes your life MUCH easier once you figure out the gist of it. ',
-      is_project: true,
-      url: '/html_css/project_bootstrap.md',
-      accepts_submission: true,
-      has_live_preview: true,
-      identifier_uuid: 'd7c5eed1-7252-45e7-8946-199eed8b258b',
-    },
     'Animations, Subtle Effects and Compatibility' => {
       title: 'Animations, Subtle Effects and Compatibility',
       description: 'Dive into some of the more interesting stylistic tools at your disposal like transitions and animations that use only CSS3.',

--- a/db/fixtures/paths/full_stack_javascript/courses/2_html_and_css.rb
+++ b/db/fixtures/paths/full_stack_javascript/courses/2_html_and_css.rb
@@ -89,7 +89,6 @@ course.add_section do |section|
     html_and_css_lessons.fetch('Responsive Design'),
     html_and_css_lessons.fetch('Building with Responsive Design'),
     html_and_css_lessons.fetch('CSS Frameworks like Bootstrap and Foundation'),
-    html_and_css_lessons.fetch('Using Bootstrap'),
   )
 end
 

--- a/db/fixtures/paths/full_stack_rails/courses/4_html_and_css.rb
+++ b/db/fixtures/paths/full_stack_rails/courses/4_html_and_css.rb
@@ -89,7 +89,6 @@ course.add_section do |section|
     html_and_css_lessons.fetch('Responsive Design'),
     html_and_css_lessons.fetch('Building with Responsive Design'),
     html_and_css_lessons.fetch('CSS Frameworks like Bootstrap and Foundation'),
-    html_and_css_lessons.fetch('Using Bootstrap'),
   )
 end
 


### PR DESCRIPTION
#### Because:
<!--
If your pull request resolves an open issue, please provide a link to it. For example: Resolves: https://github.com/TheOdinProject/theodinproject/issues/1886
Otherwise, please briefly explain why these changes were made, what problem does it solve?.
-->



Related to [issue #21944 in curriculum repo](https://github.com/TheOdinProject/curriculum/issues/21944).

Bootstrap lesson should be removed.

#### This commit
<!--
A bullet point list of one or more items outlining what was done in this pull request to solve the problem.
-->
* Removes the bootstrap lesson from the html & css courses.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
