### PR TITLE
Make lesson images open in a new tab when clicked

### DIFF
--- a/app/javascript/src/js/lessons.js
+++ b/app/javascript/src/js/lessons.js
@@ -141,12 +141,33 @@ function spyLessonSections() {
   $('.scrollspy').scrollSpy({ scrollOffset: 50 });
 }
 
+function makeSimpleContentImagesClickable() {
+  const images = getElements('.lesson-content img');
+
+  // If there is already a wrapping anchor tag, we do not want to add another
+  [...images].filter(image => image.parentElement.nodeName !== 'a')
+  .forEach(makeImageChildOfAnchor);
+}
+
+function makeImageChildOfAnchor(image) {
+  const imageSrc = image.getAttribute('src');
+
+  const wrappingAnchor = document.createElement('a');
+  wrappingAnchor.href = imageSrc;
+  wrappingAnchor.setAttribute('target', '_blank');
+
+  // Append after image in DOM tree, then embed image into the anchor
+  image.after(wrappingAnchor);
+  wrappingAnchor.appendChild(image);
+}
+
 document.addEventListener('turbolinks:load', () => {
   if (!isLessonPage()) return;
 
   Prism.highlightAll();
   setTargetForExternalLinks();
   constructLessonSections();
+  makeSimpleContentImagesClickable();
 
   if (!window.matchMedia('(min-width: 992px)').matches) {
     return;


### PR DESCRIPTION
#### Because:
<!--
If your pull request resolves an open issue, please provide a link to it. For example: Resolves: https://github.com/TheOdinProject/theodinproject/issues/1886
Otherwise, please briefly explain why these changes were made, what problem does it solve?.
-->
closes: #2317 

#### This commit
<!--
A bullet point list of one or more items outlining what was done in this pull request to solve the problem.
-->

* Uses existing lesson modification structure to 
  * Identify images that are not wrapped in an anchor tag
   * Append the anchor tag to the DOM adjacent to the image
   * Append the image to be a child of the anchor tag. 

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
