### PR TITLE
Fix: code tag color inside knowledge check

### DIFF
--- a/app/assets/stylesheets/components/lesson/lesson_content.scss
+++ b/app/assets/stylesheets/components/lesson/lesson_content.scss
@@ -149,9 +149,14 @@
   .knowledge-check-link {
     color: inherit;
     text-decoration: inherit;
+    
     &:active, &:focus, &:hover, &:visited {
         color: inherit;
         text-decoration: none;
+    }
+    
+    & > code {
+      color: $pink;
     }
   }
 


### PR DESCRIPTION
 

#### Because:
`<code>` tag inside `.knowledge-check-link` which is an `<a>` tag, overrides the color of `<code>` to `grey` from `pink`. It's because bootstrap's reboot which has a selector `a > code` that changes it.

![now](https://user-images.githubusercontent.com/67100964/136185673-132c0e39-fe14-4c39-9468-8451a26afcc6.png)

![then](https://user-images.githubusercontent.com/67100964/136185641-89d4869d-a7b8-48e1-aadd-071db453b6dd.png)

#### This commit
So I've added a `.knowledge-check-link > code` selector which gives `pink` color to `<code>` tag. `$pink` variable is declared in bootstrap.

For example you can see the knowledge check section [here](https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/fundamentals-part-1#knowledge-check), `==` like things inside `<code>` tag are in color `grey` instead of `pink`.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [ ] You have verified the tests and linters all pass against your changes?
 - [ ] You have included automated tests for your changes where applicable?
