### PR TITLE
feat: Add service objects for updating the flag to notify user and

### DIFF
--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -5,5 +5,5 @@ class Flag < ApplicationRecord
   validates :reason, presence: true
 
   enum status: { active: 0, resolved: 1 }
-  enum taken_action: { pending: 0, dismiss: 1, ban: 2, removed_project_submission: 3 }
+  enum taken_action: { pending: 0, dismiss: 1, ban: 2, removed_project_submission: 3, notified_user: 4 }
 end

--- a/app/services/admin/flags/notify_user.rb
+++ b/app/services/admin/flags/notify_user.rb
@@ -1,0 +1,36 @@
+module Admin
+  module Flags
+    class NotifyUser
+      def initialize(admin:, flag:, notification:)
+        @admin = admin
+        @flag = flag
+        @notification = notification
+        @success = false
+      end
+
+      def self.call(**args)
+        new(**args).call
+      end
+
+      # rubocop:disable Metrics/AbcSize
+      def call
+        flag.transaction do
+          flag.notified_user!
+          flag.resolved!
+          flag.update!(resolved_by_id: admin.id)
+          FlagNotification.with(flag: flag, message: message.content, url: message.url)
+                          .deliver_later(flag.project_submission.user)
+        end
+      end
+      # rubocop:enable Metrics/AbcSize
+
+      private
+
+      attr_reader :flag, :admin, :notification
+
+      def message
+        Messages::DeadLink.new(flag)
+      end
+    end
+  end
+end

--- a/app/services/messages/dead_link.rb
+++ b/app/services/messages/dead_link.rb
@@ -1,0 +1,38 @@
+module Messages
+  class DeadLink
+    include Rails.application.routes.url_helpers
+
+    attr_reader :flag
+
+    def initialize(flag)
+      @flag = flag
+    end
+
+    # rubocop:disable Layout/LineLength
+    def content
+      "Hey #{username}, heads up your project submission for #{lesson_name} was flagged because it has a broken link. " \
+        'We aim to keep the submission lists useful and so we remove any submissions with broken links often. ' \
+        'When you get a moment, can you update your submission with the correct links for us please? ' \
+        "Otherwise we will have to remove it on #{date}."
+    end
+    # rubocop:enable Layout/LineLength
+
+    def url
+      lesson_url(flag.project_submission.lesson, only_path: true)
+    end
+
+    private
+
+    def username
+      flag.project_submission.user.username
+    end
+
+    def lesson_name
+      flag.project_submission.lesson.title
+    end
+
+    def date
+      7.days.from_now.strftime('%d %b %Y')
+    end
+  end
+end

--- a/spec/models/flag_spec.rb
+++ b/spec/models/flag_spec.rb
@@ -8,5 +8,8 @@ RSpec.describe Flag do
 
   it { is_expected.to validate_presence_of(:reason) }
   it { is_expected.to define_enum_for(:status).with_values(%i[active resolved]) }
-  it { is_expected.to define_enum_for(:taken_action).with_values(%i[pending dismiss ban removed_project_submission]) }
+  it do
+    is_expected.to define_enum_for(:taken_action)
+      .with_values(%i[pending dismiss ban removed_project_submission notified_user])
+  end
 end

--- a/spec/services/admin/flags/notify_user_spec.rb
+++ b/spec/services/admin/flags/notify_user_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe Admin::Flags::NotifyUser do
+  subject(:service) { described_class.call(admin: admin, flag: flag, notification: notification) }
+
+  let(:admin) { create(:user, admin: true) }
+  let(:flag) { create(:flag, project_submission: project_submission) }
+  let(:notification) { double('Notifications::DeadLink', call: 'called') }
+  let(:project_submission) { create(:project_submission, user: user) }
+  let(:user) { create(:user) }
+
+  describe '#call' do
+    it 'sets the flags taken action to notified_user' do
+      expect { service }.to change { flag.taken_action }.from('pending').to('notified_user')
+    end
+
+    it 'sets the flags status to resolved' do
+      expect { service }.to change { flag.status }.from('active').to('resolved')
+    end
+
+    it 'sets the resolved_by_id to the id of the current admin user' do
+      expect { service }.to change { flag.resolved_by_id }.from(nil).to(admin.id)
+    end
+
+    it 'creates a notification' do
+      expect { service }.to change { Notification.count }.from(0).to(1)
+    end
+  end
+end

--- a/spec/services/messages/dead_link_spec.rb
+++ b/spec/services/messages/dead_link_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe Messages::DeadLink do
+  subject(:message) { described_class.new(flag) }
+
+  let(:flag) do
+    create(
+      :flag,
+      id: 120,
+      flagger: flagger,
+      project_submission: flagged_submission,
+      reason: 'I find it offensive'
+    )
+  end
+
+  let(:flagger) { create(:user, username: 'OdinUser') }
+  let(:flagged_submission) { create(:project_submission, lesson: lesson, user: user) }
+  let(:lesson) { create(:lesson, title: 'test lesson1') }
+  let(:user) { create(:user, username: 'testuser1') }
+
+  describe '#content' do
+    let(:content) do
+      'Hey testuser1, heads up your project submission for test lesson1 was flagged because it has a broken link. ' \
+        'We aim to keep the submission lists useful and so we remove any submissions with broken links often. ' \
+        'When you get a moment, can you update your submission with the correct links for us please? ' \
+        'Otherwise we will have to remove it on 08 Aug 2021.'
+    end
+
+    it 'sets the message for the notification' do
+      travel_to Time.zone.local(2021, 8, 1) do
+        expect(message.content).to eq content
+      end
+    end
+  end
+
+  describe '#url' do
+    it 'sets the url for the message' do
+      expect(message.url).to eq '/lessons/test-lesson1'
+    end
+  end
+end


### PR DESCRIPTION
Because: Admins should be able to resolve a flag for a project
submission with a dead link by notifying the user that they need to
update their submission.

This commit:

- Add notified_user to taken_action enum on the flag model
- Create admin flag service object for notifying users
- Add message class for a dead link
- Add tests for message class
- Add tests for notify_user