### PR TITLE
Chore: Unscope Lesson Slugs from their Path/Course.

### DIFF
--- a/app/admin/flags.rb
+++ b/app/admin/flags.rb
@@ -34,11 +34,7 @@ ActiveAdmin.register Flag do
       row :lesson do
         link_to(
           flag.project_submission.lesson.title,
-          path_course_lesson_path(
-            flag.project_submission.lesson.path,
-            flag.project_submission.lesson.course,
-            flag.project_submission.lesson
-          ),
+          lesson_path(flag.project_submission.lesson),
           target: '_blank', rel: 'noopener'
         )
       end

--- a/app/controllers/lessons/project_submissions_controller.rb
+++ b/app/controllers/lessons/project_submissions_controller.rb
@@ -23,10 +23,7 @@ module Lessons
     def check_if_project_submitable
       return if @lesson.accepts_submission?
 
-      redirect_to(
-        path_course_lesson_url(@lesson.course.path, @lesson.course, @lesson),
-        alert: 'This project does not accept submissions'
-      )
+      redirect_to(lesson_path(@lesson), alert: 'This project does not accept submissions')
     end
   end
 end

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -23,10 +23,16 @@ class LessonsController < ApplicationController
   end
 
   def lesson
-    course.lessons.find(params[:id])
+    if course.present?
+      course.lessons.find(params[:id])
+    else
+      Lesson.find(params[:id])
+    end
   end
 
   def course
+    return unless params[:path_id].present? && params[:course_id].present?
+
     Path.find(params[:path_id]).courses.find(params[:course_id])
   end
 end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -1,7 +1,7 @@
 class Lesson < ApplicationRecord
   extend FriendlyId
 
-  friendly_id :slug_candidates, use: %i[scoped slugged history finders], scope: :section
+  friendly_id :slug_candidates, use: %i[slugged history finders]
 
   belongs_to :section
   has_one :course, through: :section
@@ -31,11 +31,9 @@ class Lesson < ApplicationRecord
   def slug_candidates
     [
       :title,
-      [:title, course_title]
+      [section&.title, :title],
+      [section&.title, course&.title, :title],
+      [section&.title, course&.title, path&.title, :title]
     ]
-  end
-
-  def course_title
-    course&.title
   end
 end

--- a/app/serializers/project_submission_serializer.rb
+++ b/app/serializers/project_submission_serializer.rb
@@ -21,7 +21,7 @@ class ProjectSubmissionSerializer
       user_id: project_submission.user.id,
       lesson_id: lesson.id,
       lesson_title: lesson.title,
-      lesson_path: path_course_lesson_path(lesson.course.path, lesson.course, lesson),
+      lesson_path: lesson_path(lesson),
       lesson_has_live_preview: lesson.has_live_preview,
       likes: project_submission.votes_for.size,
       is_liked_by_current_user: current_user_voted_for_project?

--- a/app/views/lessons/_lesson_buttons.html.erb
+++ b/app/views/lessons/_lesson_buttons.html.erb
@@ -9,7 +9,7 @@
 
 <% if lesson.next_lesson %>
   <%= link_to 'Next Lesson',
-      path_course_lesson_path(course.path, course, lesson.next_lesson),
+      lesson_path(lesson.next_lesson),
       title: "Move on to '#{lesson.next_lesson.title}'",
       class: "button #{next_lesson_button_state(lesson)} lesson-button-group__item lesson-button",
       data: { test_id: 'next-lesson-btn' }

--- a/app/views/users/_skill.html.erb
+++ b/app/views/users/_skill.html.erb
@@ -15,11 +15,7 @@
       <%= link_to 'Open', path_course_path(course.path, course), class: 'button button--transparent skill__button', data: { test_id: "#{course.title.downcase}-open-btn" } %>
     <% elsif course_started_by_user?(course, current_user) %>
       <%= link_to 'Resume',
-        path_course_lesson_url(
-          course.path,
-          course,
-          next_lesson_to_complete(course, current_user.lesson_completions_for_course(course))
-        ),
+        lesson_path(next_lesson_to_complete(course, current_user.lesson_completions_for_course(course))),
         class: 'button button--primary skill__button',
         data: { test_id: "#{course.title.downcase}-resume-btn" }
       %>

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Lesson do
-  subject(:lesson) { described_class.new }
+  subject(:lesson) { create(:lesson) }
 
   it { is_expected.to belong_to(:section) }
   it { is_expected.to have_one(:course).through(:section) }
