### PR TITLE
Feature: Allow Points API Consumers to Pass through a Points Value to Increment By

### DIFF
--- a/app/controllers/api/points_controller.rb
+++ b/app/controllers/api/points_controller.rb
@@ -3,7 +3,7 @@ class Api::PointsController < ApplicationController
   before_action :authenticate, except: %i[index show]
 
   def index
-    render json: Point.all.order(points: :desc).limit(limit).offset(offset)
+    render json: Point.all.order(points: :desc).limit(params[:limit]).offset(params[:offset])
   end
 
   def show
@@ -24,14 +24,6 @@ class Api::PointsController < ApplicationController
   end
 
   private
-
-  def offset
-    params[:offset]
-  end
-
-  def limit
-    params[:limit]
-  end
 
   def authenticate
     authenticate_or_request_with_http_token do |token|

--- a/app/controllers/api/points_controller.rb
+++ b/app/controllers/api/points_controller.rb
@@ -18,9 +18,13 @@ class Api::PointsController < ApplicationController
 
   def create
     user_points = Point.find_or_create_by(discord_id: params[:discord_id].to_i)
-    user_points.increment_points
+    value = params.fetch(:value, 1).to_i
 
-    render json: user_points
+    if user_points.increment_points_by(value)
+      render json: user_points
+    else
+      render json: { message: 'Unable to update points' }
+    end
   end
 
   private

--- a/app/models/point.rb
+++ b/app/models/point.rb
@@ -1,7 +1,12 @@
 class Point < ApplicationRecord
+  LOWEST_ALLOWED_INCREMENT = 1
+  MAX_ALLOWED_INCREMENT = 5
+
   validates :discord_id, presence: true, uniqueness: true
 
-  def increment_points
-    increment(:points).save!
+  def increment_points_by(value)
+    return unless value.between?(LOWEST_ALLOWED_INCREMENT, MAX_ALLOWED_INCREMENT)
+
+    update!(points: self.points += value)
   end
 end

--- a/spec/factories/points.rb
+++ b/spec/factories/points.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :point do
+    sequence :discord_id do |n|
+      n
+    end
+  end
+end

--- a/spec/models/point_spec.rb
+++ b/spec/models/point_spec.rb
@@ -6,11 +6,27 @@ RSpec.describe Point do
   it { is_expected.to validate_presence_of(:discord_id) }
   it { is_expected.to validate_uniqueness_of(:discord_id).case_insensitive }
 
-  describe '#increment_points' do
+  describe '#increment_points_by' do
     let(:user_points) { Point.create(discord_id: '1234') }
 
-    it 'increments the points' do
-      expect { user_points.increment_points }.to change { user_points.reload.points }.from(0).to(1)
+    it 'increments the points by 1' do
+      expect { user_points.increment_points_by(1) }.to change(user_points, :points).from(0).to(1)
+    end
+
+    it 'increments the points by 2' do
+      expect { user_points.increment_points_by(2) }.to change(user_points, :points).from(0).to(2)
+    end
+
+    it 'increments the points by 5' do
+      expect { user_points.increment_points_by(5) }.to change(user_points, :points).from(0).to(5)
+    end
+
+    it 'does not increment the points by 0' do
+      expect { user_points.increment_points_by(0) }.not_to change(user_points, :points)
+    end
+
+    it 'does not increment the points by 6' do
+      expect { user_points.increment_points_by(6) }.not_to change(user_points, :points)
     end
   end
 end

