### PR TITLE
Chore: Bump React Hook Form

### DIFF
--- a/app/javascript/components/project-submissions/components/create-form.jsx
+++ b/app/javascript/components/project-submissions/components/create-form.jsx
@@ -1,5 +1,5 @@
 import React, { useContext } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm } from 'react-hook-form-7';
 import PropTypes from 'prop-types';
 import { yupResolver } from '@hookform/resolvers';
 
@@ -9,13 +9,19 @@ import ProjectSubmissionContext from '../ProjectSubmissionContext';
 const CreateForm = ({ onClose, onSubmit, userId }) => {
   const { lesson } = useContext(ProjectSubmissionContext);
   const {
-    register, handleSubmit, formState, errors,
+    register,
+    handleSubmit,
+    formState,
   } = useForm({
     resolver: yupResolver(schema),
     defaultValues: {
       is_public: true,
     },
   });
+
+  const {
+    errors,
+  } = formState;
 
   if (userId === null) {
     return (
@@ -41,6 +47,7 @@ const CreateForm = ({ onClose, onSubmit, userId }) => {
     );
   }
 
+  /* eslint-disable react/jsx-props-no-spreading */
   return (
     <div>
       <h1 className="text-center accent">Upload Your Project</h1>
@@ -52,10 +59,9 @@ const CreateForm = ({ onClose, onSubmit, userId }) => {
             autoFocus
             className="form__element form__element--with-icon"
             type="url"
-            name="repo_url"
+            {...register('repo_url')}
             placeholder="Repository URL"
             data-test-id="repo-url-field"
-            ref={register()}
           />
         </div>
         {errors.repo_url && (
@@ -74,9 +80,8 @@ const CreateForm = ({ onClose, onSubmit, userId }) => {
                 className="form__element form__element--with-icon"
                 type="url"
                 placeholder="Live Preview URL"
-                name="live_preview_url"
+                {...register('live_preview_url')}
                 data-test-id="live-preview-url-field"
-                ref={register()}
               />
             </div>
             { errors.live_preview_url && (
@@ -96,8 +101,7 @@ const CreateForm = ({ onClose, onSubmit, userId }) => {
                 id="is_public"
                 className="toggle__input"
                 type="checkbox"
-                name="is_public"
-                ref={register()}
+                {...register('is_public')}
               />
               <div className="toggle__fill" />
             </label>
@@ -115,6 +119,7 @@ const CreateForm = ({ onClose, onSubmit, userId }) => {
       </form>
     </div>
   );
+  /* eslint-enable react/jsx-props-no-spreading */
 };
 
 CreateForm.defaultProps = {

--- a/app/javascript/components/project-submissions/components/create-form.jsx
+++ b/app/javascript/components/project-submissions/components/create-form.jsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
-import { useForm } from 'react-hook-form-7';
+import { useForm } from 'react-hook-form';
 import PropTypes from 'prop-types';
-import { yupResolver } from '@hookform/resolvers';
+import { yupResolver } from '@hookform/resolvers/yup';
 
 import schema from '../schemas/project-submission-schema';
 import ProjectSubmissionContext from '../ProjectSubmissionContext';

--- a/app/javascript/components/project-submissions/components/edit-form.jsx
+++ b/app/javascript/components/project-submissions/components/edit-form.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { useForm } from 'react-hook-form-7';
+import { useForm } from 'react-hook-form';
 import { func, object } from 'prop-types';
-import { yupResolver } from '@hookform/resolvers';
+import { yupResolver } from '@hookform/resolvers/yup';
 
 import schema from '../schemas/project-submission-schema';
 

--- a/app/javascript/components/project-submissions/components/edit-form.jsx
+++ b/app/javascript/components/project-submissions/components/edit-form.jsx
@@ -1,5 +1,5 @@
-import React, { Fragment } from 'react';
-import { useForm } from 'react-hook-form';
+import React from 'react';
+import { useForm } from 'react-hook-form-7';
 import { func, object } from 'prop-types';
 import { yupResolver } from '@hookform/resolvers';
 
@@ -9,7 +9,9 @@ const EditForm = ({
   submission, onSubmit, onClose, onDelete,
 }) => {
   const {
-    register, errors, handleSubmit, formState,
+    register,
+    handleSubmit,
+    formState,
   } = useForm({
     resolver: yupResolver(schema),
     defaultValues: {
@@ -18,6 +20,10 @@ const EditForm = ({
       is_public: submission.is_public,
     },
   });
+
+  const {
+    errors,
+  } = formState;
 
   const handleDelete = () => {
     onDelete(submission.id);
@@ -33,23 +39,23 @@ const EditForm = ({
     );
   }
 
+  /* eslint-disable react/jsx-props-no-spreading */
   return (
     <div>
       <h1 className="text-center accent">Edit Your Project</h1>
 
       <form className="form" onSubmit={handleSubmit(onSubmit)}>
-        <input type="hidden" name="id" value={submission.id} ref={register()} />
-        <input type="hidden" name="lesson_id" value={submission.lesson_id} ref={register()} />
+        <input type="hidden" {...register('id')} value={submission.id} />
+        <input type="hidden" {...register('lesson_id')} value={submission.lesson_id} />
         <div className="form__section">
           <span className="form__icon fab fa-github" />
           <input
             autoFocus
             className="form__element form__element--with-icon"
             type="text"
-            name="repo_url"
+            {...register('repo_url')}
             placeholder="Repository URL"
             data-test-id="repo-url-field"
-            ref={register()}
           />
         </div>
         {errors.repo_url && (
@@ -67,9 +73,8 @@ const EditForm = ({
                 className="form__element form__element--with-icon"
                 type="text"
                 placeholder="Live Preview URL"
-                name="live_preview_url"
+                {...register('live_preview_url')}
                 data-test-id="live-preview-url-field"
-                ref={register()}
               />
             </div>
             {errors.live_preview_url && (
@@ -86,7 +91,7 @@ const EditForm = ({
           <div className="form__toggle-checkbox">
             <p className="bold">MAKE SOLUTION PUBLIC</p>
             <label htmlFor="is_public" className="toggle form__public-checkbox" data-test-id="is-public-toggle-slider">
-              <input id="is_public" className="toggle__input" type="checkbox" name="is_public" ref={register()} />
+              <input id="is_public" className="toggle__input" type="checkbox" {...register('is_public')} />
               <div className="toggle__fill round" />
             </label>
           </div>
@@ -101,6 +106,7 @@ const EditForm = ({
       </form>
     </div>
   );
+  /* eslint-enable react/jsx-props-no-spreading */
 };
 
 EditForm.propTypes = {

--- a/app/javascript/components/project-submissions/components/flag-form.jsx
+++ b/app/javascript/components/project-submissions/components/flag-form.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm } from 'react-hook-form-7';
 import { func, object, number } from 'prop-types';
 
 const FlagForm = ({ onSubmit, submission, userId }) => {
   const {
-    register, handleSubmit, errors, formState,
+    register, handleSubmit, formState,
   } = useForm();
+
+  const { errors } = formState;
 
   if (userId === null) {
     return (
@@ -31,26 +33,28 @@ const FlagForm = ({ onSubmit, submission, userId }) => {
     );
   }
 
+  /* eslint-disable react/jsx-props-no-spreading */
   return (
     <div>
-      <h1 className="text-center accent">Flag Submission</h1>
+      <h1 className="text-center accent">Flag Submission 1</h1>
 
       <form className="form" onSubmit={handleSubmit(onSubmit)}>
-        <input type="hidden" name="project_submission_id" value={submission.id} ref={register()} />
+        <input
+          type="hidden"
+          {...register('project_submission_id')}
+          value={submission.id}
+        />
         <div className="form__section">
           <textarea
             autoFocus
             placeholder="Please be as detailed as possible"
             className="form__element"
             rows="5"
-            name="reason"
+            {...register('reason', {
+              minLength: { value: 4, message: 'Must be at least 4 characters' },
+              required: 'Required',
+            })}
             data-test-id="flag-description-field"
-            ref={
-              register({
-                minLength: { value: 4, message: 'Must be at least 4 characters' },
-                required: 'Required',
-              })
-            }
           />
         </div>
         {errors.reason && (
@@ -66,6 +70,7 @@ const FlagForm = ({ onSubmit, submission, userId }) => {
       </form>
     </div>
   );
+  /* eslint-enable react/jsx-props-no-spreading */
 };
 
 FlagForm.defaultProps = {

--- a/app/javascript/components/project-submissions/components/flag-form.jsx
+++ b/app/javascript/components/project-submissions/components/flag-form.jsx
@@ -36,7 +36,7 @@ const FlagForm = ({ onSubmit, submission, userId }) => {
   /* eslint-disable react/jsx-props-no-spreading */
   return (
     <div>
-      <h1 className="text-center accent">Flag Submission 1</h1>
+      <h1 className="text-center accent">Flag Submission</h1>
 
       <form className="form" onSubmit={handleSubmit(onSubmit)}>
         <input

--- a/app/javascript/components/project-submissions/components/flag-form.jsx
+++ b/app/javascript/components/project-submissions/components/flag-form.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useForm } from 'react-hook-form-7';
+import { useForm } from 'react-hook-form';
 import { func, object, number } from 'prop-types';
 
 const FlagForm = ({ onSubmit, submission, userId }) => {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-dom": "^16.14.0",
     "react-flip-move": "^3.0.4",
     "react-hook-form": "^6.15.1",
+    "react-hook-form-7": "npm:react-hook-form@7.11.0",
     "react-scrolllock": "^5.0.1",
     "react-tabs": "^3.2.2",
     "react_ujs": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "@babel/preset-react": "^7.14.5",
-    "@hookform/resolvers": "^0.1.1",
+    "@hookform/resolvers": "2.6.1",
     "@rails/ujs": "^6.1.4",
     "@rails/webpacker": "5.4.0",
     "@sentry/browser": "^6.8.0",
@@ -27,8 +27,7 @@
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-flip-move": "^3.0.4",
-    "react-hook-form": "^6.15.1",
-    "react-hook-form-7": "npm:react-hook-form@7.11.0",
+    "react-hook-form": "7.11.0",
     "react-scrolllock": "^5.0.1",
     "react-tabs": "^3.2.2",
     "react_ujs": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8701,6 +8701,11 @@ react-flip-move@^3.0.4:
   resolved "https://registry.npmjs.org/react-flip-move/-/react-flip-move-3.0.4.tgz"
   integrity sha512-HyUVv9g3t/BS7Yz9HgrtYSWyRNdR2F81nkj+C5iRY675AwlqCLB5JU9mnZWg0cdVz7IM4iquoyZx70vzZv3Z8Q==
 
+"react-hook-form-7@npm:react-hook-form@7.11.0":
+  version "7.11.0"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.11.0.tgz#9cae5e21ba1c1a98a40c65cfee07db9e677edc21"
+  integrity sha512-aJVvL5VV6JqUWvwx9fbrhc6La83aQAfXfqQr+TD/sWy3LPdqYBgBIHBt8WAKWzKRm3g29YV2CLfn4wkhNB9b+g==
+
 react-hook-form@^6.15.1:
   version "6.15.1"
   resolved "https://registry.npmjs.org/react-hook-form/-/react-hook-form-6.15.1.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1278,10 +1278,10 @@
   dependencies:
     purgecss "^3.1.3"
 
-"@hookform/resolvers@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-0.1.1.tgz"
-  integrity sha512-IKWcvDG82D0N+3ZjMSbdHul6TgL2Dd68aXyijLvc1mUCzBChvQwS6YDsXRrc9WuIjUPb9nluaVIIrmg3V1JMGQ==
+"@hookform/resolvers@2.6.1":
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-2.6.1.tgz#d41296521ccebba71f671e105b75cf36071fa293"
+  integrity sha512-7tml6bUUzdkk7tYb5LBk4i6ctV/1Rs4U5qVxrNBXZd8ZhxvsELI0TyYrnCK0XSlCo8Htlat8TOzxSZcKWOH5KQ==
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
@@ -8701,15 +8701,10 @@ react-flip-move@^3.0.4:
   resolved "https://registry.npmjs.org/react-flip-move/-/react-flip-move-3.0.4.tgz"
   integrity sha512-HyUVv9g3t/BS7Yz9HgrtYSWyRNdR2F81nkj+C5iRY675AwlqCLB5JU9mnZWg0cdVz7IM4iquoyZx70vzZv3Z8Q==
 
-"react-hook-form-7@npm:react-hook-form@7.11.0":
+react-hook-form@7.11.0:
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.11.0.tgz#9cae5e21ba1c1a98a40c65cfee07db9e677edc21"
   integrity sha512-aJVvL5VV6JqUWvwx9fbrhc6La83aQAfXfqQr+TD/sWy3LPdqYBgBIHBt8WAKWzKRm3g29YV2CLfn4wkhNB9b+g==
-
-react-hook-form@^6.15.1:
-  version "6.15.1"
-  resolved "https://registry.npmjs.org/react-hook-form/-/react-hook-form-6.15.1.tgz"
-  integrity sha512-bL0LQuQ3OlM3JYfbacKtBPLOHhmgYz8Lj6ivMrvu2M6e1wnt4sbGRtPEPYCc/8z3WDbjrMwfAfLX92OsB65pFA==
 
 react-is@^16.8.1:
   version "16.13.1"


### PR DESCRIPTION
#### Because:
- There were breaking changes to react-hook-form preventing it from being updated

#### This commit
- Updates `react-hook-form` to version 7.11.0
- Updates `@hookform/resolvers` to version 2.6.1
- Updates edit-form, create-form, and flag-form to use the new versions

Resolves #1848

#### Checklist
 - [X] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [X] You have verified the tests and linters all pass against your changes?
 - [X] You have included automated tests for your changes where applicable?
