### PR TITLE
Fix: Unique Constraint Race Conditions

### DIFF
--- a/app/controllers/project_submissions_controller.rb
+++ b/app/controllers/project_submissions_controller.rb
@@ -3,7 +3,7 @@ class ProjectSubmissionsController < ApplicationController
   before_action :find_project_submission, only: %i[update destroy]
 
   def create
-    project_submission = current_user.project_submissions.new(project_submission_params)
+    project_submission = current_user.project_submissions.create_or_find_by!(project_submission_params)
 
     if project_submission.save
       render json: ProjectSubmissionSerializer.as_json(project_submission), status: :ok

--- a/app/models/project_submission.rb
+++ b/app/models/project_submission.rb
@@ -15,6 +15,7 @@ class ProjectSubmission < ApplicationRecord
   validates :repo_url, url: true
   validates :live_preview_url, allow_blank: true, url: true
   validates :repo_url, presence: { message: 'Required' }
+  validates :user_id, uniqueness: { scope: :lesson_id }
 
   scope :viewable, -> { where(is_public: true, banned: false, discarded_at: nil) }
   scope :created_today, -> { where('created_at >= ?', Time.zone.now.beginning_of_day) }

--- a/spec/models/project_submission_spec.rb
+++ b/spec/models/project_submission_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe ProjectSubmission, type: :model do
   it { is_expected.to allow_value('https://www.github.com/fff').for(:live_preview_url) }
   it { is_expected.to_not allow_value('not_a_url').for(:live_preview_url) }
 
+  it { is_expected.to validate_uniqueness_of(:user_id).scoped_to(:lesson_id) }
+
   describe '.viewable' do
     let!(:banned_project_submission) { create(:project_submission, banned: true) }
     let!(:private_project_submission) { create(:project_submission, is_public: false) }


### PR DESCRIPTION
Because:
* This error is happening frequently on Sentry and we think there is a race condition.

This commit:
* Uses create_or_find_by! as this will handle RecordNotUnique internally on creation and return the existing record instead.
* Add unique validation to project submissions model so we can funnel this error back to the user instead of returning a 500 response.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
