### PR TITLE
Fix: Broken Course Badge on Mobile

### DIFF
--- a/app/assets/stylesheets/components/progress_circle.scss
+++ b/app/assets/stylesheets/components/progress_circle.scss
@@ -40,8 +40,8 @@ $back-color: #dddddd;
     top: 2px;
     left: 2px;
     @media (max-width: 991px){
-      top: -8px;
-      left: -8px;
+      top: 0px;
+      left: 0px;
     }
   }
 


### PR DESCRIPTION
Because:
* The course badge was positioned a little wrong for mobile.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
