### PR TITLE
Change danger zone links width

### DIFF
--- a/app/assets/stylesheets/components/settings/delete_account.scss
+++ b/app/assets/stylesheets/components/settings/delete_account.scss
@@ -5,4 +5,5 @@
   text-align: left;
   text-decoration: underline;
   display: block;
+  width: fit-content;
 }


### PR DESCRIPTION
#### Because:

Danger zone links have full width across the card, making them clickable throughout. Desktop users can get feedback that links are clickable throughout the width because of the hover effect on cursor and links. Not obvious for mobile users.

![image](https://user-images.githubusercontent.com/85733202/148643526-7d816166-1520-4945-88df-cf83ca196770.png)


<!--
If your pull request resolves an open issue, please provide a link to it. For example: Resolves: https://github.com/TheOdinProject/theodinproject/issues/1886
Otherwise, please briefly explain why these changes were made, what problem does it solve?.
-->

#### This commit will

Set danger zone links' `width` property to `fit-content`
<!--
A bullet point list of one or more items outlining what was done in this pull request to solve the problem.
-->

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [ ] You have included automated tests for your changes where applicable?