@@ -42,7 +42,7 @@ RSpec.describe Lesson do
     end
   end
 
-  describe '#import' do
+  describe '#import_content_from_github' do
     it 'uses the lesson content importer to get lesson content from github' do
       expect(LessonContentImporter).to receive(:for).with(lesson)
       lesson.import_content_from_github

--- a/spec/requests/lesson_spec.rb
+++ b/spec/requests/lesson_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe 'Lesson', type: :request do
+  describe 'GET #show' do
+    context 'when path_id and course_id params are present' do
+      it 'finds the lesson using the path and course params' do
+        lesson = create(:lesson)
+
+        get path_course_lesson_path(lesson.path, lesson.course, lesson)
+
+        expect(response).to have_http_status(200)
+        expect(response).to render_template(:show)
+      end
+    end
+
+    context 'when path_id and course_id params are not present' do
+      it 'finds the lesson using the id param' do
+        lesson = create(:lesson)
+
+        get lesson_path(lesson)
+
+        expect(response).to have_http_status(200)
+        expect(response).to render_template(:show)
+      end
+    end
+  end
+end

--- a/spec/serializers/project_submission_serializer_spec.rb
+++ b/spec/serializers/project_submission_serializer_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe ProjectSubmissionSerializer do
         user_id: 123,
         lesson_id: 12,
         lesson_title: 'A LESSON TITLE',
-        lesson_path: '/paths/a-path/courses/a-course/lessons/a-lesson-title',
+        lesson_path: '/lessons/a-lesson-title',
         lesson_has_live_preview: true,
         likes: 0,
         is_liked_by_current_user: nil

--- a/spec/system/admin/flags_spec.rb
+++ b/spec/system/admin/flags_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'Admin Flags', type: :system do
     end
 
     it 'removes the submission from the lesson page' do
-      visit path_course_lesson_path(lesson.course.path, lesson.course, lesson)
+      visit lesson_path(lesson)
 
       within(:test_id, 'submissions-list') do
         expect(page).not_to have_content(submission_owner.username)
@@ -81,7 +81,7 @@ RSpec.describe 'Admin Flags', type: :system do
     end
 
     it 'removes the submission from the lesson' do
-      visit path_course_lesson_path(lesson.course.path, lesson.course, lesson)
+      visit lesson_path(lesson)
 
       within(:test_id, 'submissions-list') do
         expect(page).not_to have_content(submission_owner.username)

--- a/spec/system/all_lesson_project_submissions_spec.rb
+++ b/spec/system/all_lesson_project_submissions_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'View all Project Submissions for a Lesson', type: :system do
 
     it 'paginates the results' do
       create_list(:project_submission, 20, lesson: lesson)
-      visit path_course_lesson_path(lesson.section.course.path, lesson.section.course, lesson)
+      visit lesson_path(lesson)
       find(:test_id, 'view-all-projects-link').click
 
       within(:test_id, 'submissions-list') do
@@ -27,8 +27,7 @@ RSpec.describe 'View all Project Submissions for a Lesson', type: :system do
     it 'does not have an all project submissions page for the lesson' do
       visit lesson_project_submissions_path(lesson)
 
-      expect(page).to have_current_path(path_course_lesson_path(lesson.section.course.path, lesson.section.course,
-                                                                lesson))
+      expect(page).to have_current_path(lesson_path(lesson))
       expect(find(:test_id, 'flash')).to have_content('This project does not accept submissions')
     end
   end

--- a/spec/system/course_progress_badge_spec.rb
+++ b/spec/system/course_progress_badge_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Course Progress Badge', type: :system do
 
   context 'when course has some progress' do
     it 'shows percentage of completion' do
-      visit path_course_lesson_path(path, course, first_lesson)
+      visit lesson_path(first_lesson)
       find(:test_id, 'complete_btn').click
       visit path_course_path(path, course)
 
@@ -36,9 +36,9 @@ RSpec.describe 'Course Progress Badge', type: :system do
 
   context 'when course is completed' do
     it 'shows 100% completion' do
-      visit path_course_lesson_path(path, course, first_lesson)
+      visit lesson_path(first_lesson)
       find(:test_id, 'complete_btn').click
