### PR TITLE
Fix: Marking a Submission as Private Allows Users to Add Another Submission

### DIFF
--- a/app/controllers/project_submissions_controller.rb
+++ b/app/controllers/project_submissions_controller.rb
@@ -6,7 +6,7 @@ class ProjectSubmissionsController < ApplicationController
     project_submission = current_user.project_submissions.create_or_find_by!(project_submission_params)
 
     if project_submission.save
-      render json: ProjectSubmissionSerializer.as_json(project_submission), status: :ok
+      render json: ProjectSubmissionSerializer.as_json(project_submission, current_user), status: :ok
     else
       render json: project_submission.errors, status: :unprocessable_entity
     end

--- a/app/helpers/lessons_helper.rb
+++ b/app/helpers/lessons_helper.rb
@@ -2,11 +2,4 @@ module LessonsHelper
   def github_edit_url(lesson)
     github_link("curriculum/edit/main#{lesson.url}")
   end
-
-  def user_submission(current_user, lesson)
-    return if current_user.blank?
-
-    project_submission = current_user.project_submissions.viewable.find_by(lesson_id: lesson.id)
-    ProjectSubmissionSerializer.as_json(project_submission, current_user) if project_submission.present?
-  end
 end

--- a/app/javascript/components/project-submissions/components/__tests__/submission-title.test.jsx
+++ b/app/javascript/components/project-submissions/components/__tests__/submission-title.test.jsx
@@ -26,12 +26,12 @@ describe('Submission title', () => {
     it('displays submissions username', () => {
       render(<SubmissionTitle submission={submission} />);
       expect(screen.getByText('TestUser')).toBeInTheDocument();
-      expect(screen.getByText('TestUser')).not.toHaveAttribute('href', '/dashboard');
+      expect(screen.getByText('TestUser')).not.toHaveAttribute('href', '/');
     });
 
     it('displays link to users dashboard when submission belongs to the current user', () => {
       render(<SubmissionTitle submission={submission} isCurrentUsersSubmission />);
-      expect(screen.getByText('TestUser')).toHaveAttribute('href', '/dashboard');
+      expect(screen.getByText('TestUser')).toHaveAttribute('href', '/');
     });
   });
 });

--- a/app/javascript/components/project-submissions/components/submission-title.jsx
+++ b/app/javascript/components/project-submissions/components/submission-title.jsx
@@ -6,7 +6,7 @@ const SubmissionTitle = ({ submission, isDashboardView, isCurrentUsersSubmission
     return <a href={submission.lesson_path}>{ submission.lesson_title }</a>;
   }
   if (isCurrentUsersSubmission) {
-    return <a href="/dashboard">{submission.user_name}</a>;
+    return <a href="/">{submission.user_name}</a>;
   }
   return submission.user_name;
 };

--- a/app/models/project_submission.rb
+++ b/app/models/project_submission.rb
@@ -17,7 +17,8 @@ class ProjectSubmission < ApplicationRecord
   validates :repo_url, presence: { message: 'Required' }
   validates :user_id, uniqueness: { scope: :lesson_id }
 
-  scope :viewable, -> { where(is_public: true, banned: false, discarded_at: nil) }
+  scope :only_public, -> { where(is_public: true) }
+  scope :not_removed_by_admin, -> { where(discarded_at: nil) }
   scope :created_today, -> { where('created_at >= ?', Time.zone.now.beginning_of_day) }
-  scope :discardable, -> { viewable.where('discard_at <= ?', Time.zone.now) }
+  scope :discardable, -> { not_removed_by_admin.where('discard_at <= ?', Time.zone.now) }
 end

--- a/app/queries/lesson_project_submissions_query.rb
+++ b/app/queries/lesson_project_submissions_query.rb
@@ -1,18 +1,26 @@
 class LessonProjectSubmissionsQuery
-  def initialize(lesson, limit: nil)
+  def initialize(lesson:, current_user:, limit: nil)
     @lesson = lesson
+    @current_user = current_user
     @limit = limit
   end
 
-  def with_current_user_submission_first(user)
+  def current_user_submission
+    return if current_user.nil?
+
+    current_user.project_submissions.not_removed_by_admin.find_by(lesson: lesson)
+  end
+
+  def public_submissions
     lesson.project_submissions
-          .where
-          .not(user_id: user&.id)
-          .viewable.order(cached_votes_total: :desc, created_at: :desc)
+          .only_public
+          .not_removed_by_admin
+          .where.not(user: current_user)
+          .order(cached_votes_total: :desc, created_at: :desc)
           .limit(limit)
   end
 
   private
 
-  attr_reader :lesson, :limit
+  attr_reader :lesson, :limit, :current_user
 end

--- a/app/serializers/project_submission_serializer.rb
+++ b/app/serializers/project_submission_serializer.rb
@@ -1,12 +1,12 @@
 class ProjectSubmissionSerializer
   include Rails.application.routes.url_helpers
 
-  def initialize(project_submission, current_user = nil)
-    @current_user = current_user
+  def initialize(project_submission, current_user)
     @project_submission = project_submission
+    @current_user = current_user
   end
 
