### PR TITLE
Update faq.scss faq-10 to faq-9

### DIFF
--- a/app/assets/stylesheets/components/faq.scss
+++ b/app/assets/stylesheets/components/faq.scss
@@ -10,7 +10,7 @@
     @include box-shadow(0 2px 4px 0 $very-pale-grey);
     border: 0;
 
-    #faq-item-10 .card-block {
+    #faq-item-9 .card-block {
       ul { padding-left: 40px; }
       h2 { padding-top: 25px; }
     }


### PR DESCRIPTION
Here style applied for `faq-10` but it doesn't need this style as it doesn't have  `ul`. This style is for `faq-9`. So class name `faq-10` updated to `faq-9`. So it will fix `faq-9`'s `ul`'s margin/padding issue. `faq-{id}` where id starts with `0` so `faq-9` refers `10th faq`.

https://www.theodinproject.com/faq

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [ ] You have included automated tests for your changes where applicable?
