### PR TITLE
Chore: Add Descriptive Title Content to Path Show and Index Pages

### DIFF
--- a/app/views/paths/index.html.erb
+++ b/app/views/paths/index.html.erb
@@ -1,3 +1,5 @@
+<%= title("All Paths") %>
+
 <div class="paths curriculum-background">
   <div class="container">
     <h1 class="text-center camel card-list__title">All Paths</h1>

--- a/app/views/paths/show.html.erb
+++ b/app/views/paths/show.html.erb
@@ -1,3 +1,5 @@
+<%= title(@path.title) %>
+
 <div class="container">
   <h1 class="text-center camel light curriculum-title"><%= @path.title %></h1>
   <% if user_signed_in? && current_user.path != @path %>


### PR DESCRIPTION
Because:
* These pages didn't have descriptive titles and were using the fallback.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
