### PR TITLE
Chore: Create Maintainer Users to be Used with Review App's

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,3 +16,6 @@ load './db/seeds/success_stories.rb'
 
 # GENERATE test projects
 load './db/seeds/test_project_submissions.rb'
+
+# GENERATE maintainer users for testing
+load './db/seeds/maintainer_users.rb'

--- a/db/seeds/maintainer_users.rb
+++ b/db/seeds/maintainer_users.rb
@@ -1,0 +1,10 @@
+if Rails.env.development? || ENV['STAGING']
+  names = ['kevin']
+
+  names.each do |name|
+    User.find_or_create_by!(email: "#{name}@odin.com") do |user|
+      user.username = name
+      user.password = 'password'
+    end
+  end
+end


### PR DESCRIPTION
Because:
* We cannot use Github or Google oauth with the review apps and therefore have to sign up manually when testing which is a pain. Each maintainer can add their name to the names list and it will automatically make an account for them when the review app is building.
* I have also enabled this for development mode.
* This should also provide a nice opportunity for every maintainer to make a commit to the codebase.

This commit:
* set up a maintainer users seeds file and added myself.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