-  def self.as_json(project_submission, current_user = nil)
+  def self.as_json(project_submission, current_user)
     new(project_submission, current_user).as_json
   end
 
@@ -24,20 +24,16 @@ class ProjectSubmissionSerializer
       lesson_path: path_course_lesson_path(lesson.course.path, lesson.course, lesson),
       lesson_has_live_preview: lesson.has_live_preview,
       likes: project_submission.votes_for.size,
-      is_liked_by_current_user: current_user_voted_for_project?
+      is_liked_by_current_user: current_user.voted_for?(project_submission),
     }
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   private
 
-  attr_reader :project_submission
+  attr_reader :project_submission, :current_user
 
   def lesson
     project_submission.lesson
-  end
-
-  def current_user_voted_for_project?
-    @current_user.voted_for?(project_submission) unless @current_user.nil?
   end
 end

--- a/app/services/admin/flags/ban_user.rb
+++ b/app/services/admin/flags/ban_user.rb
@@ -29,8 +29,11 @@ module Admin
       attr_reader :flag, :admin
 
       def update_flag_for_ban
-        flag.project_submission.update!(banned: true)
-        flag.project_submission.user.update!(banned: true)
+        user = flag.project_submission.user
+
+        user.project_submissions.each(&:discard)
+        user.update!(banned: true)
+
         flag.ban!
         flag.resolved!
         flag.update!(resolved_by_id: admin.id)

--- a/app/views/lessons/project_submissions/index.html.erb
+++ b/app/views/lessons/project_submissions/index.html.erb
@@ -10,7 +10,7 @@
             course: @lesson.course.as_json,
             lesson: @lesson.as_json,
             submissions: @project_submissions.map { |submission| ProjectSubmissionSerializer.as_json(submission, current_user) },
-            userSubmission: user_submission(current_user, @lesson)
+            userSubmission: @user_submission
           }
         ) %>
 

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -31,16 +31,18 @@
         <%= react_component(
           "project-submissions/index",
           {
-            userId: current_user&.id,
+            userId: current_user.id,
             course: @lesson.course.as_json,
             lesson: @lesson.as_json,
-            submissions: @project_submissions.map { |submission| ProjectSubmissionSerializer.as_json(submission, current_user) },
+            submissions: @project_submissions,
             allSubmissionsPath: lesson_project_submissions_path(@lesson.id),
-            userSubmission: user_submission(current_user, @lesson)
+            userSubmission: @user_submission
           }
         ) %>
       <% elsif @lesson.accepts_submission? %>
-          <p class="lesson-functions__call-to-login">Please <%= link_to 'Log In', login_path, class: 'lesson-functions__link' %> or <%= link_to 'Sign Up', sign_up_path, class: 'lesson-functions__link', data: {test_id: 'sign_up'} %> to view user submissions for this project!</p>
+          <p class="lesson-functions__call-to-login">
+            Please <%= link_to 'Log In', login_path, class: 'lesson-functions__link' %> or <%= link_to 'Sign Up', sign_up_path, class: 'lesson-functions__link', data: {test_id: 'sign_up'} %> to view user submissions for this project!
+          </p>
       <% end %>
 
       <div class="lesson-button-group">

--- a/db/migrate/20211229150146_remove_banned_from_project_submission.rb
+++ b/db/migrate/20211229150146_remove_banned_from_project_submission.rb
@@ -1,0 +1,5 @@
+class RemoveBannedFromProjectSubmission < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :project_submissions, :banned
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_24_201230) do
+ActiveRecord::Schema.define(version: 2021_12_29_150146) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -165,7 +165,6 @@ ActiveRecord::Schema.define(version: 2021_08_24_201230) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "is_public", default: true, null: false
-    t.boolean "banned", default: false, null: false
     t.integer "cached_votes_total", default: 0
     t.datetime "discarded_at"
     t.datetime "discard_at"

--- a/spec/helpers/lessons_helper_spec.rb
+++ b/spec/helpers/lessons_helper_spec.rb
@@ -10,46 +10,4 @@ RSpec.describe LessonsHelper do
       )
     end
   end
-
-  describe '#user_submission' do
-    let(:current_user) { create(:user) }
-    let(:lesson) { create(:lesson) }
-
-    context 'when the user has a project submission for the lesson' do
-      let!(:project_submission) { create(:project_submission, user: current_user, lesson: lesson) }
-
-      before do
-        allow(ProjectSubmissionSerializer).to receive(:as_json)
-      end
-
-      it 'returns the users submission in json format' do
-        helper.user_submission(current_user, lesson)
-        expect(ProjectSubmissionSerializer).to have_received(:as_json).with(project_submission, current_user)
-      end
-    end
-
-    context 'when the user is not logged in' do
-      let(:current_user) { nil }
-
-      it 'returns nil' do
-        expect(helper.user_submission(current_user, lesson)).to be_nil
-      end
-    end
-
-    context 'when the user does not have a project submission for the lesson' do
-      it 'returns nil' do
-        expect(helper.user_submission(current_user, lesson)).to be_nil
-      end
-    end
-
-    context 'when the user has had their submission soft deleted' do
-      let!(:soft_deleted_project_submission) do
-        create(:project_submission, user: current_user, lesson: lesson, discarded_at: Time.zone.today)
-      end
-
-      it 'returns nil' do
-        expect(helper.user_submission(current_user, lesson)).to be_nil
-      end
-    end
-  end
 end

