### PR TITLE
Chore: Scope Lessons to Courses.

### DIFF
--- a/db/migrate/20210622162155_add_course_id_to_lessons.rb
+++ b/db/migrate/20210622162155_add_course_id_to_lessons.rb
@@ -1,0 +1,18 @@
+class AddCourseIdToLessons < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :lessons, :course, index: true
+    add_foreign_key :lessons, :courses
+
+    remove_index :lessons, %i[identifier_uuid section_id], unique: true
+    add_index :lessons, %i[identifier_uuid course_id], unique: true
+
+    sql = %(
+      Update lessons
+      set course_id = sections.course_id
+      from sections
+      where lessons.section_id = sections.id
+    )
+
+    ActiveRecord::Base.connection.execute(sql)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_12_034228) do
+ActiveRecord::Schema.define(version: 2021_06_22_162155) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -105,7 +105,9 @@ ActiveRecord::Schema.define(version: 2021_05_12_034228) do
     t.boolean "has_live_preview", default: false, null: false
     t.boolean "choose_path_lesson", default: false, null: false
     t.string "identifier_uuid", default: "", null: false
-    t.index ["identifier_uuid", "section_id"], name: "index_lessons_on_identifier_uuid_and_section_id", unique: true
+    t.bigint "course_id"
+    t.index ["course_id"], name: "index_lessons_on_course_id"
+    t.index ["identifier_uuid", "course_id"], name: "index_lessons_on_identifier_uuid_and_course_id", unique: true
     t.index ["position"], name: "index_lessons_on_position"
     t.index ["slug", "section_id"], name: "index_lessons_on_slug_and_section_id", unique: true
     t.index ["url"], name: "index_lessons_on_url"
@@ -248,6 +250,7 @@ ActiveRecord::Schema.define(version: 2021_05_12_034228) do
   add_foreign_key "flags", "project_submissions"
   add_foreign_key "flags", "users", column: "flagger_id"
   add_foreign_key "lesson_completions", "lessons", on_delete: :cascade
+  add_foreign_key "lessons", "courses"
   add_foreign_key "path_prerequisites", "paths"
   add_foreign_key "path_prerequisites", "paths", column: "prerequisite_id"
   add_foreign_key "project_submissions", "lessons"

--- a/lib/seeds/lesson_seeder.rb
+++ b/lib/seeds/lesson_seeder.rb
@@ -12,7 +12,7 @@ module Seeds
 
     # rubocop: disable Metrics/AbcSize, Metrics/MethodLength
     def lesson
-      Lesson.seed(:identifier_uuid, :section_id) do |lesson|
+      Lesson.seed(:identifier_uuid, :course_id) do |lesson|
         lesson.identifier_uuid = attributes.fetch(:identifier_uuid)
         lesson.title = attributes.fetch(:title)
         lesson.description = attributes.fetch(:description)
@@ -22,6 +22,7 @@ module Seeds
         lesson.accepts_submission = attributes.fetch(:accepts_submission, false)
         lesson.has_live_preview = attributes.fetch(:has_live_preview, false)
         lesson.position = position
+        lesson.course_id = section.course_id
       end
     end
     # rubocop: enable Metrics/AbcSize, Metrics/MethodLength

--- a/spec/lib/seeds/course_seeder_spec.rb
+++ b/spec/lib/seeds/course_seeder_spec.rb
@@ -108,12 +108,12 @@ RSpec.describe Seeds::CourseSeeder do
 
     it 'deletes lessons that are in the db but removed from the seeds file' do
       course = create(:course, identifier_uuid: 'course_uuid')
-      section_one = create(:section, identifier_uuid: 'section_uuid_1', course_id: course.id)
-      section_two = create(:section, identifier_uuid: 'section_uuid_2', course_id: course.id)
+      section_one = create(:section, identifier_uuid: 'section_uuid_1', course: course)
+      section_two = create(:section, identifier_uuid: 'section_uuid_2', course: course)
 
-      create(:lesson, section_id: section_one.id, identifier_uuid: 'lesson_uuid_1')
-      lesson_two = create(:lesson, section_id: section_two.id, identifier_uuid: 'lesson_uuid_2')
-      create(:lesson, section_id: section_one.id, identifier_uuid: 'lesson_uuid_3')
+      create(:lesson, section: section_one, course_id: course.id, identifier_uuid: 'lesson_uuid_1')
+      lesson_two = create(:lesson, section: section_two, course_id: course.id, identifier_uuid: 'lesson_uuid_2')
+      create(:lesson, section: section_one, course_id: course.id, identifier_uuid: 'lesson_uuid_3')
 
       course_seeder.add_section do |section|
         section.identifier_uuid = 'section_uuid_2'

--- a/spec/lib/seeds/lesson_seeder_spec.rb
+++ b/spec/lib/seeds/lesson_seeder_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 RSpec.describe Seeds::LessonSeeder do
   subject(:lesson_seeder) { described_class.create(section, position, attributes) }
 
-  let(:section) { create(:section) }
+  let(:section) { create(:section, course: course) }
+  let(:course) { create(:course) }
   let(:position) { 1 }
   let(:attributes) do
     {
@@ -111,7 +112,8 @@ RSpec.describe Seeds::LessonSeeder do
           identifier_uuid: 'lesson_uuid',
           title: 'JS Lesson',
           position: 2,
-          section: section
+          section: section,
+          course_id: course.id,
         )
 
         expect { lesson_seeder }.to change { existing_lesson.reload.title }


### PR DESCRIPTION
Because:
* This will allow us to move lessons between sections in the same course without duplicating them in the db.

This commit:
* Add a course_id reference column to the lessons table.
* Replace the lesson seeder section_id constraint with course_id so lessons can be moved between sections in a course.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
