### PR TITLE
Chore: Fix View Component Engine Deprecation Warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem 'sentry-ruby', '~> 4.8.1'
 gem 'sidekiq'
 gem 'sprockets', '~> 4.0.2'
 gem 'uglifier', '~> 4.2'
-gem 'view_component', '~> 2.47', require: 'view_component/engine'
+gem 'view_component', '~> 2.47'
 gem 'webpacker'
 
 group :development, :test, :docker do


### PR DESCRIPTION
Because:
* This message was being displayed when starting the dev server:
DEPRECATION WARNING: This manually engine loading is deprecated and will be removed in v3.0.0. Remove `require "view_component/engine"`

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