-      visit path_course_lesson_path(path, course, second_lesson)
+      visit lesson_path(second_lesson)
       find(:test_id, 'complete_btn').click
       visit path_course_path(path, course)
 

--- a/spec/system/lesson_completion_spec.rb
+++ b/spec/system/lesson_completion_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Lesson Completions', type: :system do
   context 'when user is signed in' do
     before do
       sign_in(user)
-      visit path_course_lesson_path(path, course, lesson)
+      visit lesson_path(lesson)
     end
 
     it 'can complete a lesson' do
@@ -38,7 +38,7 @@ RSpec.describe 'Lesson Completions', type: :system do
 
   context 'when user is not signed in' do
     it 'cannot complete a lesson' do
-      visit path_course_lesson_path(path, course, lesson)
+      visit lesson_path(lesson)
 
       expect(page).to have_no_submit_button('complete_btn')
       expect(page).to have_no_submit_button('incomplete_btn')

--- a/spec/system/lesson_navigation_spec.rb
+++ b/spec/system/lesson_navigation_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Navigating Lessons', type: :system do
       let!(:next_lesson) { create(:lesson, position: 2, section: section) }
 
       it 'moves to the next lesson in the section when clicked' do
-        visit path_course_lesson_path(path, course, lesson)
+        visit lesson_path(lesson)
         find(:test_id, 'next-lesson-btn').click
 
         expect(find(:test_id, 'lesson-title-header')).to have_text(/#{next_lesson.title}/i)
@@ -28,7 +28,7 @@ RSpec.describe 'Navigating Lessons', type: :system do
       let!(:next_section_lesson) { create(:lesson, position: 2, section: next_section) }
 
       it 'moves to the first lesson in the next section when clicked' do
-        visit path_course_lesson_path(path, course, lesson)
+        visit lesson_path(lesson)
         find(:test_id, 'next-lesson-btn').click
 
         expect(find(:test_id, 'lesson-title-header')).to have_text(/#{next_section_lesson.title}/i)
@@ -37,7 +37,7 @@ RSpec.describe 'Navigating Lessons', type: :system do
 
     context 'on last lesson in the course' do
       it 'should not be present' do
-        visit path_course_lesson_path(path, course, lesson)
+        visit lesson_path(lesson)
 
         expect(page).to have_no_selector('[data-test-id="next-lesson-btn"]')
       end
@@ -46,7 +46,7 @@ RSpec.describe 'Navigating Lessons', type: :system do
 
   describe 'the View Course button' do
     it 'directs to the course view' do
-      visit path_course_lesson_path(path, course, lesson)
+      visit lesson_path(lesson)
       find(:test_id, 'view-course-btn').click
 
       expect(find(:test_id, 'course-title-header')).to have_text(/#{course.title}/i)
@@ -61,7 +61,7 @@ RSpec.describe 'Navigating Lessons', type: :system do
     let!(:choose_path_lesson) { create(:lesson, position: 2, section: section, choose_path_lesson: true) }
 
     it 'directs the user to the path selection page' do
-      visit path_course_lesson_path(path, course, choose_path_lesson)
+      visit lesson_path(choose_path_lesson)
       find(:test_id, 'choose-path-lesson-btn').click
 
       expect(page).to have_current_path(paths_path)

--- a/spec/system/lesson_project_submissions/add_submission_spec.rb
+++ b/spec/system/lesson_project_submissions/add_submission_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Add a Project Submission', type: :system do
 
     before do
       sign_in(user)
-      visit path_course_lesson_path(lesson.section.course.path, lesson.section.course, lesson)
+      visit lesson_path(lesson)
     end
 
     it 'successfully adds a submission' do
@@ -37,7 +37,7 @@ RSpec.describe 'Add a Project Submission', type: :system do
         end
 
         using_session('another_user') do
-          visit path_course_lesson_path(lesson.section.course.path, lesson.section.course, lesson)
+          visit lesson_path(lesson)
 
           within(:test_id, 'submissions-list') do
             expect(page).not_to have_content(user.username)
@@ -49,7 +49,7 @@ RSpec.describe 'Add a Project Submission', type: :system do
 
   context 'when a user is not signed in' do
     before do
-      visit path_course_lesson_path(lesson.section.course.path, lesson.section.course, lesson)
+      visit lesson_path(lesson)
     end
 
     it 'they cannot add a project submission' do

--- a/spec/system/lesson_project_submissions/delete_submission_spec.rb
+++ b/spec/system/lesson_project_submissions/delete_submission_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Deleting a Project Submission', type: :system do
 
   before do
     sign_in(user)
-    visit path_course_lesson_path(lesson.section.course.path, lesson.section.course, lesson)
+    visit lesson_path(lesson)
     Pages::ProjectSubmissions::Form.fill_in_and_submit
   end
 

--- a/spec/system/lesson_project_submissions/edit_submission_spec.rb
+++ b/spec/system/lesson_project_submissions/edit_submission_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Editing a Project Submission', type: :system do
 
   before do
     sign_in(user)
-    visit path_course_lesson_path(lesson.section.course.path, lesson.section.course, lesson)
+    visit lesson_path(lesson)
     Pages::ProjectSubmissions::Form.fill_in_and_submit
   end
 

--- a/spec/system/lesson_project_submissions/flag_submission_spec.rb
+++ b/spec/system/lesson_project_submissions/flag_submission_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Flagging a Project Submission', type: :system do
 
   before do
     sign_in(user)
-    visit path_course_lesson_path(lesson.section.course.path, lesson.section.course, lesson)
+    visit lesson_path(lesson)
   end
 
   it 'successfully flags a submission' do

--- a/spec/system/lesson_project_submissions/voting_spec.rb
+++ b/spec/system/lesson_project_submissions/voting_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Voting on Project Submissions', type: :system do
 
   before do
     sign_in(user)
-    visit path_course_lesson_path(lesson.section.course.path, lesson.section.course, lesson)
+    visit lesson_path(lesson)
   end
 
   it 'a user can vote on another users submission' do

--- a/spec/system/user_dashboard/open_course_spec.rb
+++ b/spec/system/user_dashboard/open_course_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe 'Opening Course from User Dashboard', type: :system do
   context 'when user has completed a course' do
     before do
       sign_in(user)
-      visit path_course_lesson_path(default_path, foundations_course, first_lesson)
+      visit lesson_path(first_lesson)
       find(:test_id, 'complete_btn').click
-      visit path_course_lesson_path(default_path, foundations_course, second_lesson)
+      visit lesson_path(second_lesson)
       find(:test_id, 'complete_btn').click
       visit dashboard_path
     end

--- a/spec/system/user_dashboard/resume_course_spec.rb
+++ b/spec/system/user_dashboard/resume_course_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Resuming Course from User Dashboard', type: :system do
   context 'when user has completed first lesson in course' do
     before do
       sign_in(user)
-      visit path_course_lesson_path(default_path, foundations_course, lesson)
+      visit lesson_path(lesson)
       find(:test_id, 'complete_btn').click
       visit dashboard_path
     end
@@ -23,7 +23,7 @@ RSpec.describe 'Resuming Course from User Dashboard', type: :system do
     it 'successfully resumes next incomplete lesson' do
       find(:test_id, 'foundations-resume-btn').click
 
-      expect(page).to have_current_path(path_course_lesson_path(default_path, foundations_course, incomplete_lesson))
+      expect(page).to have_current_path(lesson_path(incomplete_lesson))
     end
   end
 end

--- a/spec/system/user_project_submissions/edit_submission_spec.rb
+++ b/spec/system/user_project_submissions/edit_submission_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'Editing a Project Submission on the Dashboard', type: :system do
     end
 
     using_session('another_user') do
-      visit path_course_lesson_path(lesson.section.course.path, lesson.section.course, lesson)
+      visit lesson_path(lesson)
 
       within(:test_id, 'submissions-list') do
         expect(page).not_to have_content(user.username)


### PR DESCRIPTION
Because:
* At present we have to provide the lessons path and course when generating lesson path routes. This results in messy code and very long lesson paths in a few cases.

This commit:
* Remove the friendly is scope on lessons so we can generate unique slugs for lessons with the same name.
* Keep external urls that use the old scheme working by adding a conditional to only use the path and course params when finding lessons if those params have been provided.
* Add a request spec around the above conditional behaviour.
* Update all instances of path_course_lesson_url route helpers to now use the shorter lesson_path route helper.


#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
