### PR TITLE
remove deprecated front end section

### DIFF
--- a/db/fixtures/paths/foundations/seed.rb
+++ b/db/fixtures/paths/foundations/seed.rb
@@ -69,26 +69,10 @@ course.add_section do |section|
 end
 
 # +++++++++++++++++++++++++++++++
-# SECTION - The Front End
-# +++++++++++++++++++++++++++++++
-course.add_section do |section|
-  section.title = 'The Front End (OLD)'
-  section.description = "Skip this section. These lessons will be removed shortly. We've left them up for a short time as a reference for people who were in progress when the new material was added."
-  section.identifier_uuid = '552d3718-14c6-4b0a-848d-2dcca271ac61'
-
-  section.add_lessons(
-    foundation_lessons.fetch('Introduction to the Front End'),
-    foundation_lessons.fetch('HTML and CSS Basics'),
-    foundation_lessons.fetch('Developer Tools'),
-    foundation_lessons.fetch('Google Homepage'),
-  )
-end
-
-# +++++++++++++++++++++++++++++++
 # SECTION - HTML
 # +++++++++++++++++++++++++++++++
 course.add_section do |section|
-  section.title = 'HTML Foundations (New Lessons!)'
+  section.title = 'HTML Foundations'
   section.description = 'Learn the foundations of HTML, a fundamental building block of everything on the web.'
   section.identifier_uuid = '8b6abb7a-095f-4c1d-b81f-e348aaaf2894'
 
@@ -107,7 +91,7 @@ end
 # SECTION - CSS Basics
 # +++++++++++++++++++++++++++++++
 course.add_section do |section|
-  section.title = 'CSS Foundations (New Lessons!)'
+  section.title = 'CSS Foundations'
   section.description = 'Learn how to make your HTML look the way you want by adding styles with CSS.'
   section.identifier_uuid = 'd2476929-d71b-4b25-969b-8f7da6a40c94'
 
@@ -123,7 +107,7 @@ end
 # SECTION - HTML
 # +++++++++++++++++++++++++++++++
 course.add_section do |section|
-  section.title = 'Flexbox (New Lessons!)'
+  section.title = 'Flexbox'
   section.description = 'Learn how to put things exactly where you want them on your web projects using flexbox.'
   section.identifier_uuid = '1cac0d64-f276-4999-8ff1-85d37797c312'
 


### PR DESCRIPTION
This PR removes the old html/css content from foundations, and removes the `(New Lessons)` tag from the new stuff

Don't merge until we're ready to do that. (give it a week or so)