### PR TITLE
Chore: Remove Jemalloc

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 release: bin/heroku_release
-web: jemalloc.sh bundle exec puma -C config/puma.rb
+web: bundle exec puma -C config/puma.rb
 worker: bundle exec sidekiq -c 2

--- a/app.json
+++ b/app.json
@@ -13,9 +13,6 @@
           "url": "heroku/ruby"
         },
         {
-          "url": "https://github.com/gaffneyc/heroku-buildpack-jemalloc.git"
-        },
-        {
           "url": "https://github.com/carwow/heroku-buildpack-cachesave.git"
         },
         {


### PR DESCRIPTION
Because:
* We will be upgrading our Heroku stack which will negate any performance gains Jemalloc currently gives us.

This commit:
* Removes the Jemalloc bash script that wraps the web process.
* Removes adding the Jemalloc buildpack to review apps.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?

**Important**
Ensure the Jemalloc Buildpack is removed from production after deploying this.