### PR TITLE
Feature: Allow Users to Access the Main Homepage when Signed in

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,7 +1,5 @@
 class StaticPagesController < ApplicationController
-  def home
-    redirect_to dashboard_path if user_signed_in?
-  end
+  def home; end
 
   def about; end
 

--- a/app/views/shared/_logo.html.erb
+++ b/app/views/shared/_logo.html.erb
@@ -1,4 +1,4 @@
-<%= link_to home_url, class: 'logo' do %>
+<%= link_to root_path, class: 'logo' do %>
   <%= image_tag 'odin-logo.svg' , alt: "Odin Logo" , class: 'logo__img' %>
   <div class="logo__text"> The Odin Project </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,13 @@ Rails.application.routes.draw do
 
   resource :github_webhooks, only: :create, defaults: { formats: :json }
 
-  root 'static_pages#home'
+  unauthenticated do
+    root 'static_pages#home'
+  end
+
+  authenticated :user do
+    root to: 'users#show', as: :dashboard
+  end
 
   devise_for :users, controllers: {
     registrations: 'registrations',
@@ -47,7 +53,6 @@ Rails.application.routes.draw do
     resources :paths, only: :create
     resources :progress, only: :destroy
   end
-  get 'dashboard' => 'users#show', as: :dashboard
 
   # Deprecated Route to Web Development 101 from external links
   get '/courses/web-development-101', to: redirect('/courses/foundations')

--- a/spec/requests/static_pages_spec.rb
+++ b/spec/requests/static_pages_spec.rb
@@ -2,24 +2,11 @@ require 'rails_helper'
 
 RSpec.describe 'Static Pages', type: :request do
   describe 'GET #home' do
-    context 'when guest user' do
-      it 'renders the home page' do
-        get home_path
+    it 'renders the home page' do
+      get home_path
 
-        expect(response).to have_http_status(200)
-        expect(response).to render_template(:home)
-      end
-    end
-
-    context 'when user is signed in' do
-      it 'redirects to the users dashboard' do
-        user = create(:user)
-
-        sign_in(user)
-        get home_path
-
-        expect(response).to redirect_to(dashboard_path)
-      end
+      expect(response).to have_http_status(200)
+      expect(response).to render_template(:home)
     end
   end
 


### PR DESCRIPTION
Because:
* When I'm signed in to TOP, then I want to be able to access the main homepage, so I can view it.

This commit:
* Removes the dashboard redirect on the homepage for signed in users.
* Changes the root path to be the dashboard for signed in users.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
