### PR TITLE
Split DOM Manipulation Lesson

### DIFF
--- a/db/fixtures/lessons/foundation_lessons.rb
+++ b/db/fixtures/lessons/foundation_lessons.rb
@@ -349,5 +349,12 @@ def foundation_lessons
       has_live_preview: true,
       identifier_uuid: '22e0c585-c146-4dab-9dc0-17a20f0ecbc5',
     },
+    'DOM Manipulation and Events' => {
+      title: 'DOM Manipulation and Events',
+      description: 'Finally, let\'s learn how to make our webpages move.',
+      is_project: false,
+      url: '/foundations/javascript_basics/DOM_manipulation_and_events.md',
+      identifier_uuid: '9c8fa0eb-2f69-4fc7-87a9-4506bd43ca1f',
+    },
   }
 end

--- a/db/fixtures/lessons/foundation_lessons.rb
+++ b/db/fixtures/lessons/foundation_lessons.rb
@@ -356,5 +356,12 @@ def foundation_lessons
       url: '/foundations/javascript_basics/DOM_manipulation_and_events.md',
       identifier_uuid: '9c8fa0eb-2f69-4fc7-87a9-4506bd43ca1f',
     },
+    'Revisiting Rock Paper Scissors' => {
+      title: 'Revisiting Rock Paper Scissors',
+      description: 'Let\'s apply our newfound knowledge of DOM and build our RPS\'s UI',
+      is_project: false,
+      url: '/foundations/javascript_basics/revisiting_rock_paper_scissors.md',
+      identifier_uuid: '7ff13edf-27d6-4edf-b0d0-863a632604d6',
+    },
   }
 end

--- a/db/fixtures/lessons/foundation_lessons.rb
+++ b/db/fixtures/lessons/foundation_lessons.rb
@@ -186,13 +186,6 @@ def foundation_lessons
       url: '/foundations/javascript_basics/fundamentals-4.md',
       identifier_uuid: '336b3336-c589-4e61-876f-1c0e60617da4',
     },
-    'DOM manipulation' => {
-      title: 'DOM manipulation',
-      description: 'Finally, lets learn how to make your webpages move!',
-      is_project: false,
-      url: '/foundations/javascript_basics/DOM-manipulation.md',
-      identifier_uuid: '7718816d-45eb-477d-9443-a8f1de2db22c',
-    },
     'Etch-a-Sketch' => {
       title: 'Etch-a-Sketch',
       description: 'etch-a-sketch',

--- a/db/fixtures/paths/foundations/seed.rb
+++ b/db/fixtures/paths/foundations/seed.rb
@@ -139,6 +139,7 @@ course.add_section do |section|
     foundation_lessons.fetch('Clean Code'),
     foundation_lessons.fetch('Fundamentals Part 4'),
     foundation_lessons.fetch('DOM Manipulation and Events'),
+    foundation_lessons.fetch('Revisiting Rock Paper Scissors'),
     foundation_lessons.fetch('Etch-a-Sketch'),
     foundation_lessons.fetch('Fundamentals Part 5'),
     foundation_lessons.fetch('Calculator'),

--- a/db/fixtures/paths/foundations/seed.rb
+++ b/db/fixtures/paths/foundations/seed.rb
@@ -138,6 +138,7 @@ course.add_section do |section|
     foundation_lessons.fetch('Rock Paper Scissors'),
     foundation_lessons.fetch('Clean Code'),
     foundation_lessons.fetch('Fundamentals Part 4'),
+    foundation_lessons.fetch('DOM Manipulation and Events'),
     foundation_lessons.fetch('Etch-a-Sketch'),
     foundation_lessons.fetch('Fundamentals Part 5'),
     foundation_lessons.fetch('Calculator'),

--- a/db/fixtures/paths/foundations/seed.rb
+++ b/db/fixtures/paths/foundations/seed.rb
@@ -138,7 +138,6 @@ course.add_section do |section|
     foundation_lessons.fetch('Rock Paper Scissors'),
     foundation_lessons.fetch('Clean Code'),
     foundation_lessons.fetch('Fundamentals Part 4'),
-    foundation_lessons.fetch('DOM manipulation'),
     foundation_lessons.fetch('Etch-a-Sketch'),
     foundation_lessons.fetch('Fundamentals Part 5'),
     foundation_lessons.fetch('Calculator'),


### PR DESCRIPTION
#### Because:

- DOM manipulation lesson was split into [DOM Manipulation and Events](https://github.com/TheOdinProject/curriculum/pull/23080) and [Revisiting Rock Paper Scissors](https://github.com/TheOdinProject/curriculum/pull/23079)

<!--
If your pull request resolves an open issue, please provide a link to it. For example: Resolves: https://github.com/TheOdinProject/theodinproject/issues/1886
Otherwise, please briefly explain why these changes were made, what problem does it solve?.
-->

#### This commit

- Removes the old DOM manipulation lesson
- Adds [DOM Manipulation and Events](https://github.com/TheOdinProject/curriculum/pull/23080) Lesson and [Revisiting Rock Paper Scissors](https://github.com/TheOdinProject/curriculum/pull/23079) Lesson

<!--
A bullet point list of one or more items outlining what was done in this pull request to solve the problem.
-->

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [ ] You have included automated tests for your changes where applicable?
