### PR TITLE
Rename Developer Tools 2 - Foundations

### DIFF
--- a/db/fixtures/lessons/foundation_lessons.rb
+++ b/db/fixtures/lessons/foundation_lessons.rb
@@ -135,11 +135,11 @@ def foundation_lessons
       url: '/foundations/javascript_basics/fundamentals-2.md',
       identifier_uuid: '06069c6b-8278-4023-be4f-336156621ba3',
     },
-    'Developer Tools 2' => {
-      title: 'Developer Tools 2',
-      description: 'covers using the dev tools from the perspective of a JS developer',
+    'JavaScript Developer Tools' => {
+      title: 'JavaScript Developer Tools',
+      description: 'Covers using the dev tools from the perspective of a JS developer',
       is_project: false,
-      url: '/foundations/javascript_basics/developer_tools_2.md',
+      url: '/foundations/javascript_basics/javascript_developer_tools.md',
       identifier_uuid: '60494609-9c68-4ddb-8b3b-96dc8afd876c',
     },
     'Fundamentals Part 3' => {

--- a/db/fixtures/paths/foundations/seed.rb
+++ b/db/fixtures/paths/foundations/seed.rb
@@ -147,7 +147,7 @@ course.add_section do |section|
   section.add_lessons(
     foundation_lessons.fetch('Fundamentals Part 1'),
     foundation_lessons.fetch('Fundamentals Part 2'),
-    foundation_lessons.fetch('Developer Tools 2'),
+    foundation_lessons.fetch('JavaScript Developer Tools'),
     foundation_lessons.fetch('Fundamentals Part 3'),
     foundation_lessons.fetch('Problem Solving'),
     foundation_lessons.fetch('Understanding Errors'),


### PR DESCRIPTION
Developer Tools lesson going to be deleted with the old lessons so the name `Developer Tools 2` needs change. So it's changed to `Javascript Developer Tools` with this Pull Request. Also the new lesson name updated in the curriculm repo also. That's a file name change.
Closes #2205

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [ ] You have included automated tests for your changes where applicable?
