### PR TITLE
Fixed blockquote styling in lesson content - resolves #2017

### DIFF
--- a/app/assets/stylesheets/components/lesson/lesson_content.scss
+++ b/app/assets/stylesheets/components/lesson/lesson_content.scss
@@ -136,4 +136,9 @@
       color: $primary;
     }
   }
+
+  blockquote {
+    border-left: solid 1px $grey;
+    padding-left: 1em;
+  }
 }


### PR DESCRIPTION
#### Because:
<!--
If your pull request resolves an open issue, please provide a link to it. For example: Resolves: https://github.com/TheOdinProject/theodinproject/issues/1886
Otherwise, please briefly explain why these changes were made, what problem does it solve?.
-->
Resolves: https://github.com/TheOdinProject/theodinproject/issues/2017 

#### This commit
<!--
A bullet point list of one or more items outlining what was done in this pull request to solve the problem.
-->
Added a blockquote selector to lesson_content.scss. 
Added left border and left padding to blockquote elements

Before:
![Before](https://user-images.githubusercontent.com/86421012/125390490-991f4780-e368-11eb-9ba7-fd764a046b41.png)

After:
![After](https://user-images.githubusercontent.com/86421012/125390493-9b81a180-e368-11eb-8973-30747f19d084.png)




#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [ X] You have verified the tests and linters all pass against your changes?
 - [ ] You have included automated tests for your changes where applicable?
