### PR TITLE
Add discard project submissions rake task

### DIFF
--- a/lib/tasks/project_submissions.rake
+++ b/lib/tasks/project_submissions.rake
@@ -1,0 +1,6 @@
+namespace :project_submissions do
+  desc 'Discard discardable project submissions'
+  task discard: :environment do
+    DiscardProjectSubmissionJob.new.perform
+  end
+end

--- a/spec/tasks/project_submissions_spec.rb
+++ b/spec/tasks/project_submissions_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+require 'rake'
+
+describe ':project_submissions' do
+  before :all do
+    Rake.application.rake_require 'tasks/project_submissions'
+    Rake::Task.define_task(:environment)
+  end
+
+  let(:project_submissions_discard) do
+    Rake::Task['project_submissions:discard'].reenable
+
+    Rake.application.invoke_task 'project_submissions:discard'
+  end
+
+  describe 'project_submissions:discard' do
+    context 'with a discardable project submission' do
+      let(:project_submission) do
+        FactoryBot.create(
+          :project_submission,
+          discard_at: 1.day.ago
+        )
+      end
+
+      it 'discards it' do
+        project_submissions_discard
+        expect(project_submission.reload.discard_at).not_to be_nil
+      end
+    end
+
+    context 'with a non discardable project submission' do
+      let(:project_submission) do
+        FactoryBot.create(:project_submission)
+      end
+
+      it 'does not discard it' do
+        project_submissions_discard
+        expect(project_submission.reload.discard_at).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Because: The DiscardProjectSubmissionsJob needs to run at a set interval

This commit:

- Creates a project_submissions:discard rake task
- Writes a couple of tests on the behaviour

The tests do duplicate some of the testing around the job itself but
thought it was worth those extra tests just to make sure we don't
inadvertantly discard any project submissions that shouldn't be
discarded