### PR TITLE
Fix: Flash Overlapping User Menu.

### DIFF
--- a/app/assets/stylesheets/components/odin-dropdown-menu.scss
+++ b/app/assets/stylesheets/components/odin-dropdown-menu.scss
@@ -19,6 +19,7 @@
     border-radius: 10px;
     transform-origin: top right;
     transition: transform ease-in 0.2s, opacity ease-in 0.1s;
+    background-color: $white;
   }
 
   &__toggle {


### PR DESCRIPTION
Because:
* If a flash message is on the screen and the user opens the dropdown menu, the flash message will appear on top of it.

![](https://cdn.discordapp.com/attachments/740260710121996338/871081247030509588/Screen_Shot_2021-07-31_at_12.24.32_PM.png)

This Commit:
* Sets the dropdown menu's background to white instead of using the default transparent value for the background color.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
