### PR TITLE
Chore: Reduce Weekly Dependabot PR's

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 5
   ignore:
   - dependency-name: rubocop
     versions:
@@ -25,7 +25,7 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 5
   ignore:
   - dependency-name: react-hook-form
     versions:


### PR DESCRIPTION
Because:
* We are getting a few too many each week, which increases the risk of a bump breaking something.

This commit:
* Reduces Ruby gem bumps to 5 a week
* Reduces JS package bumps to 5 a week

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
