### PR TITLE
Chore: Updates the title of the named projects

### DIFF
--- a/db/fixtures/lessons/database_lessons.rb
+++ b/db/fixtures/lessons/database_lessons.rb
@@ -14,8 +14,8 @@ def database_lessons
       url: '/databases/databases.md',
       identifier_uuid: '60439aa4-1f12-49e2-8cc9-515574e2ad71',
     },
-    'SQL' => {
-      title: 'SQL',
+    'SQL Zoo' => {
+      title: 'SQL Zoo',
       description: 'The best way to learn is by practice, so this project will give you plenty of opportunity to apply your new SQL powers (for good).',
       is_project: true,
       url: '/databases/project_databases.md',

--- a/db/fixtures/lessons/javascript_lessons.rb
+++ b/db/fixtures/lessons/javascript_lessons.rb
@@ -212,8 +212,8 @@ def javascript_lessons
       has_live_preview: true,
       identifier_uuid: '386dd44a-31dc-45dc-a535-cd5508365c86',
     },
-    'Final Project' => {
-      title: 'Final Project',
+    'JavaScript Final Project' => {
+      title: 'JavaScript Final Project',
       description: "Tie everything you've learned from every course so far into one project where you'll build your favorite website from scratch.",
       is_project: true,
       url: '/javascript/finishing-up/project_final_js.md',

--- a/db/fixtures/lessons/ruby_lessons.rb
+++ b/db/fixtures/lessons/ruby_lessons.rb
@@ -168,8 +168,8 @@ def ruby_lessons
       has_live_preview: false,
       identifier_uuid: 'a47be9ab-7c78-44c2-b098-ec63d82af1cf',
     },
-    'File I/O and Serialization' => {
-      title: 'File I/O and Serialization',
+    'Hangman' => {
+      title: 'Hangman',
       description: "You'll get a chance to scrub an existing dataset and then work with dictionaries by building Hangman.",
       is_project: true,
       url: '/ruby_programming/files_and_serialization/project_file_io.md',
@@ -262,8 +262,8 @@ def ruby_lessons
       url: '/ruby_programming/testing_with_rspec/introduction_to_rspec.md',
       identifier_uuid: '34eb5b73-29a8-4d5b-8747-a2ccad75806e',
     },
-    'Testing Your Ruby Code' => {
-      title: 'Testing Your Ruby Code',
+    'Connect Four' => {
+      title: 'Connect Four',
       description: "The real way to learn is by doing, so you'll jump in the time machine and write some tests for prior projects.",
       is_project: true,
       url: '/ruby_programming/testing_with_rspec/project_testing_your_ruby_code.md',

--- a/db/fixtures/lessons/ruby_on_rails_lessons.rb
+++ b/db/fixtures/lessons/ruby_on_rails_lessons.rb
@@ -88,8 +88,8 @@ def ruby_on_rails_lessons
       url: '/rails_programming/databases_and_activerecord/active_record_basics.md',
       identifier_uuid: '260d1def-c36c-4512-b8aa-223458f356b0',
     },
-    'Building With Active Record' => {
-      title: 'Building With Active Record',
+    'Micro-Reddit' => {
+      title: 'Micro-Reddit',
       description: "You'll start getting practice thinking data first before building something that acts a lot like Reddit.",
       is_project: true,
       url: '/rails_programming/databases_and_activerecord/project_ar_basics.md',
@@ -120,8 +120,8 @@ def ruby_on_rails_lessons
       url: '/rails_programming/forms_and_authentication/sessions_cookies_authentication.md',
       identifier_uuid: '95e85ce2-008a-4e1b-a553-664029025cf5',
     },
-    'Authentication' => {
-      title: 'Authentication',
+    'Members Only!' => {
+      title: 'Members Only!',
       description: "You'll build a closed community for sharing embarrassing gossip with the world.",
       is_project: true,
       url: '/rails_programming/forms_and_authentication/project_auth.md',
@@ -143,8 +143,8 @@ def ruby_on_rails_lessons
       url: '/rails_programming/advanced_forms_and_activerecord/active_record_associations.md',
       identifier_uuid: '211edb41-e48f-4da1-bec2-0271e900f266',
     },
-    'Associations' => {
-      title: 'Associations',
+    'Private Events' => {
+      title: 'Private Events',
       description: "Build a system to manage signups for you and your friends' special events.",
       is_project: true,
       url: '/rails_programming/advanced_forms_and_activerecord/project_associations.md',
@@ -166,8 +166,8 @@ def ruby_on_rails_lessons
       url: '/rails_programming/advanced_forms_and_activerecord/forms_advanced.md',
       identifier_uuid: 'a47db11b-de26-4e38-bd24-edb640319ca2',
     },
-    'Building Advanced Forms' => {
-      title: 'Building Advanced Forms',
+    'Flight Booker' => {
+      title: 'Flight Booker',
       description: 'Build an airline flight signup system, which is a nest of interesting complexities',
       is_project: true,
       url: '/rails_programming/advanced_forms_and_activerecord/project_forms_advanced.md',
@@ -198,8 +198,8 @@ def ruby_on_rails_lessons
       has_live_preview: true,
       identifier_uuid: '5d0433d7-f3f3-46fa-99e7-3bc5893a2599'
     },
-    'Using an API' => {
-      title: 'Using an API',
+    'Flickr API' => {
+      title: 'Flickr API',
       description: "In this project, you'll work with a third-party API.",
       is_project: true,
       url: '/rails_programming/apis/project_using_an_api.md',
@@ -237,8 +237,8 @@ def ruby_on_rails_lessons
       url: '/rails_programming/mailers_advanced_topics/websockets_and_actioncable.md',
       identifier_uuid: '949892d1-90af-46e0-a750-bedab0c5120b',
     },
-    'Final Project' => {
-      title: 'Final Project',
+    'Rails Final Project' => {
+      title: 'Rails Final Project',
       description: "There's a pretty popular social networking app you should build.  They may have made a movie about it.",
       is_project: true,
       url: '/rails_programming/mailers_advanced_topics/project_final.md',

--- a/db/fixtures/paths/full_stack_javascript/courses/1_javascript.rb
+++ b/db/fixtures/paths/full_stack_javascript/courses/1_javascript.rb
@@ -138,7 +138,7 @@ course.add_section do |section|
   section.identifier_uuid = 'b0761d75-2a9a-4c33-b02a-1d072b75889f'
 
   section.add_lessons(
-    javascript_lessons.fetch('Final Project'),
+    javascript_lessons.fetch('JavaScript Final Project'),
     javascript_lessons.fetch('Conclusion'),
   )
 end

--- a/db/fixtures/paths/full_stack_rails/courses/1_ruby.rb
+++ b/db/fixtures/paths/full_stack_rails/courses/1_ruby.rb
@@ -87,7 +87,7 @@ course.add_section do |section|
   section.add_lessons(
     ruby_lessons.fetch('Files and Serialization'),
     ruby_lessons.fetch('Event Manager'),
-    ruby_lessons.fetch('File I/O and Serialization'),
+    ruby_lessons.fetch('Hangman'),
   )
 end
 
@@ -136,7 +136,7 @@ course.add_section do |section|
   section.add_lessons(
     ruby_lessons.fetch('Test Driven Development'),
     ruby_lessons.fetch('Introduction to RSpec'),
-    ruby_lessons.fetch('Testing Your Ruby Code'),
+    ruby_lessons.fetch('Connect Four'),
   )
 end
 

--- a/db/fixtures/paths/full_stack_rails/courses/2_databases.rb
+++ b/db/fixtures/paths/full_stack_rails/courses/2_databases.rb
@@ -18,7 +18,7 @@ course.add_section do |section|
   section.add_lessons(
     database_lessons.fetch('Databases'),
     database_lessons.fetch('Databases and SQL'),
-    database_lessons.fetch('SQL'),
+    database_lessons.fetch('SQL Zoo'),
   )
 end
 

--- a/db/fixtures/paths/full_stack_rails/courses/3_rails.rb
+++ b/db/fixtures/paths/full_stack_rails/courses/3_rails.rb
@@ -52,7 +52,7 @@ course.add_section do |section|
 
   section.add_lessons(
     ruby_on_rails_lessons.fetch('Active Record Basics'),
-    ruby_on_rails_lessons.fetch('Building With Active Record'),
+    ruby_on_rails_lessons.fetch('Micro-Reddit'),
   )
 end
 
@@ -68,7 +68,7 @@ course.add_section do |section|
     ruby_on_rails_lessons.fetch('Form Basics'),
     ruby_on_rails_lessons.fetch('Forms'),
     ruby_on_rails_lessons.fetch('Sessions, Cookies and Authentication'),
-    ruby_on_rails_lessons.fetch('Authentication'),
+    ruby_on_rails_lessons.fetch('Members Only!'),
   )
 end
 
@@ -83,10 +83,10 @@ course.add_section do |section|
   section.add_lessons(
     ruby_on_rails_lessons.fetch('Active Record Queries'),
     ruby_on_rails_lessons.fetch('Active Record Associations'),
-    ruby_on_rails_lessons.fetch('Associations'),
+    ruby_on_rails_lessons.fetch('Private Events'),
     ruby_on_rails_lessons.fetch('Active Record Callbacks'),
     ruby_on_rails_lessons.fetch('Advanced Forms'),
-    ruby_on_rails_lessons.fetch('Building Advanced Forms'),
+    ruby_on_rails_lessons.fetch('Flight Booker'),
   )
 end
 
@@ -102,7 +102,7 @@ course.add_section do |section|
     ruby_on_rails_lessons.fetch('APIs and Building Your Own'),
     ruby_on_rails_lessons.fetch('Working With External APIs'),
     ruby_on_rails_lessons.fetch('Kittens API'),
-    ruby_on_rails_lessons.fetch('Using an API'),
+    ruby_on_rails_lessons.fetch('Flickr API'),
   )
 end
 
@@ -119,7 +119,7 @@ course.add_section do |section|
     ruby_on_rails_lessons.fetch('Sending Confirmation Emails'),
     ruby_on_rails_lessons.fetch('Advanced Topics'),
     ruby_on_rails_lessons.fetch('Websockets and Actioncable'),
-    ruby_on_rails_lessons.fetch('Final Project'),
+    ruby_on_rails_lessons.fetch('Rails Final Project'),
     ruby_on_rails_lessons.fetch('Conclusion'),
   )
 end

--- a/db/fixtures/paths/full_stack_rails/courses/5_javascript.rb
+++ b/db/fixtures/paths/full_stack_rails/courses/5_javascript.rb
@@ -138,7 +138,7 @@ course.add_section do |section|
   section.identifier_uuid = 'd3a05406-615d-4645-85f2-0cba667f2749'
 
   section.add_lessons(
-    javascript_lessons.fetch('Final Project'),
+    javascript_lessons.fetch('JavaScript Final Project'),
     javascript_lessons.fetch('Conclusion'),
   )
 end


### PR DESCRIPTION
Because:
* The project names were inconsistent.
* This made it difficult to parse the project submissions list on dashboard.
* This change makes it easier to navigate to a project quickly when helping someone on Discord.

This Commit:
* Updates titles for all named projects.
* Updates the lesson and course fixtures files.

Additional Info:
I have changed the title of each of the named projects, but left the un-named projects alone. For example, the `Authentication` project is now named `Members Only` because that is the name of the project, but left the unnamed projects like `Sending Confirmation Emails` alone.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
