### PR TITLE
Fix: Resume Course Should Start at the Next Incomplete Lesson

### DIFF
--- a/app/services/next_lesson.rb
+++ b/app/services/next_lesson.rb
@@ -5,34 +5,24 @@ class NextLesson
   end
 
   def to_complete
-    next_lesson_to_complete || remaining_lesson_to_complete
+    next_uncompleted_lesson || remaining_lessons_to_complete.first
   end
 
   private
 
   attr_reader :course, :lesson_completions
 
-  def lessons_left_to_complete
-    course.lessons - lessons_already_completed
+  def next_uncompleted_lesson
+    remaining_lessons_to_complete.find do |lesson|
+      lesson.position > most_recent_completed_lesson.position
+    end
   end
 
-  def lessons_already_completed
-    lesson_completions.map(&:lesson)
+  def remaining_lessons_to_complete
+    (course.lessons - lesson_completions.map(&:lesson)).sort_by(&:position)
   end
 
-  def last_lesson_completion
-    lesson_completions.max_by(&:created_at)
-  end
-
-  def latest_completed_lesson
-    last_lesson_completion.lesson
-  end
-
-  def next_lesson_to_complete
-    FindLesson.new(latest_completed_lesson, course).next_lesson
-  end
-
-  def remaining_lesson_to_complete
-    lessons_left_to_complete.min_by(&:position)
+  def most_recent_completed_lesson
+    lesson_completions.max_by(&:created_at).lesson
   end
 end


### PR DESCRIPTION
Because:
* When taking lessons out of order, the resume course button was not taking into account if
 the next lesson after the users most recently completed lesson had already been completed or not.

This commit:
* Only return incomplete lessons from the next lesson service.
* General refactor of the next lesson service and specs for improved code quality and test coverage.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