--- a/spec/queries/lesson_project_submissions_query_spec.rb
+++ b/spec/queries/lesson_project_submissions_query_spec.rb
@@ -1,24 +1,43 @@
 require 'rails_helper'
 
 RSpec.describe LessonProjectSubmissionsQuery do
-  subject(:query) { described_class.new(lesson, limit: limit) }
+  subject(:query) { described_class.new(lesson: lesson, current_user: current_user, limit: limit) }
 
   let(:lesson) { create(:lesson) }
+  let(:current_user) { create(:user) }
   let(:limit) { nil }
 
-  describe '#with_current_user_submission_first' do
-    context 'when the current user is nil' do
-      let!(:project_submission_one) { create(:project_submission, lesson: lesson, created_at: 1.hour.ago) }
-      let!(:project_submission_two) { create(:project_submission, lesson: lesson, created_at: 2.hours.ago) }
+  describe '#current_user_submission' do
+    context 'when the current user is present and they have a submission' do
+      it 'returns the current users submission' do
+        current_user_submission = create(:project_submission, user: current_user, lesson: lesson)
 
-      it 'returns the lesson project submissions without the users submission at the top' do
-        expect(query.with_current_user_submission_first(nil)).to eq(
-          [
-            project_submission_one,
-            project_submission_two
-          ]
-        )
+        expect(query.current_user_submission).to eq(current_user_submission)
       end
+    end
+
+    context 'when the current user is present and they do not have a submission' do
+      it 'returns nil' do
+        expect(query.current_user_submission).to eq(nil)
+      end
+    end
+
+    context 'when the current user is not present' do
+      let(:current_user) { nil }
+
+      it 'returns nil' do
+        expect(query.current_user_submission).to eq(nil)
+      end
+    end
+  end
+
+  describe '#public_submissions' do
+    it 'returns any public project submissions that do not belong to the user for the lesson' do
+      project_submission_one = create(:project_submission, lesson: lesson, created_at: 1.hour.ago)
+      project_submission_two = create(:project_submission, lesson: lesson, created_at: 2.hours.ago)
+      create(:project_submission, lesson: lesson, created_at: 3.hours.ago, user: current_user)
+
+      expect(query.public_submissions).to eq([project_submission_one, project_submission_two])
     end
   end
 end

--- a/spec/serializers/project_submission_serializer_spec.rb
+++ b/spec/serializers/project_submission_serializer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ProjectSubmissionSerializer do
-  subject { described_class.as_json(project_submission) }
+  subject { described_class.as_json(project_submission, current_user) }
 
   let(:project_submission) do
     create(
@@ -14,6 +14,7 @@ RSpec.describe ProjectSubmissionSerializer do
       lesson: lesson
     )
   end
+  let(:current_user) { create(:user) }
 
   let(:user) { create(:user, id: 123, username: 'A USERNAME') }
   let(:path) { create(:path, title: 'A Path') }
@@ -35,7 +36,7 @@ RSpec.describe ProjectSubmissionSerializer do
         lesson_path: '/paths/a-path/courses/a-course/lessons/a-lesson-title',
         lesson_has_live_preview: true,
         likes: 0,
-        is_liked_by_current_user: nil
+        is_liked_by_current_user: false
       }
     end
 

--- a/spec/services/admin/flags/ban_user_spec.rb
+++ b/spec/services/admin/flags/ban_user_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Admin::Flags::BanUser do
 
   describe '#call' do
     it 'sets the flagged project submission to banned' do
-      expect { service }.to change { project_submission.banned }.from(false).to(true)
+      expect { service }.to change { project_submission.reload.discarded_at }.from(nil)
     end
 
     it 'sets the flagged project submissions owner to banned' do

--- a/spec/system/lesson_project_submissions/add_submission_spec.rb
+++ b/spec/system/lesson_project_submissions/add_submission_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe 'Add a Project Submission', type: :system do
         form.close
 
         within(:test_id, 'submissions-list') do
+          page.driver.refresh
           expect(page).to have_content(user.username)
         end
 


### PR DESCRIPTION
Because:
* We were only looking for the users public submissions when fetching the users submission for a lesson. When the submission was private it was treated like the user had not submitted a project for that lesson. This made the add project button appear, allowing users to add another project which caused a not unique exception on the project submissions table.

This commit:
* Fetches all of the users submissions including the private submissions when finding a submission for a lesson.
* Splits viewable scope into public_only and not_admin_removed scopes so we can use public_only on the submissions not belonging to the current user and not_admin_banned on both the users submission and all the rest - allowing more granular control of what we display.
* Refactor to use the LessonProjectSubmissionsQuery object for fetching the current users submission instead of using a helper.
* Removed banned attribute from project submission table since it should be discarded instead.
* Updates the submission title url to use `/` path as this is the path the dashboard is now on.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
