### PR TITLE
Feature: User Lesson Completion Reset Progress

### DIFF
--- a/app/assets/stylesheets/components/settings/delete_account.scss
+++ b/app/assets/stylesheets/components/settings/delete_account.scss
@@ -1,7 +1,8 @@
 .delete-account {
-  padding-bottom: 3.5rem;
+  padding-bottom: 1.5rem;
   font-size: 0.8125;
   color: $red-danger;
+  text-align: left;
   text-decoration: underline;
   display: block;
 }

--- a/app/controllers/users/progress_controller.rb
+++ b/app/controllers/users/progress_controller.rb
@@ -1,0 +1,14 @@
+module Users
+  class ProgressController < ApplicationController
+    before_action :authenticate_user!
+
+    def destroy
+      result = Users::ResetProgress.call(current_user)
+      if result.success?
+        redirect_to edit_user_registration_path, notice: 'Success: Your progress has been reset.'
+      else
+        redirect_to edit_user_registration_path, notice: 'Failure: Unable to reset your progress.'
+      end
+    end
+  end
+end

--- a/app/javascript/src/js/settings.js
+++ b/app/javascript/src/js/settings.js
@@ -6,9 +6,11 @@ document.addEventListener('turbolinks:load', (element) => {
     const settingsViewForm = element.querySelector('.settings-view--hidden');
     const settingsView = element.querySelector('.settings-view');
 
-    toggler.addEventListener('click', () => {
-      switchViews();
-    });
+    if (toggler) {
+      toggler.addEventListener('click', () => {
+        switchViews();
+      });
+    }
 
     $(settingsViewForm).on('ajax:success', (event) => {
       const data = event.detail[0];

--- a/app/services/users/reset_progress.rb
+++ b/app/services/users/reset_progress.rb
@@ -1,0 +1,38 @@
+module Users
+  class ResetProgress
+    def initialize(user)
+      @user = user
+      @success = false
+    end
+
+    def self.call(user)
+      new(user).call
+    end
+
+    def call
+      user.transaction do
+        delete_lesson_completions
+        reset_default_path unless user.path.default_path?
+        @success = true
+      end
+
+      self
+    end
+
+    def success?
+      @success
+    end
+
+    private
+
+    attr_reader :user
+
+    def delete_lesson_completions
+      user.lesson_completions.delete_all
+    end
+
+    def reset_default_path
+      user.update(path: Path.default_path)
+    end
+  end
+end

--- a/app/views/devise/registrations/_danger_zone.html.erb
+++ b/app/views/devise/registrations/_danger_zone.html.erb
@@ -1,0 +1,26 @@
+<div class="settings-section">
+  <div class="settings-card card-main">
+
+    <h2 class="accent settings-card__heading">Danger Zone</h2>
+
+    <div class="settings-card__content">
+      <div class="settings-view">
+
+        <%= link_to 'Reset my progress',
+          users_progress_path(user),
+          class: 'delete-account',
+          data: { confirm: 'Are you sure?', test_id: 'user-reset-progress-link' },
+          method: :delete
+        %>
+
+        <%= link_to 'Delete my account',
+          registration_path(resource_name),
+          class: 'delete-account',
+          data: { confirm: 'Are you sure?', test_id: 'user-account-delete-link' },
+          method: :delete
+        %>
+
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,6 +1,6 @@
 <%= title('Settings') %>
 
-<div class="gradient">
+<div class="gradient pb-1">
   <div class="container">
     <h1 class="text-center accent">Settings</h1>
     <div class='col-lg-10 offset-lg-1'>
@@ -12,12 +12,8 @@
         <%= render 'devise/registrations/password', user: @user %>
       <% end %>
 
-      <%= link_to 'Delete my account',
-        registration_path(resource_name),
-        class: 'delete-account text-center',
-        data: { confirm: 'Are you sure?', test_id: 'user-account-delete-link' },
-        method: :delete
-      %>
+      <%= render 'devise/registrations/danger_zone', user: @user %>
+
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,7 @@ Rails.application.routes.draw do
 
   namespace :users do
     resources :paths, only: :create
+    resources :progress, only: :destroy
   end
   get 'dashboard' => 'users#show', as: :dashboard
 

--- a/spec/services/users/reset_progress_spec.rb
+++ b/spec/services/users/reset_progress_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe Users::ResetProgress do
+  subject(:service) { described_class.call(user) }
+  let!(:user) { create(:user, path: foundations_path) }
+  let!(:foundations_path) { create(:path, default_path: true) }
+  let!(:first_completion) { create(:lesson_completion, lesson: create(:lesson), user: user) }
+  let!(:second_completion) { create(:lesson_completion, lesson: create(:lesson), user: user) }
+
+  describe '#call' do
+    it 'deletes all lesson completions' do
+      expect { service }.to change { user.lesson_completions.count }.from(2).to(0)
+    end
+
+    context 'when path is default path' do
+      it 'does not change path' do
+        expect { service }.not_to(change { user.path })
+      end
+    end
+
+    context 'when path is not the default path' do
+      let(:rails_path) { create(:path, default_path: false) }
+
+      it 'changes path to the default path' do
+        user.update(path: rails_path)
+        expect { service }.to change { user.path.default_path? }.from(false).to(true)
+      end
+    end
+  end
+
+  describe '#success?' do
+    it 'returns true' do
+      expect(service.success?).to be(true)
+    end
+  end
+end

--- a/spec/system/user_reset_progress_spec.rb
+++ b/spec/system/user_reset_progress_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe 'User Reset Progress', type: :system do
+  let!(:user) { create(:user) }
+  let!(:foundations_path) { create(:path, title: 'Foundations', default_path: true) }
+  let!(:foundation_course) { create(:course, title: 'Foundations', path: foundations_path) }
+  let!(:foundation_lesson) { create(:lesson, course: foundation_course) }
+  let!(:foundation_completion) { create(:lesson_completion, lesson: foundation_lesson, user: user) }
+  let!(:rails_path) { create(:path, title: 'Rails') }
+  let!(:rails_course) { create(:course, title: 'Rails', path: rails_path) }
+  let!(:rails_lesson) { create(:lesson, course: rails_course) }
+  let!(:rails_completion) { create(:lesson_completion, lesson: rails_lesson, user: user) }
+
+  it 'deletes all lesson completions and resets to default path' do
+    user.update(path: rails_path)
+    sign_in(user)
+    visit dashboard_path
+
+    expect(user.lesson_completions.count).to eq(2)
+    within(find('.skills')) do
+      expect(page).to have_content(rails_course.title)
+      expect(find(:test_id, 'progress-badge')).to have_text('100%')
+      expect(find(:test_id, 'rails-open-btn')).to have_text('Open')
+    end
+
+    visit edit_user_registration_path
+    page.accept_confirm do
+      find(:test_id, 'user-reset-progress-link').click
+    end
+    visit dashboard_path
+
+    expect(user.reload.path).not_to eq(rails_path)
+    expect(user.lesson_completions.count).to eq(0)
+    within(find('.skills')) do
+      expect(page).to have_content(foundation_course.title)
+      expect(find(:test_id, 'default-badge')).to have_text('')
+      expect(find(:test_id, 'foundations-start-btn')).to have_text('Start')
+    end
+  end
+end


### PR DESCRIPTION
#### Because:
* Users may want to reset their lesson completions if they restart TOP.

#### This Commit:
* Adds ResetProgressJob to delete lesson completions and reset path.
* Adds progress controller and route.
* Adds unit and system tests.
* Adds danger_zone partial and adjusts styling.
* Updates test environment config to have sidekiq run immediately.
* Updates settings.js to allow for element without toggler class.

Resolves: #2109 

#### Questions/Concerns:
The User model has the following method:
```
def enroll_in_foundations
  default_path = Path.default_path

  self.path_id = default_path.id if default_path.present?
end
```
This makes me wonder if Reset Progress Job `#perform` should also check for the existence of the default path.

If you do not like the red border on the Danger Zone, it can be removed. I added it because I felt like it added another visual clue. However, I understand if you'd rather not have a border, since the surrounding card components do not have a border.
![Screen Shot 2021-08-04 at 2 10 31 PM](https://user-images.githubusercontent.com/33227096/128246332-f9306470-c647-4825-893d-3767440362c1.png)

I followed the pattern of flash notices being in past tense "Your progress has been reset." However, since this is handled in a background job, should it be "Your progress will be reset soon." since it may take a few moments for the changes to be reflected?

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
