### PR TITLE
Feature: Enable Tailwind Base Directive

### DIFF
--- a/app/assets/stylesheets/components/dashboard/profile_card.scss
+++ b/app/assets/stylesheets/components/dashboard/profile_card.scss
@@ -9,19 +9,6 @@
     text-align: center;
   }
 
-  &__image {
-    width: 100px;
-    height: 100px;
-    background-color:#fff;
-    border-radius:50%;
-    margin-right: 2rem;
-
-    @include media-breakpoint-down(md) {
-      margin-right: 0;
-      margin-bottom: 1rem;
-    }
-  }
-
   &__username {
     margin-bottom: 0;
     flex-basis: 60%;

--- a/app/assets/stylesheets/components/home/hero.scss
+++ b/app/assets/stylesheets/components/home/hero.scss
@@ -6,11 +6,6 @@
     padding-bottom: 3.75rem;
   }
 
-  &__main-heading {
-    margin-bottom: 0;
-    padding-bottom: 1.875rem;
-  }
-
   &__sub-heading {
     padding-bottom: 4.375rem;
   }

--- a/app/assets/stylesheets/components/settings/settings_card.scss
+++ b/app/assets/stylesheets/components/settings/settings_card.scss
@@ -16,14 +16,6 @@
     padding-right: 40px;
     border-right: 1px solid $pale-grey;
 
