### PR TITLE
Update ruby on rails path description

### DIFF
--- a/db/fixtures/paths/full_stack_rails/seed.rb
+++ b/db/fixtures/paths/full_stack_rails/seed.rb
@@ -3,7 +3,7 @@
 # ***************************
 @path = Seeds::PathSeeder.create do |path|
   path.title = 'Full Stack Ruby on Rails'
-  path.description = "This path takes you through our entire Ruby on Rails curriculum. The courses should be taken in the order that they are displayed. You'll learn everything you need to know to create beautiful responsive websites from scratch."
+  path.description = "This path takes you through our entire Ruby on Rails curriculum. The courses should be taken in the order that they are displayed. You'll learn everything you need to know to create beautiful responsive websites from scratch using Ruby on Rails."
   path.identifier_uuid = '16109529-1526-4800-be11-0f655bcfb4cc'
   path.position = 2
 end


### PR DESCRIPTION
Add 'using Ruby on Rails' at the end of the description

Reason: 

- To bring parity between Fullstack JS and Fullstack RoR path descriptions. Fullstack JS path description ends with "using JavaScript and NodeJs"

<!--#### Because:-->
<!--
If your pull request resolves an open issue, please provide a link to it. For example: Resolves: https://github.com/TheOdinProject/theodinproject/issues/1886
Otherwise, please briefly explain why these changes were made, what problem does it solve?.
-->

<!--#### This commit-->
<!--
A bullet point list of one or more items outlining what was done in this pull request to solve the problem.
-->

#### Checklist
 - [X] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [ ] You have included automated tests for your changes where applicable?
