### PR TITLE
Fix: Spacing Around Codepen Embeds

### DIFF
--- a/app/assets/stylesheets/components/lesson/lesson_content.scss
+++ b/app/assets/stylesheets/components/lesson/lesson_content.scss
@@ -142,6 +142,10 @@
     padding-left: 1em;
   }
 
+  .cp_embed_wrapper {
+    margin-bottom: 30px;
+  }
+
   .knowledge-check-link {
     color: inherit;
     text-decoration: inherit;


### PR DESCRIPTION
Because:
* The embeds were didn't have any bottom spacing.

This commit:
* Adds a bottom margin to all embeds.

Resolves: https://github.com/TheOdinProject/theodinproject/issues/2203

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