-    img {
-      width:100px;
-      height:100px;
-      margin: 0 auto;
-      border-radius:50%;
-      overflow: hidden;
-    }
-
     @include media-breakpoint-down(sm) {
       margin-bottom: 50px;
       margin-right: 0;

--- a/app/assets/stylesheets/global.scss
+++ b/app/assets/stylesheets/global.scss
@@ -4,7 +4,6 @@ html {
 }
 
 body {
-  font-family: $body_fonts;
   padding-right: 0 !important; // a hacky fix to avoid 15px right padding added when a modal is displayed/hidden
   min-height: 100vh;
   display: flex;
@@ -37,7 +36,6 @@ p {
 
 button {
   border: 0;
-  font-family: $body-fonts;
   padding: 0;
 }
 
@@ -115,7 +113,6 @@ ul {
 [type="password"],
 textarea {
   background-color: $pale-grey-bg;
-  font-family: $body-fonts;
   padding: 0.7rem 1rem 0.7rem 1rem;
 }
 

--- a/app/assets/stylesheets/settings.scss
+++ b/app/assets/stylesheets/settings.scss
@@ -1,8 +1,4 @@
 // Typography
-@import url('https://fonts.googleapis.com/css?family=Open+Sans:300,400,700');
-
-$headline-fonts: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
-$body-fonts: $headline-fonts;
 $logo-font: "Norse";
 
 @font-face {

--- a/app/assets/stylesheets/typography.scss
+++ b/app/assets/stylesheets/typography.scss
@@ -1,8 +1,3 @@
-h1, h2, h3, h4, p {
-  color: $text-primary;
-  font-family: $headline-fonts;
-}
-
 h1 {
   font-size: 2.25rem;
   font-weight: 300;

--- a/app/javascript/layouts/application.css
+++ b/app/javascript/layouts/application.css
@@ -1,4 +1,6 @@
 /* turning off base styles for now as they overide heading sizes */
-/* @import "tailwindcss/base"; */
+@import "tailwindcss/base";
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
+
+@import './typography.css';

--- a/app/javascript/layouts/typography.css
+++ b/app/javascript/layouts/typography.css
@@ -1,0 +1,8 @@
+@layer components {
+  body {
+    font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  }
+  .page-heading-title {
+    @apply text-4xl mb-8 text-gold-500 font-light;
+  }
+}

--- a/app/views/courses/course/_banner.html.erb
+++ b/app/views/courses/course/_banner.html.erb
@@ -9,6 +9,6 @@
   </div>
 
   <%= link_to path_course_url(course.path, course), class: 'course-card-header__link' do %>
-    <h1 class="banner__title" data-test-id="course-title-header"><%= course.title %></h1>
+    <h1 class="banner__title text-4xl font-light" data-test-id="course-title-header"><%= course.title %></h1>
   <% end %>
 </div>

--- a/app/views/courses/course/_section-lessons.html.erb
+++ b/app/views/courses/course/_section-lessons.html.erb
@@ -2,7 +2,7 @@
   <% lessons.each_with_index do |lesson, lesson_index| %>
     <div class="section-lessons__item">
 
-      <%= link_to path_course_lesson_url(course.path, course, lesson), class: 'section-lessons__item__link' do %>
+      <%= link_to path_course_lesson_url(course.path, course, lesson), class: 'section-lessons__item__link tracking-wide' do %>
         <%= numbered_lesson_title(lesson, lesson_index).html_safe %>
       <% end %>
 

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -8,7 +8,7 @@
         <%= render 'courses/course/banner',course: @course %>
 
         <div class="course-description">
-          <h2 class="course-description__heading">Overview</h2>
+          <h2 class="course-description__heading text-2xl">Overview</h2>
           <p><%= @course.description %></p>
         </div>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -2,7 +2,7 @@
 
 <div class="gradient">
   <div class="container push-container-down">
-    <h1 class="text-center accent">Forgot your password?</h1>
+    <h1 class="text-center page-heading-title mx-auto">Forgot your password?</h1>
     <div class='col-lg-8 offset-lg-2'>
 
       <div class="card-main">

--- a/app/views/devise/registrations/_danger_zone.html.erb
+++ b/app/views/devise/registrations/_danger_zone.html.erb
@@ -1,7 +1,7 @@
 <div class="settings-section">
   <div class="settings-card card-main">
 
-    <h2 class="accent settings-card__heading">Danger Zone</h2>
+    <h2 class="accent settings-card__heading text-2xl">Danger Zone</h2>
 
     <div class="settings-card__content">
       <div class="settings-view">

--- a/app/views/devise/registrations/_learning_goal.html.erb
+++ b/app/views/devise/registrations/_learning_goal.html.erb
@@ -2,7 +2,7 @@
   <div class="settings-card card-main">
 
     <div class="settings-card__edit-button settings-card__edit-button--open" data-test-id="user-edit-learning-goal-btn"></div>
-    <h2 class="accent settings-card__heading">Learning Goal</h2>
+    <h2 class="accent settings-card__heading text-2xl">Learning Goal</h2>
 
     <div class="settings-card__content">
       <div class="settings-view">

--- a/app/views/devise/registrations/_password.html.erb
+++ b/app/views/devise/registrations/_password.html.erb
@@ -1,7 +1,7 @@
 <div class="settings-section">
   <div class="settings-card card-main">
 
-    <h2 class="accent settings-card__heading">Password</h2>
+    <h2 class="accent settings-card__heading text-2xl">Password</h2>
     <div class="settings-card__edit-button settings-card__edit-button--open"></div>
 
     <div class="settings-card__content">

--- a/app/views/devise/registrations/_profile.html.erb
+++ b/app/views/devise/registrations/_profile.html.erb
@@ -1,12 +1,12 @@
 <div class="settings-section">
   <div class="settings-card card-main">
 
-    <h2 class="accent settings-card__heading">Profile</h2>
+    <h2 class="accent settings-card__heading text-2xl">Profile</h2>
     <div class="settings-card__edit-button settings-card__edit-button--open" data-test-id="user-edit-profile-btn"></div>
 
     <div class="settings-card__content">
       <div class="settings-card__picture">
-        <%= image_tag avatar_path(user.avatar), alt: "Profile Picture"%>
+        <%= image_tag avatar_path(user.avatar), alt: "Profile Picture", class: "rounded-full w-32 mx-auto" %>
       </div>
 
       <div class="settings-view">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -2,7 +2,7 @@
 
 <div class="gradient pb-1">
   <div class="container">
-    <h1 class="text-center accent">Settings</h1>
+    <h1 class="text-center accent page-heading-title">Settings</h1>
     <div class='col-lg-10 offset-lg-1'>
 
       <%= render 'devise/registrations/profile', user: @user %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -3,7 +3,7 @@
 <div class="gradient">
   <div class="container">
     <div class="col-lg-6 col-md-10 offset-lg-3 offset-md-1">
-      <h1 class="text-center accent">Sign Up for Free</h1>
+      <h1 class="text-center accent page-heading-title mx-auto">Sign Up for Free</h1>
       <%= render 'form' %>
 
       <%= render 'shared/bottom_cta',

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -3,7 +3,7 @@
 <div class="gradient">
   <div class="container">
     <div class="col-lg-6 col-md-10 offset-lg-3 offset-md-1">
-      <h1 class="text-center accent">Login</h1>
+      <h1 class="text-center page-heading-title mx-auto">Login</h1>
         <%= render 'form' %>
 
         <%= render 'shared/bottom_cta',

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -4,7 +4,7 @@
       <%= render NotificationComponent.with_collection(@notifications) %>
     <% else %>
       <div class="text-center mx-auto">
-        <h3 class="text-lg leading-6 font-medium text-gray-900">No notifications yet</h3>
+        <h3 class="text-lg leading-6 font-medium text-gray-900 mb-2">No notifications yet</h3>
         <p>Why not take your next lesson while you wait?</p>
       </div>
     <% end %>

--- a/app/views/paths/index.html.erb
+++ b/app/views/paths/index.html.erb
@@ -2,15 +2,15 @@
 
 <div class="paths curriculum-background">
   <div class="container">
-    <h1 class="text-center camel card-list__title">All Paths</h1>
+    <h1 class="text-center page-heading-title mb-16">All Paths</h1>
     <% @paths.each do |path| %>
       <% if path.title === 'Foundations' %>
         <div class='card-main card-main--clickable'>
           <%= link_to '', path, class: 'card-main__link' %>
           <div class="card-main__header">
             <div>
-              <h2 class="foundations-title"><%= path.title %></h2>
-              <h2>Start here!</h2>
+              <h2 class="foundations-title mb-2"><%= path.title %></h2>
+              <h3 class="text-2xl">Start here!</h3>
             </div>
             <% if current_user.nil? %>
               <%= button_to 'View Path', path_url(path), method: :get, class: 'button button--secondary card-main__button' %>
@@ -40,7 +40,7 @@
           <div class='card-main card-main--clickable'>
             <%= link_to '', path, class: 'card-main__link' %>
             <div class="card-secondary__header">
-              <h2 class="card-secondary__header-title"><%= path.title %></h2>
+              <h2 class="card-secondary__header-title mb-3xl"><%= path.title %></h2>
               <% if current_user.nil? %>
                 <%= button_to 'View Path', path_url(path), method: :get, class: 'button button--secondary card-main__button' %>
               <% elsif current_user.path === path %>

--- a/app/views/paths/show.html.erb
+++ b/app/views/paths/show.html.erb
@@ -1,7 +1,7 @@
 <%= title(@path.title) %>
 
 <div class="container">
-  <h1 class="text-center camel light curriculum-title"><%= @path.title %></h1>
+  <h1 class="text-center page-heading-title"><%= @path.title %></h1>
   <% if user_signed_in? && current_user.path != @path %>
     <div class="select-container">
       <%= button_to 'Select Path', users_paths_path(path_id: @path.id), class: 'button button--secondary card-main__button', remote: false, method: :post, data: { disable_with: 'Selecting...', test_id: "#{@path.title.downcase}-select-path-btn" } %>

--- a/app/views/shared/_logo.html.erb
+++ b/app/views/shared/_logo.html.erb
@@ -1,4 +1,4 @@
 <%= link_to root_path, class: 'logo' do %>
-  <%= image_tag 'odin-logo.svg' , alt: "Odin Logo" , class: 'logo__img' %>
+  <%= image_tag 'odin-logo.svg' , alt: "Odin Logo" , class: 'logo__img inline' %>
   <div class="logo__text"> The Odin Project </div>
 <% end %>

--- a/app/views/shared/_user_dropdown.html.erb
+++ b/app/views/shared/_user_dropdown.html.erb
@@ -1,6 +1,6 @@
 <div class="odin-dropdown">
   <button class="odin-dropdown__toggle" aria-label='User Menu' data-odin-dropdown='toggle'>
-    <%= image_tag avatar_path(current_user.avatar), size: "30x30", class: 'avatar', alt: 'user avatar' %>
+    <%= image_tag avatar_path(current_user.avatar), size: "30x30", class: 'avatar inline', alt: 'user avatar' %>
   </button>
 
   <ul class="odin-dropdown__menu odin-dropdown__hidden">

--- a/app/views/static_pages/about.html.erb
+++ b/app/views/static_pages/about.html.erb
@@ -31,7 +31,7 @@
   <div id="about">
     <div class="container">
       <div class="page-intro">
-        <h1 class="page-intro__title">About The Odin Project</h1>
+        <h1 class="page-intro__title page-heading-title">About The Odin Project</h1>
         <p class="page-intro__text">
           The Odin Project is one of those "What I wish I had when I was learning" resources.  Not everyone has access to a computer science education or the funds to attend an intensive coding school and neither of those is right for everyone anyway.  This project is designed to fill in the gap for people who are trying to hack it on their own but still want a high quality education.
         </p>
@@ -39,7 +39,7 @@
 
       <div class="beliefs">
         <div class="col-lg-8 offset-lg-2">
-          <h2 class="bold text-center beliefs-heading">Our Beliefs</h2>
+          <h2 class="bold text-center beliefs-heading text-2xl">Our Beliefs</h2>
           <%= render partial: 'static_pages/about/belief', collection: beliefs, as: :belief %>
         </div>
       </div>
@@ -54,7 +54,7 @@
         </div>
 
         <div class="col-md-6 col-lg-5 contact-details">
-          <h2 class="contact-details__heading">Want to contact us?</h2>
+          <h2 class="contact-details__heading text-2xl">Want to contact us?</h2>
 
           <p class="contact-details__sub-heading">
             Connect with our friendly community on discord, a chat and networking platform or <a href="mailto:theodinprojectcontact@gmail.com">send us an email</a>.

--- a/app/views/static_pages/about/_belief.html.erb
+++ b/app/views/static_pages/about/_belief.html.erb
@@ -4,7 +4,7 @@
   </div>
 
   <div class="col-sm-10 belief-description">
-    <h3 class="belief-short-text">
+    <h3 class="belief-short-text text-xl">
       <strong>
         <%= belief[:short_text] %>
       </strong>

--- a/app/views/static_pages/about/_overview.html.erb
+++ b/app/views/static_pages/about/_overview.html.erb
@@ -1,6 +1,6 @@
 <section class="overview">
   <div class="container">
-    <h2 class="overview__heading accent">Overview of The Odin Project</h2>
+    <h2 class="overview__heading accent text-2xl">Overview of The Odin Project</h2>
 
     <div class="row">
 

--- a/app/views/static_pages/contributing.html.erb
+++ b/app/views/static_pages/contributing.html.erb
@@ -2,7 +2,7 @@
 
 <div class="container">
   <div class="page-intro">
-    <h1 class="page-intro__title">How to Contribute</h1>
+    <h1 class="page-intro__title page-heading-title">How to Contribute</h1>
     <p class="page-intro__text">
       The Odin Project is an Open Source project, built and maintained by volunteers who dedicate their time and skills to making The Odin Project one of the best free education platforms on the web. We are always working on projects to improve Odin and are always looking for people who want to join our growing team of maintainers.</a>
     </p>

--- a/app/views/static_pages/contributing/_benefits.html.erb
+++ b/app/views/static_pages/contributing/_benefits.html.erb
@@ -29,14 +29,14 @@
 
 <div class="benefits">
   <div class="container">
-    <h2 class="benefits__title">Why you should get involved</h2>
+    <h2 class="benefits__title text-2xl">Why you should get involved</h2>
     <div class="row">
       <% benefits.each do |benefit| %>
         <div class="col-lg-6 benefit">
           <%= image_tag benefit[:icon], alt: benefit[:alt_text], class: "benefit__image" %>
 
           <div class="benefit__details">
-            <h3 class="benefit__title"><%= benefit[:title] %></h3>
+            <h3 class="benefit__title text-xl"><%= benefit[:title] %></h3>
             <p class="benefit__text"><%= benefit[:body] %></p>
           </div>
         </div>

--- a/app/views/static_pages/contributing/_contributing_options.html.erb
+++ b/app/views/static_pages/contributing/_contributing_options.html.erb
@@ -14,14 +14,14 @@
 %>
 
 <div class='contributing-options'>
-  <h3 class="contributing-options__title push-down-2x">There are two main ways you can contribute:</h3>
+  <h3 class="contributing-options__title text-xl mb-4">There are two main ways you can contribute:</h3>
   <div class="col-lg-10 offset-lg-1 col-md-12">
     <div class="row row-eq-height">
 
       <% contributions.each do |contribution| %>
         <div class="col-lg-6">
           <div class="contributing-card card-main">
-            <h3 class="contributing-card__title"><%= contribution[:title] %></h3>
+            <h3 class="contributing-card__title text-xl mb-2"><%= contribution[:title] %></h3>
             <p class="contributing-card__description"><%= contribution[:description] %></p>
             <div class="contributing-card__button">
               <%= link_to 'View on GitHub', github_link(contribution[:path]), class: 'button button--primary', target: '_blank', rel: 'noreferrer' %>

--- a/app/views/static_pages/contributing/_hall_of_fame.erb
+++ b/app/views/static_pages/contributing/_hall_of_fame.erb
@@ -109,7 +109,7 @@
 %>
 
 <div class="hall-of-fame gradient">
-  <h2 class="hall-of-fame__title">Hall of Fame</h3>
+  <h2 class="hall-of-fame__title text-2xl">Hall of Fame</h3>
   <p class="hall-of-fame__text">
     The Hall of Fame members are the hardworking devs who have built The Odin Project into the site that you see before you now.
   </p>

--- a/app/views/static_pages/faq.html.erb
+++ b/app/views/static_pages/faq.html.erb
@@ -4,7 +4,7 @@
   <div class="container">
     <div class="row">
       <div class="col-md-10 offset-md-1">
-        <h1 class="text-center accent faq-title">Frequently Asked Questions</h1>
+        <h1 class="text-center page-heading-title mb-16">Frequently Asked Questions</h1>
         <%= render 'static_pages/faq/faq_accordion'%>
       </div>
     </div> <!-- /.row -->

--- a/app/views/static_pages/faq/_faq_card.html.erb
+++ b/app/views/static_pages/faq/_faq_card.html.erb
@@ -1,7 +1,7 @@
 <div class="card faq-card">
   <a role="button" data-toggle="collapse" data-parent="#faq-accordion" href="#faq-item-<%= index %>" aria-expanded="true" aria-controls="faq-item-<%= index %>">
     <div class="card-header faq-card-header" role="tab">
-      <h2 class="secondary bold faq-question-title">
+      <h2 class="secondary bold faq-question-title text-2xl">
         <%= faq_item[:question] %>
       </h2>
       <i class="fas fa-plus camel expander"></i>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -1,11 +1,11 @@
 <div id="home-page">
   <div class="hero gradient">
     <header>
-      <h1 class="accent hero__main-heading"> Your Career in Web Development Starts Here </h1>
+      <h1 class="text-4xl font-light text-gold-500 mx-auto pb-4"> Your Career in Web Development Starts Here </h1>
       <div class="secondary hero__sub-heading">
         <p class="push-down">Our full stack curriculum is free and supported by a passionate open source community.</p>
         <% if Lesson.any? %>
-          <%= link_to "Last Curriculum Update: #{time_ago_in_words(Lesson.most_recent_updated_at)} ago", github_link("curriculum/commits"), target: :_blank %>
+          <%= link_to "Last Curriculum Update: #{time_ago_in_words(Lesson.most_recent_updated_at)} ago", github_link("curriculum/commits"), target: :_blank, class: "tracking-wide underline" %>
         <% end %>
       </div>
 

--- a/app/views/static_pages/home/_curriculum.html.erb
+++ b/app/views/static_pages/home/_curriculum.html.erb
@@ -1,7 +1,7 @@
 <div class="curriculum-details bg-whitesmoke">
   <div class="curriculum-details-title">
-    <h2 class="bold">Learn everything you need to know to become a web developer</h2>
-  </div> <!-- /.curriculum-details-title -->
+    <h2 class="font-bold text-2xl">Learn everything you need to know to become a web developer</h2>
+  </div>
 
   <div class="container">
     <div class="row">
@@ -9,21 +9,21 @@
         <div class="row curriculum-details-grid">
 
           <% available_courses.each do |course| %>
-            <%= link_to course[:path], :class =>"curriculum-details-tile align-items-center" do %>  
+            <%= link_to course[:path], :class =>"curriculum-details-tile align-items-center" do %>
               <%= image_tag course[:badge_image_url], alt: course[:badge_alt_text] %>
-                <h4 class="bold text-uppercase">
+                <h4 class="font-bold uppercase text-lg">
                   <%= course[:title] %>
                 </h4>
-            <% end %>      
+            <% end %>
           <% end %>
-          
+
         </div>
       </div>
-    </div> <!-- /.row -->
+    </div>
 
     <div class="text-center">
       <%= link_to 'Get Started', courses_path,
         class: 'button button--secondary' %>
-    </div> <!-- /.row -->
-  </div> <!-- /.container -->
+    </div>
+  </div>
 </div>

--- a/app/views/static_pages/home/_how_it_works.html.erb
+++ b/app/views/static_pages/home/_how_it_works.html.erb
@@ -1,7 +1,7 @@
 <div class="how-it-works">
   <div class="how-it-works-title">
     <div class="container">
-      <h2 class="bold">How it works</h2>
+      <h2 class="text-2xl font-bold">How it works</h2>
       <p>This is the website we wish we had when we were learning on our own. We scour the internet looking for only the best resources to supplement your learning and present them in a logical order.</p>
     </div>
   </div> <!-- /.how-it-works-title -->
@@ -9,8 +9,8 @@
 
     <% how_it_works_tiles.each do |tile| %>
     <div class="tile">
-      <%= image_tag tile[:image], class: 'how-it-works-image', alt: 'how-it-works illustration' %>
-      <h4 class='bold subtitle'><%= tile[:subtitle]%></h4>
+      <%= image_tag tile[:image], class: 'how-it-works-image inline', alt: 'how-it-works illustration' %>
+      <h4 class='font-bold text-xl mt-8 mb-4'><%= tile[:subtitle]%></h4>
       <div class="description">
         <p><%= tile[:description]%></p>
       </div>

--- a/app/views/static_pages/home/_success_stories.html.erb
+++ b/app/views/static_pages/home/_success_stories.html.erb
@@ -1,6 +1,6 @@
 <div class="success-stories gradient">
   <div class="success-stories-title">
-    <h2 class="bold">Success Stories</h2>
+    <h2 class="font-bold text-2xl">Success Stories</h2>
   </div>
 
   <div class="success-stories-container">

--- a/app/views/static_pages/style_guide.html.erb
+++ b/app/views/static_pages/style_guide.html.erb
@@ -1,6 +1,6 @@
 <%= title('Style Guide') %>
 <div class='container'>
-  <h1 class='colors-heading accent'>Colors</h1>
+  <h2 class='accent page-heading-title mx-auto text-center'>Colors</h2>
   <div class='colors row'>
 
     <div class="col">
@@ -93,7 +93,7 @@
       </div>
     </div>
   </div>
-  <h1 class="accent text-center">Typography</h1>
+  <h2 class="text-center page-heading-title">Typography</h2>
   <p class="text-center mb-4">
     All of the text styling on the site can be accessed through using the correct tags and classnames, without writing custom css.  Using the following tags and classes will ensure that the styling stays consistent from page to page and will be easy to modify in the future.
   </p>

--- a/app/views/static_pages/success_stories.html.erb
+++ b/app/views/static_pages/success_stories.html.erb
@@ -4,7 +4,7 @@
   <div class="container">
     <div class="success-stories-page">
       <div class="success-stories-title-full">
-        <h1 class="text-center accent">Success Stories</h1>
+        <h1 class="text-center page-heading-title">Success Stories</h1>
       </div>
 
       <div class="row">

--- a/app/views/users/_project_submissions.html.erb
+++ b/app/views/users/_project_submissions.html.erb
@@ -1,5 +1,5 @@
 <div class="user-project-submissions">
-  <h2 class="user-project-submissions__title">Project Submissions</h2>
+  <h2 class="user-project-submissions__title text-2xl">Project Submissions</h2>
 
   <% if project_submissions.any? %>
     <%= react_component(
@@ -10,6 +10,6 @@
         }
     ) %>
   <% else %>
-    <h3 class="user-project-submissions__blank-slate-message">No submissions yet</h3>
+    <h3 class="user-project-submissions__blank-slate-message text-xl">No submissions yet</h3>
   <% end %>
 </div>

--- a/app/views/users/_skill.html.erb
+++ b/app/views/users/_skill.html.erb
@@ -10,7 +10,7 @@
 
   <div class="skill__details">
     <%= link_to path_course_url(course.path, course), class: 'skill__link' do %>
-      <h3 class="skill__title"><%= course.title %></h3>
+      <h3 class="skill__title text-xl"><%= course.title %></h3>
     <% end %>
     <span class="skill__sub-title"><%= course.lessons.size %> lessons</span>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,20 +2,17 @@
 
 <div class="container">
   <div class= 'col-lg-8 offset-lg-2'>
-    <h1 class="text-center camel">My Dashboard</h1>
+    <h1 class="text-center page-heading-title mx-auto">My Dashboard</h1>
 
     <div class="card-main profile-card">
-      <div>
-        <%= image_tag avatar_path(current_user.avatar), alt: "#{current_user.username}'s avatar", class: 'profile-card__image' %>
-      </div>
-
-      <h2 class="profile-card__username" data-test-id="profile_username"><%= current_user.username %></h2>
+      <%= image_tag avatar_path(current_user.avatar), alt: "#{current_user.username}'s avatar", class: 'rounded-full w-24' %>
+      <h2 class="profile-card__username text-2xl pl-4" data-test-id="profile_username"><%= current_user.username %></h2>
       <p class="profile-card__learning-goal" data-test-id='learning_goal'><%= display_dashboard_learning_goal(current_user).html_safe %></p>
     </div>
 
     <div class="skills">
       <div class="skills__header">
-        <h2 class="skills__title">Skills Progress</h2>
+        <h2 class="skills__title text-2xl">Skills Progress</h2>
         <p class="skills__content">
           The following courses should be taken in order.
         </p>

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "notyf": "^3.10.0",
     "popper.js": "^1.16.1",
     "postcss": "^7",
+    "postcss-import": "^12.0.1",
     "prismjs": "^1.25.0",
     "prop-types": "^15.8.1",
     "react": "^16.14.0",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,19 @@ module.exports = {
   theme: {
     extend: {
       colors: {
+        'gold': {
+          DEFAULT: '#CE973E',
+          '50': '#F3E6D0',
+          '100': '#EFDDC0',
+          '200': '#E7CCA0',
+          '300': '#DFBA7F',
+          '400': '#D6A95F',
+          '500': '#CE973E',
+          '600': '#A9792B',
+          '700': '#7C5920',
+          '800': '#503914',
+          '900': '#231909'
+        },
         'nav-link-read': 'rgba(74, 74, 74, 0.7)',
         'nav-link-unread': 'rgba(206, 151, 62, 0.7)',
         'notification': 'rgba(74, 74, 74, 0.7)',


### PR DESCRIPTION
Because:
* We need this enabled because borders do not work without it. However, it includes the Tailwind Preflight base styles which is effectively a CSS reset. This has affected our headings and some images, therefore those needed to be moved over to Tailwind styles as part of this PR.

This commit:
* Enables Tailwind base directive.
* Fixes the headings affected by the CSS reset.
* Fixes the images affected by the CSS reset.
* Adds the Odin gold brand colour to Tailwinds colour config.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
