### PR TITLE
Chore: Add Jemalloc

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,6 +7,9 @@
       ],
       "buildpacks": [
         {
+          "url": "https://github.com/gaffneyc/heroku-buildpack-jemalloc.git"
+        },
+        {
           "url": "https://github.com/carwow/heroku-buildpack-cacheload.git"
         },
         {


### PR DESCRIPTION
Because:
* This should reduce the app's memory consumption on Heroku and allow us to add more web processes.
* More details here: https://www.speedshop.co/2017/12/04/malloc-doubles-ruby-memory.html

This commit:
* Adds the Jemalloc buildpack to our review apps.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
