### PR TITLE
Improve JavaScript Async introduction lesson name

### DIFF
--- a/db/fixtures/lessons/javascript_lessons.rb
+++ b/db/fixtures/lessons/javascript_lessons.rb
@@ -134,9 +134,9 @@ def javascript_lessons
       url: '/javascript/async-apis/json.md',
       identifier_uuid: 'ae0d44bf-60b7-4644-b61e-216a4a6b271b',
     },
-    'Async' => {
-      title: 'Async',
-      description: 'Async',
+    'Asynchronous Code' => {
+      title: 'Asynchronous Code',
+      description: 'Introduction to asynchronous programming',
       is_project: false,
       url: '/javascript/async-apis/promises-async.md',
       identifier_uuid: '31ab5898-fd2b-48c4-9070-0e8b622b0805',

--- a/db/fixtures/paths/full_stack_javascript/courses/1_javascript.rb
+++ b/db/fixtures/paths/full_stack_javascript/courses/1_javascript.rb
@@ -70,7 +70,7 @@ course.add_section do |section|
 
   section.add_lessons(
     javascript_lessons.fetch('JSON'),
-    javascript_lessons.fetch('Async'),
+    javascript_lessons.fetch('Asynchronous Code'),
     javascript_lessons.fetch('Working with APIs'),
     javascript_lessons.fetch('Async and Await'),
     javascript_lessons.fetch('Weather App'),

--- a/db/fixtures/paths/full_stack_rails/courses/5_javascript.rb
+++ b/db/fixtures/paths/full_stack_rails/courses/5_javascript.rb
@@ -70,7 +70,7 @@ course.add_section do |section|
 
   section.add_lessons(
     javascript_lessons.fetch('JSON'),
-    javascript_lessons.fetch('Async'),
+    javascript_lessons.fetch('Asynchronous Code'),
     javascript_lessons.fetch('Working with APIs'),
     javascript_lessons.fetch('Async and Await'),
     javascript_lessons.fetch('Weather App'),


### PR DESCRIPTION
#### Because:
As discussed on discord ( https://discord.com/channels/505093832157691914/540903304046182425/893182342011691008 ) the JavaScript `Async` lesson name could be improved for clarity, particularly when there is a later lesson named `Async and Await`

#### This commit
Updated the name of the lesson and it's description in `db/fixtures/lessons/javascript_lessons.rb`:

```rb
 'Asynchronous Code' => {
      title: 'Asynchronous Code',
      description: 'Introduction to asynchronous programming',
```

Updated the lesson fetch functions in the `full_stack_rails` and `full_stack_javascript` course paths.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
