### PR TITLE
Feature: Skip the show path screen when a path only has one course

### DIFF
--- a/app/controllers/paths_controller.rb
+++ b/app/controllers/paths_controller.rb
@@ -1,17 +1,13 @@
 class PathsController < ApplicationController
   def show
     @path = Path.friendly.find(params[:id])
-    @courses = decorated_courses
-    @user = current_user
+
+    if @path.courses.size == 1
+      redirect_to path_course_path(@path, @path.courses.first)
+    end
   end
 
   def index
     @paths = Path.order(:position)
-  end
-
-  private
-
-  def decorated_courses
-    @path.courses.map { |course| CourseDecorator.new(course) }
   end
 end

--- a/app/views/paths/show.html.erb
+++ b/app/views/paths/show.html.erb
@@ -9,7 +9,7 @@
   <% end %>
   <p class="text-center path-description push-down-2x"><%= @path.description %></p>
 
-  <% @courses.each do |course| %>
+  <% @path.courses.each do |course| %>
     <%= render 'courses/course_card', course: course %>
   <% end %>
 

--- a/spec/requests/paths_spec.rb
+++ b/spec/requests/paths_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe 'Static Pages', type: :request do
+  describe 'GET #path' do
+    context 'when path has more than one course' do
+      it 'renders the path page' do
+        path = create(:path)
+        create(:course, path: path)
+        create(:course, path: path)
+
+        get path_url(path)
+
+        expect(response).to render_template(:show)
+      end
+    end
+
+    context 'when path only has one course' do
+      it 'redirects to the course' do
+        path = create(:path)
+        course = create(:course, path: path)
+
+        get path_url(path)
+
+        expect(response).to redirect_to(path_course_path(path, course))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Because:
* When I'm visiting a path that only has one course, then I want to be redirected to that course instead of the path show page, so I can save myself a click.

This commit:
* Checks if the path has one course. Then redirects to the course page if it does.
* Adds request specs around the redirect.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
