### PR TITLE
Fixed the intro title of flexbox section

### DIFF
--- a/db/fixtures/lessons/foundation_lessons.rb
+++ b/db/fixtures/lessons/foundation_lessons.rb
@@ -321,7 +321,7 @@ def foundation_lessons
     },
     'Introduction' => {
       title: 'Introduction to Flexbox',
-      description: "Let's get starting with flexbox",
+      description: "Let's get started with Flexbox",
       is_project: false,
       url: '/foundations/html_css/flexbox/flexbox-intro.md',
       identifier_uuid: '41a157af-b416-4744-bac0-ab5dabde1ad9',

--- a/db/fixtures/lessons/foundation_lessons.rb
+++ b/db/fixtures/lessons/foundation_lessons.rb
@@ -320,7 +320,7 @@ def foundation_lessons
       identifier_uuid: '25874e5c-2485-4e62-aaa5-5d6cf65b6b52',
     },
     'Introduction' => {
-      title: 'Introduction',
+      title: 'Introduction to Flexbox',
       description: "Let's get starting with flexbox",
       is_project: false,
       url: '/foundations/html_css/flexbox/flexbox-intro.md',


### PR DESCRIPTION
Because:
Resolves issue#2209: https://github.com/TheOdinProject/theodinproject/issues/2209

This commit:
- Changed the title "Introduction" of the flexbox section from Foundations lesson to "Introduction to Flexbox".
