### PR TITLE
Move Ruby Debugging lesson before Enumerables

### DIFF
--- a/db/fixtures/paths/full_stack_rails/courses/1_ruby.rb
+++ b/db/fixtures/paths/full_stack_rails/courses/1_ruby.rb
@@ -38,10 +38,10 @@ course.add_section do |section|
     ruby_lessons.fetch('Arrays'),
     ruby_lessons.fetch('Hashes'),
     ruby_lessons.fetch('Methods'),
+    ruby_lessons.fetch('Debugging'),
     ruby_lessons.fetch('Basic Enumerable Methods'),
     ruby_lessons.fetch('Predicate Enumerable Methods'),
     ruby_lessons.fetch('Nested Collections'),
-    ruby_lessons.fetch('Debugging'),
   )
 end
 


### PR DESCRIPTION
#### Because:
* The Ruby Debugging Lesson needs to move before the Enumerables so that students are more equipped to debug their code as they work through the TDD exercises.

#### This commit
* Re-orders the db fixtures files so that the debugging lesson comes before Enumerables

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