--- a/spec/requests/api/points_spec.rb
+++ b/spec/requests/api/points_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe 'Static Pages', type: :request do
         expect do
           post(
             '/api/points',
-            params: { discord_id: 1007 },
+            params: { discord_id: 1007, value: 1 },
             headers: { 'Authorization' => 'Token ODIN_BOT_ACCESS_TOKEN' }
           )
         end.to change {
@@ -69,12 +69,22 @@ RSpec.describe 'Static Pages', type: :request do
         expect do
           post(
             '/api/points',
-            params: { discord_id: 1007 },
+            params: { discord_id: 1007, value: 5 },
             headers: { 'Authorization' => 'Token ODIN_BOT_ACCESS_TOKEN' }
           )
-        end.to change {
-          Point.count
-        }.from(0).to(1)
+        end.to change(Point, :count).from(0).to(1)
+      end
+
+      it 'returns an error message if it cannot increment the users points' do
+        create(:point, points: 1, discord_id: 1007)
+
+        post(
+          '/api/points',
+          params: { discord_id: 1007, value: 6 },
+          headers: { 'Authorization' => 'Token ODIN_BOT_ACCESS_TOKEN' }
+        )
+
+        expect(JSON.parse(response.body)).to eq({ 'message' => 'Unable to update points' })
       end
     end
 
@@ -82,15 +92,11 @@ RSpec.describe 'Static Pages', type: :request do
       it 'does not increment the discord users points' do
         user_points = create(:point, points: 6, discord_id: 1007)
 
-        expect { post '/api/points', params: { discord_id: 1007 } }.not_to(
-          change { user_points.reload.points }
-        )
+        expect { post '/api/points', params: { discord_id: 1007 } }.not_to change(user_points, :points)
       end
 
       it 'does not create a points record if the discord user does not exist' do
-        expect { post '/api/points', params: { discord_id: 1007 } }.not_to(
-          change { Point.count }
-        )
+        expect { post '/api/points', params: { discord_id: 1007 } }.not_to change(Point, :count)
       end
     end
   end

--- a/spec/requests/api/points_spec.rb
+++ b/spec/requests/api/points_spec.rb
@@ -1,0 +1,97 @@
+require 'rails_helper'
+
+RSpec.describe 'Static Pages', type: :request do
+  describe 'GET #index' do
+    it 'returns all points ordered by the highest amount' do
+      highest_points = create(:point, points: 6)
+      middle_points = create(:point, points: 5)
+      lowest_points = create(:point, points: 1)
+
+      get api_points_path
+      expect(JSON.parse(response.body)).to eq(
+        [highest_points, middle_points, lowest_points].map(&:as_json)
+      )
+    end
+
+    context 'when limit and offset params are provided' do
+      it 'returns the filtererd points ordered by highest' do
+        create(:point, points: 6)
+        create(:point, points: 1)
+        middle_points = create(:point, points: 5)
+
+        get api_points_path(offset: 1, limit: 1)
+        expect(JSON.parse(response.body)).to eq([middle_points.as_json])
+      end
+    end
+  end
+
+  describe 'GET #show' do
+    it 'returns the points for that discord user' do
+      user_points = create(:point, points: 6, discord_id: 907)
+
+      get api_point_path(id: 907)
+
+      expect(JSON.parse(response.body)).to eq(user_points.as_json)
+    end
+
+    it 'returns an error message if the discord user cannot be found' do
+      get api_point_path(id: 907)
+
+      expect(JSON.parse(response.body)).to eq({ 'message' => 'Unable to find that user' })
+    end
+  end
+
+  describe 'GET #create' do
+    context 'when authenticated' do
+      around do |example|
+        ClimateControl.modify(
+          ODIN_BOT_ACCESS_TOKEN: 'ODIN_BOT_ACCESS_TOKEN'
+        ) do
+          example.run
+        end
+      end
+
+      it 'increments the discord users points' do
+        user_points = create(:point, points: 6, discord_id: 1007)
+
+        expect do
+          post(
+            '/api/points',
+            params: { discord_id: 1007 },
+            headers: { 'Authorization' => 'Token ODIN_BOT_ACCESS_TOKEN' }
+          )
+        end.to change {
+          user_points.reload.points
+        }.from(6).to(7)
+      end
+
+      it 'creates a new points record if the discord user does not exist' do
+        expect do
+          post(
+            '/api/points',
+            params: { discord_id: 1007 },
+            headers: { 'Authorization' => 'Token ODIN_BOT_ACCESS_TOKEN' }
+          )
+        end.to change {
+          Point.count
+        }.from(0).to(1)
+      end
+    end
+
+    context 'when unauthenticated' do
+      it 'does not increment the discord users points' do
+        user_points = create(:point, points: 6, discord_id: 1007)
+
+        expect { post '/api/points', params: { discord_id: 1007 } }.not_to(
+          change { user_points.reload.points }
+        )
+      end
+
+      it 'does not create a points record if the discord user does not exist' do
+        expect { post '/api/points', params: { discord_id: 1007 } }.not_to(
+          change { Point.count }
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### Because:
* We want to award more points for different bot commands.

#### This commit
* Adds Request specs around the points api
* Changes the create points api to accept a value param.
* Allows the points model to increment by more than 1.
* Limits the increment to 5 at a time to ensure consumers cannot abuse the api.

Resolves: https://github.com/TheOdinProject/theodinproject/issues/2057

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
