### PR TITLE
Fix: After Sign in Redirect

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -45,10 +45,6 @@ class ApplicationController < ActionController::Base
   end
 
   def storable_location?
-    request.get? && is_navigational_format? && !devise_controller? && !request.xhr? && lesson_path?
-  end
-
-  def lesson_path?
     controller_path == 'lessons' && action_name == 'show'
   end
 


### PR DESCRIPTION
Because:
* It was sometimes(rarely) storing the course progress json response as the last visited page.

This commit:
* Only allow the lesson page to be stored as the last visited page so log in redirects cannot go anywhere else.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
