### PR TITLE
Chore: Use ruby-version File to Fetch the Ruby Version in the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
+ruby File.read('.ruby-version').strip
+
 source 'https://rubygems.org'
-ruby '~> 2.7'
 
 gem 'rails', '6.1.4.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -628,7 +628,7 @@ DEPENDENCIES
   webpacker
 
 RUBY VERSION
-   ruby 2.7.1p83
+   ruby 2.7.4p191
 
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION
Because:
* We will only need to update the ruby version in one place for future upgrades.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
