### PR TITLE
Update submission.test.jsx

### DIFF
--- a/app/javascript/components/project-submissions/components/__tests__/submission.test.jsx
+++ b/app/javascript/components/project-submissions/components/__tests__/submission.test.jsx
@@ -37,7 +37,7 @@ describe('Submission', () => {
   });
 
   describe('Tests for all submissions', () => {
-    test('Renders live preivew with valid live_preview_url', () => {
+    test('Renders live preview with valid live_preview_url', () => {
       ({ queryByTestId } = renderSubmissionComponent({
         ...defaultSubmission,
         live_preview_url: 'https://google.com',

--- a/app/javascript/components/project-submissions/components/__tests__/submission.test.jsx
+++ b/app/javascript/components/project-submissions/components/__tests__/submission.test.jsx
@@ -32,10 +32,6 @@ const renderSubmissionComponent = (submission, userId = 1, onFlag) => render(
 describe('Submission', () => {
   let queryByTestId;
 
-  afterAll(() => {
-    jest.resetModules();
-  });
-
   describe('Tests for all submissions', () => {
     test('Renders live preview with valid live_preview_url', () => {
       ({ queryByTestId } = renderSubmissionComponent({
@@ -72,10 +68,6 @@ describe('Submission', () => {
       ({ queryByTestId } = renderSubmissionComponent(defaultSubmission));
     });
 
-    afterAll(() => {
-      jest.resetModules();
-    });
-
     test('Renders edit button', () => {
       const editButton = queryByTestId('edit-submission-btn');
       expect(editButton).toBeInTheDocument();
@@ -99,10 +91,6 @@ describe('Submission', () => {
 
     beforeEach(() => {
       ({ queryByTestId } = renderSubmissionComponent(defaultSubmission, 2, onFlag));
-    });
-
-    afterAll(() => {
-      jest.resetModules();
     });
 
     test('Does not render edit button', () => {


### PR DESCRIPTION
#### Because:

- Typo
- Unnecessary use of jest.resetModules() method

<!--
If your pull request resolves an open issue, please provide a link to it. For example: Resolves: https://github.com/TheOdinProject/theodinproject/issues/1886
Otherwise, please briefly explain why these changes were made, what problem does it solve?.
-->

#### This commit

- Fixes typo
- Removes jest.resetModules() methods

<!--
A bullet point list of one or more items outlining what was done in this pull request to solve the problem.
-->

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [ ] You have included automated tests for your changes where applicable?
