### PR TITLE
Fix: Automatic Curriculum Content Updates

### DIFF
--- a/app/controllers/github_webhooks_controller.rb
+++ b/app/controllers/github_webhooks_controller.rb
@@ -1,6 +1,8 @@
 class GithubWebhooksController < ApplicationController
   include GithubWebhook::Processor
 
+  skip_before_action :verify_authenticity_token
+
   def github_push(payload)
     event = ::GithubPushEventAdaptor.new(payload)
 


### PR DESCRIPTION
Because:
* The Github webhooks endpoint was trying to verify a csrf token.

This commit:
* Skips verify_authenticity_token in the Github webhooks endpoint.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
