### PR TITLE
Chore: Turn Off Turbolinks Caching

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="The Odin Project empowers aspiring web developers to learn together for free">
     <meta property="og:image" content="<%= image_url('og-logo.png') %>">
+     <meta name="turbolinks-cache-control" content="no-cache">
     <%= csrf_meta_tags %>
 
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">


### PR DESCRIPTION
Because:
* I suspect this is whats causing the complete button to sometimes hit the wrong endpoint and cause an ActiveRecord::RecordNotUnique exception.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [ ] You have included automated tests for your changes where applicable?
