### PR TITLE
Chore: Cache Asset Compilation Between Builds

### DIFF
--- a/.buildcache
+++ b/.buildcache
@@ -1,0 +1,6 @@
+public/packs
+tmp/cache/assets
+tmp/cache/webpacker
+~/.cache/yarn
+node_modules
+tmp/cache/bootsnap-load-path-cache

--- a/.slugcleanup
+++ b/.slugcleanup
@@ -1,0 +1,8 @@
+app/javascript
+app/assets/fonts
+app/assets/images
+app/assets/javascripts
+app/assets/stylesheets
+node_modules
+spec
+tmp/cache

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'activeadmin'
 gem 'activeadmin_addons', '~> 1.8.2'
 gem 'active_material'
 gem 'acts_as_votable'
+gem 'bootsnap', '~> 1.7.5', require: false
 gem 'bootstrap', '4.6.0'
 gem 'cancancan'
 gem 'devise', '>= 4.7.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,8 @@ GEM
     bindex (0.8.1)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
+    bootsnap (1.7.5)
+      msgpack (~> 1.0)
     bootstrap (4.6.0)
       autoprefixer-rails (>= 9.1.0)
       popper_js (>= 1.14.3, < 2)
@@ -281,6 +283,7 @@ GEM
     mini_mime (1.1.0)
     mini_portile2 (2.5.3)
     minitest (5.14.4)
+    msgpack (1.4.2)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
@@ -549,6 +552,7 @@ DEPENDENCIES
   acts_as_votable
   better_errors
   binding_of_caller (~> 1.0)
+  bootsnap (~> 1.7.5)
   bootstrap (= 4.6.0)
   cancancan
   capybara

--- a/app.json
+++ b/app.json
@@ -7,10 +7,19 @@
       ],
       "buildpacks": [
         {
+          "url": "https://github.com/carwow/heroku-buildpack-cacheload.git"
+        },
+        {
           "url": "heroku/ruby"
         },
         {
           "url": "https://github.com/gaffneyc/heroku-buildpack-jemalloc.git"
+        },
+        {
+          "url": "https://github.com/carwow/heroku-buildpack-cachesave.git"
+        },
+        {
+          "url": "https://github.com/carwow/heroku-buildpack-cleanup.git"
         }
       ],
       "addons": [

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,4 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
+require 'bootsnap/setup'

--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -1,0 +1,16 @@
+# https://github.com/heroku/heroku-buildpack-ruby/pull/892#issuecomment-640900787
+namespace :yarn do
+  task install: :environment do
+    # don't run if webpacker doesn't need to run
+    next unless Webpacker::Instance.new.compiler.stale?
+
+    # These yarn settings come from the nodejs buildpack
+    # https://github.com/heroku/heroku-buildpack-nodejs/blob/02af461e42c37e7d10120e94cb1f2fa8508cb2a5/lib/dependencies.sh
+    yarn_flags = '--production=false --frozen-lockfile --ignore-engines --prefer-offline --cache-folder=~/.cache/yarn'
+
+    puts '*** [yarn:install] Configuring yarn with all build dependencies'
+    command = "yarn install #{yarn_flags}"
+    puts "Running: #{command}"
+    system command
+  end
+end


### PR DESCRIPTION
Because:
* It will speed up our build time during deploy.

This commit:
* Adds Bootsnap for quicker boots.
* Adds buildcache that is used with the cache load and save heroku build packs.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
