### PR TITLE
Adds static pages for our community material

### DIFF
--- a/app/views/static_pages/before_asking.html.erb
+++ b/app/views/static_pages/before_asking.html.erb
@@ -1,0 +1,11 @@
+<%= title('Before Asking') %>
+
+<div class="gradient pb-1">
+  <div class="col-xl-8 offset-xl-2">
+    <div class="lesson-content">
+      <% f = File.open('app/views/static_pages/dashboard_steps/before_asking.md', 'r:UTF-8') %>
+      <%= MarkdownConverter.new(f.read).as_html.html_safe %>
+      <% f.close %>
+    </div>
+  </div>
+</div>

--- a/app/views/static_pages/community_rules.html.erb
+++ b/app/views/static_pages/community_rules.html.erb
@@ -1,0 +1,11 @@
+<%= title('Community Expectations') %>
+
+<div class="gradient pb-1">
+  <div class="col-xl-8 offset-xl-2">
+    <div class="lesson-content">
+      <% f = File.open('app/views/static_pages/dashboard_steps/community_rules.md', 'r:UTF-8') %>
+      <%= MarkdownConverter.new(f.read).as_html.html_safe %>
+      <% f.close %>
+    </div>
+  </div>
+</div>

--- a/app/views/static_pages/dashboard_steps/before_asking.md
+++ b/app/views/static_pages/dashboard_steps/before_asking.md
@@ -1,0 +1,62 @@
+### Help Yourself Before Asking Others
+
+When you are a part of an active community of experienced developers, like our Discord server, it can be tempting to ask for help before doing enough legwork on your own. If this becomes a habit, it will impede your own progress because you'll miss opportunities to strengthen your own troubleshooting skills. These skills are vital to becoming a successful developer, so let's look at some practical tips to help yourself before asking others for help.
+
+#### Adjust Your Expectations
+
+Most of our exercises and projects are designed to push you to your limit and force you to do some research on your own. This experience is similar to being assigned to build a new feature in your future job. When you first start on it, you will most likely not know how to complete all of it. Instead of holding on to this unrealistic expectation, adjust your perspective and get comfortable not knowing the entire solution when you begin.
+
+#### Break Down the Problem
+
+Break down the problem into small pieces and write it out in pseudo code. If you would like a detailed explanation of this step, read our [Problem Solving lesson](/paths/foundations/courses/foundations/lessons/problem-solving) with this specific problem in mind.
+
+#### Research a Sub-Problem
+
+After you have broken your problem down into smaller sub-problems, you should research a sub-problem using your favorite search engine. As an example, you should research "return random item from array in javascript" not "how to create rock paper scissors in javascript"
+
+If you are not getting helpful search results, read [How to Use Google to Solve Your Programming Questions](https://codinginflow.com/google-programming-questions) for tips on how to adjust your search criteria.
+
+#### Examine Error Messages
+
+Error messages are designed to help you get to the root of the problem. When you get an error, it is important to look at the entire error message to learn about the error and its location. If you do not understand the error message, copy and paste the most relevant line into your favorite search engine. You can also use the search feature in our Discord server to read how other people may have resolved similar issues. For even more tips, read our [Understanding Errors lesson](paths/foundations/courses/foundations/lessons/understanding-errors).
+
+#### Triple Check Terminal Commands
+
+If you are following our directions and get an error message or other unexpected output, complete the following trouble-shooting tips:
+
+* Starting at the beginning, re-read all of our directions.
+* Compare the directions to your terminal history to ensure that you did not skip anything.
+* Copy and paste the exact terminal command from our lesson to prevent typos.
+* Use the command `pwd` to confirm that you are in the correct directory.
+
+If you are not following our directions, research it and confirm that you are using the correct command. You can also research the error message or unexpected output because someone else has probably experienced a similar situation.
+
+#### Review Previous Lessons
+
+It can be helpful to review the previous lessons because you might have overlooked something that you can apply to your current task.
+
+#### Check for Typos
+
+It is important to check your code for typos, because they can result in a wide variety of weird behavior and error messages. To help prevent typos, use [VS Code's IntelliSense](https://code.visualstudio.com/docs/editor/intellisense) to complete methods, parameters, variables, etc.
+
+#### Debug Your Code
+
+When your code has unexpected behavior, the most important tool at your disposal is a debugger. This may sound like overkill, but look at all of your variables at every point in your code. Be assured that your code is doing exactly what you instructed it to do. The problem is that you are misunderstanding what you told it to do. Your job is to investigate where the misunderstanding is taking place. For even more information, check out [JavaScript's DevTools](https://developer.chrome.com/docs/devtools/javascript/) or [Ruby's pry-byebug](/paths/full-stack-ruby-on-rails/courses/ruby-programming/lessons/debugging#debugging-with-pry-byebug).
+
+#### Read Documentation Thoroughly
+
+When you have isolated your problem down to a specific function or method that is producing unexpected results, you should read through its documentation. It is very common to learn that you misunderstood what the function/method does, its return value, or possible side effects.
+
+#### Know When to Take a Break
+
+It is time to take a break when you begin to feel tired, frustrated, overwhelmed, etc. At a certain point, persistence can be more detrimental than beneficial.
+
+In addition, there is a very common phenomenon in programming where new ideas and solutions come to you after you take a break. This may sound crazy (until you've experienced it), so you need to trust us on this. Sometimes it comes to you when you are doing a mundane task, like walking your dog, cooking a meal, folding socks, etc. Sometimes it happens when you get back to your desk and start reviewing the problem and your code.
+
+#### Talk Through Your Code Line By Line
+
+The final tip is to explain your code line by line, which is a tried and true technique called [rubber duck debugging](https://en.wikipedia.org/wiki/Rubber_duck_debugging). This may sound silly, so you need to trust us on this one too. When you take the time to examine each line of code, especially after taking a break, you'll be amazed how you'll see things that you did not see before!
+
+### Conclusion
+
+Going through each of these tips can take quite a bit of time, but as you get more experience many of these will become part of your development process, which will save you time in the end. If you have not found the root of the problem, after working through each of these tips, it is time to ask others. However, asking others for help is not as simple as it may sound, so please read [How to Ask a Technical Question](/how_to_ask).

--- a/app/views/static_pages/dashboard_steps/community_rules.md
+++ b/app/views/static_pages/dashboard_steps/community_rules.md
@@ -1,0 +1,78 @@
+### Community Rules
+
+Our Discord server is a very active community of people from all over the world and is moderated by a team of volunteers. When you join Discord, you'll see that our moderation team has 3 different [roles](https://github.com/TheOdinProject/top-meta/blob/main/about/discord-roles.md): Core, Maintainer, and Moderator.
+
+Our moderation team is committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender identity and expression, sexual orientation, disability, neurodivergence, personal appearance, body, race, ethnicity, age, religion, nationality, or other similar characteristic.
+
+We expect everyone to handle themselves in a professional manner and follow the spirit of our community rules. If you are given a warning by a member of our moderation team, please do not take it personally or be argumentative. We truly want to help you learn how to interact with others professionally, but your second chance does not have priority over the well-being of our community.
+
+#### 1. Please leave moderation to the moderators
+Please DM the @ModMail user with issues that need to be resolved with things on the server, like someone being a troll, or breaking rules in a way that requires intervention. Don't be afraid to let us know if something isn't right.
+
+#### 2. This community only supports the content in our curriculum
+All questions and advice should stay within the scope of our curriculum because we are only equipped to support our own material and recommendations. If you seek support on homework, personal projects, relationships, depression, mental illness, or anything else outside the scope of our curriculum, please seek out more equipped resources.
+
+#### 3. This community does not support Windows/WSL
+Our maintainer team has chosen to not recommend or support Windows/WSL for [multiple reasons](https://github.com/TheOdinProject/blog/wiki/Why-We-Do-Not-Support-Windows). If you have chosen to ignore this prerequisite, it is your responsibility to research instructions outside of this community.
+
+#### 4. Do not short-circuit a teaching moment
+If somebody is already getting help, do not jump in the middle of the conversation. We know you mean well, but it is counter-productive and overwhelming for the person receiving help to follow multiple conversations. For more information on how we encourage guiding a person to their own answer, please read [How to Help Others Solve Coding Problems](https://github.com/TheOdinProject/blog/wiki/How-to-Help-Others-Solve-Coding-Problems).
+
+#### 5. Do not send anyone an unsolicited ping, DM, or friend request
+Everyone in this community is a volunteer and shares the responsibility to answer questions. It is unfair to expect specific people to answer your question. If you are being privately harassed by a community member, please DM the @ModMail user to report the situation.
+
+#### 6. Any form of harassment is not tolerated
+Do not post NSFL/NSFW content or sexual remarks. In addition, any racist remarks, religious persecution, doxing, trolling, spamming, flaming, baiting or any other attention-stealing behavior will result in an immediate ban.
+
+#### 7. Any form of illegal activity is not tolerated
+Posting about any illegal activities, including piracy, links to pirated material, or suggesting someone pirate intellectual property will result in an immediate ban.
+
+#### 8. No political or religious topics
+This is a diverse community; there are people from many different ethnic, socioeconomic, and geographic backgrounds. Do not post any topic that could be perceived as political or religious because it can be divisive and hinder our ability to support each other.
+
+#### 9. Ask detailed and specific questions
+We encourage questions, so do not worry about asking a "stupid question". However, it is important that you [Help Yourself Before Asking Others](/before_asking) and follow our tips on [How to Ask a Technical Question](/how_to_ask). In addition, to ensure that everyone has the same expectations, below are some specific guidelines on asking questions:
+
+<div class="lesson-content__panel" markdown="1">
+
+* **Ask questions in the proper channel.** We have specific channels for every section in our curriculum, so please find the best one to ask your question.
+
+* **Post your question in one and only one channel.** Cross posting will not get you an answer sooner, and it will split the discussion into redundant and/or conflicting answers.
+
+* **Stay online after asking a question.** Most of the time, answers are not simple and straight-forward. Therefore, you should be prepared to stick around and discuss it with those trying to help.
+
+* **Wait patiently for a response.** Even though our community is fairly active, not all questions will be answered right away. While you are waiting, make sure that you have provided a detailed question and continue trouble-shooting. If your post is getting buried and/or if you have been waiting for an hour, you can direct people to your question.
+
+* **Do not ask to ask a question.** You have permission to ask questions, provided that it falls within our rules. We know you mean well, but it is somewhat inconsiderate to make people wait for your actual question. For more information, please read [Don't ask to ask, just ask](https://dontasktoask.com/).
+
+* **Use external services for code sharing.** Posting small snippets of code is acceptable, but anything longer than a few lines is hard to read and parse. Do not upload files for people to download. Use [Pastebin](http://pastebin.com/) for long error messages. Use [CodePen](https://codepen.io/), [Replit](https://replit.com/), or [CodeSandbox](https://codesandbox.io/) for code examples.
+
+</div>
+
+#### 10. Be professional and have good etiquette
+
+We expect everyone to handle themselves professionally and treat others respectfully, no matter how old you are or how much experience you have. To ensure that everyone has the same expectations, below are some specific guidelines:
+
+<div class="lesson-content__panel" markdown="1">
+
+* **Do not post personal information.** This applies to all sensitive information, as well as **your age** (unless you are an adult).
+
+* **No sexual or offensive usernames, nicknames, or profile pictures.** This detracts from a professional, friendly, safe and welcoming environment.
+
+* **Do not compare time with others.** When people try to compare how much time it takes even to do TOP or even just one project, it tends to lead to feelings of inadequacy or a false sense of accomplishment. Everyone has different life circumstances and project completion expectations, so we discourage comparing time and instead focus on learning the material well.
+
+* **Only ping another user when necessary.** It is often not necessary to ping a specific person because everyone shares the responsibility to help others. If you choose to ping another user about a recent conversation, please wait patiently for a reply.
+
+* **Do not bomb the chat by sending multiple messages in a row.** Please type your entire comment or question in one message. To create a new line, use `shift + enter/return` on your computer or the `enter/return` button on your mobile device.
+
+* **Provide context when sharing a resource.** When posting a link to an article or youtube video, include **why** you are sharing it. Otherwise it will be marked as spam and deleted.
+
+* **Post your finished projects in #creations-showcase.** This channel is a great collection of finished projects. Feedback happens in the #creations-discussions channel. Everyone is welcome to provide feedback on a project that you have completed.
+
+* **Respect that people will have differences of opinion.** Every design or implementation choice carries a trade-off and numerous costs. There is seldom a single right answer.
+
+* **Remember the Human.** Behind every username there is a person with feelings, so be kind to everyone! If you wouldn't say it out loud, don't post it.
+
+* **Be gracious during misunderstandings.** When misunderstandings happen, choose to be gracious instead of argumentative. Give others the benefit of the doubt during text-based communication because you can not take into account body language, cultural differences, or other contextual cues.
+
+</div>

--- a/app/views/static_pages/dashboard_steps/how_to_ask.md
+++ b/app/views/static_pages/dashboard_steps/how_to_ask.md
@@ -1,0 +1,72 @@
+### How to Ask Technical Questions
+
+While asking questions may seem rather simple, asking technical questions is actually really complex. Understanding these complexities is vital to your success. Let's explore a few tips that will equip you to ask technical questions in our Discord server, Stack Overflow, and in your future workplace!
+
+#### Do Your Own Legwork
+
+Learning how to find the root of a problem, which is often referred to as a bug, is a vital skill for developers. Believe it or not, but when you get a job, their code base will have a number of bugs! Matter of fact, it is very likely that you will be assigned a handful of bugs to resolve to help you get acquainted with the code base. Therefore, it is important for you to practice finding the root of bugs in your own code, so we have some tips that you should follow to [Help Yourself Before Asking Others](/before_asking).
+
+#### Pick the Most Relevant Help Channel
+
+Before you ask your question, go to the most relevant help channel in our Discord server. There are a handful of channels that are really busy, so posts get buried quickly. The best place will be one of our help channels, like #git-help, #html-css-help, #javascript-help, #ruby-help, etc.
+
+#### Explain the Big Picture
+
+Once you have done your own legwork and chose the most relevant help channel, it is time to begin writing your very detailed question. In addition to explaining how you need help, the first piece of additional information that you must provide is explaining the big picture of what you are trying to do.
+
+It is a common misconception to keep your questions short and concise so that you do not waste anyone's time, however there is usually a lot more to your question than you realize. If the person that is helping you knows the big picture, they are more likely to know if your problem is going to solve the big picture issue, or if it would be better to steer you in a different direction. This is commonly referred to as the [“XY Problem”](https://xyproblem.info/), which is a common pitfall for programmers to overcome as they learn how to ask detailed questions.
+
+#### Provide the Relevant Source
+
+The second piece of additional information that you must provide is the relevant code, error message, terminal command, server output, etc. There are multiple ways to share this information depending on what your situation calls for, but you should never post a file for people to download.
+
+If you are asking a question about code, you should provide it in a way that others can easily run it. Here is a list of our recommendations:
+
+* [CodePen](https://codepen.io/) for basic HTML/CSS/Javascript
+* [Replit](https://replit.com/) for Javascript/Ruby
+* [CodeSandbox](https://codesandbox.io/) for Webpack/React
+
+You may not have used the above resources before, but they are essential to making it as easy as possible for others to help you. Before you share your code, make sure it reproduces the problem that you are describing. In addition, if you are working on a large project, it is very helpful to isolate the problem to a small piece of code and only share the problematic code. If that is not possible, you should at least point to the exact function, method, or line number.
+
+If none of the above ways make the most sense to provide the relevant source, here are a few additional ways to provide the relevant information.
+
+* If you are asking about a long error message or server logs, use [pastebin](http://pastebin.com/) to share it.
+* If you are asking about a terminal command, use a screenshot. In Discord, you can drag and drop the screenshot file or you use the PrtScn and paste keyboard shortcuts. If you don't know how to take a screenshot on your computer, then you should research this using your favorite search engine.
+* To share a few lines of code, use backticks to create a code block in Discord. For more detailed instructions, use our bot command `/code` in the #bot-spam-playground channel.
+* If you need to share multiple pieces of code that work together, it might make sense to share a link to your GitHub repo. Be sure to make it as easy as possible for others to help you by providing detailed information (file names, function/method names, and line numbers).
+
+If your question does not provide the relevant source, you will only receive theoretical and vague answers. This often causes frustration for everyone. You may become frustrated because the answers are not helpful. Those helping may become frustrated because as you add new information, the meaning of your original question changes and they wasted time trying to answer it. If you truly want to ask a purely conceptual question, you should indicate this in your question in lieu of a relevant source.
+
+#### Provide Surrounding Context
+
+The final pieces of your question needs to focus on providing all the surrounding context, such as:
+
+* The link to the lesson, project, or article that you are referencing
+* Any steps to reproduce the problem
+* Explain the desired behavior
+* Explain the actual behavior
+* Summarize what you have investigated and how you have attempted to resolve the issue.
+
+If you'd like to read more about providing all of the surrounding context in your question, you should read one of our favorite articles, [How to be Great at Asking Coding Questions](https://medium.com/@gordon_zhu/how-to-be-great-at-asking-questions-e37be04d0603), by Gordon Zhu.
+
+### Our Community Standards
+
+Everyone in our Discord community is a volunteer. Our community includes those that write and maintain our curriculum, professional software engineers, and others that are working their way through the curriculum. We hold every user and their questions to similar standards as [Stack Overflow](https://stackoverflow.com/help/how-to-ask), which is the world’s most popular programming help resource.
+
+#### Be Open to Receiving Help
+
+Most of the time, your question will not just be provided with an answer. Instead you will have a back and forth conversation leading you to your own answer, a lesson to review, a resource explaining something in more details, etc. If this approach is different than you expect, you should read [How to Help Others Solve Coding Problems](https://github.com/TheOdinProject/blog/wiki/How-to-Help-Others-Solve-Coding-Problems)
+
+#### Be Patient and Courteous
+
+If you ask a question without providing enough context, you will be asked clarifying questions to gather all the relevant information. We occasionally see people taking offense or being impatient when asked these types of questions. Be assured that these questions are part of the process to avoid the frustration of helping someone with an incomplete picture. Your question may seem obvious to you, but it is often not obvious to someone with more experience.
+
+#### Be Open to Feedback
+
+Our curriculum and Discord community highly values helping you stand on your own two feet without holding your hand. Adjusting to this approach can be difficult, because it is different from the majority of your educational experiences. If you develop a pattern of asking vague questions or other ["help vampire"](https://slash7.com/2006/12/22/vampires/) behaviors, one of our moderators will privately address this with you.
+
+### Conclusion
+
+One of the biggest benefits of taking the time to write a very detailed question is that you will occasionally solve your own problem. This is one of the best outcomes to have! You should celebrate this achievement and consider documenting the problem and solution in the `README.md` of the project that you are working on.
+
+If you do not find your own answer, following these tips will allow others to help you as easily as possible. It is highly recommended to review these tips each time you ask a question, at least until it is second nature to always provide this level of detail.

--- a/app/views/static_pages/how_to_ask.html.erb
+++ b/app/views/static_pages/how_to_ask.html.erb
@@ -1,0 +1,11 @@
+<%= title('How to Ask Technical Questions') %>
+
+<div class="gradient pb-1">
+  <div class="col-xl-8 offset-xl-2">
+    <div class="lesson-content">
+      <% f = File.open('app/views/static_pages/dashboard_steps/how_to_ask.md', 'r:UTF-8') %>
+      <%= MarkdownConverter.new(f.read).as_html.html_safe %>
+      <% f.close %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,9 @@ Rails.application.routes.draw do
   get 'terms_of_use' => 'static_pages#terms_of_use'
   get 'styleguide' => 'static_pages#style_guide'
   get 'success_stories' => 'static_pages#success_stories'
+  get 'community_rules' => 'static_pages#community_rules'
+  get 'before_asking' => 'static_pages#before_asking'
+  get 'how_to_ask' => 'static_pages#how_to_ask'
   get 'sitemap' => 'sitemap#index', defaults: { format: 'xml' }
 
   # failure route if github information returns invalid


### PR DESCRIPTION
Because:
* The community material needs to be more accessible.
* It is currently only in Foundations.

This Commit:
* Adds page of tips for users to do before asking others for help.
* Adds page of tips for users to do when asking others for help.
* Adds page of our community rules and guidelines.

#### Purpose
To remove the community material out of the Foundations, so that no matter when someone joins Discord, they are required to learn how to ask a question. In addition, by putting our rules on the website, they are open-source and easy for anyone to update.

**After feature is complete, these 2 lessons can be removed from Foundations**
* [Join The Odin Community](https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/join-the-odin-community)
* [Asking for Help](https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/asking-for-help)

#### Proposal
Add these 3 pages as [steps](https://tailwindui.com/components/application-ui/navigation/steps) to the user's dashboard.

In addition, I propose that we require users to complete these 3 steps in order to be given the link to join our Discord server.

Two concerns
1. These 3 pages are longer than a user will take the time to read. However, this is a continual problem and by having these 3 pages on our website, we will be able to easily link users back to them, as needed.
2.  By not automatically giving every user access to our Discord community, we may see less people joining. However, I think it will improve the quality of questions from people joining Discord in places outside of Foundations.

As you can tell, this will be quite a big change to a user's workflow to join Discord. I am open to discussing other ways to accomplish the above stated purpose.

This is in part, addressing this [issue](https://github.com/TheOdinProject/top-meta/issues/66).

In addition, this is utilizing the [wiki idea](https://github.com/TheOdinProject/blog/wiki) for our FAQ and popular posts. Not only does it make them open-source and easy for anyone to update, but also provides links that will always work (unlike links to past conversations in Discord, especially on mobile devices).

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [ ] You have included automated tests for your changes where applicable?
