### PR TITLE
Fix: lesson preview page styles

### DIFF
--- a/app/assets/stylesheets/components/lesson-preview.scss
+++ b/app/assets/stylesheets/components/lesson-preview.scss
@@ -1,8 +1,0 @@
-.lesson-preview {
-
-  &__input {
-    width: 100%;
-    height: 600px;
-    padding: 1rem;
-  }
-}

--- a/app/assets/stylesheets/components/lesson/lesson_preview.scss
+++ b/app/assets/stylesheets/components/lesson/lesson_preview.scss
@@ -3,5 +3,11 @@
     text-align: center;
     margin-bottom: 25px;
   }
+
+  &__input {
+    width: 100%;
+    height: 600px;
+    padding: 1rem;
+  }
 }
 

--- a/app/assets/stylesheets/components/lesson/lesson_preview.scss
+++ b/app/assets/stylesheets/components/lesson/lesson_preview.scss
@@ -1,8 +1,4 @@
 .lesson-preview {
-  &__title {
-    color: $primary;
-    text-align: center;
-  }
   &__detail {
     text-align: center;
     margin-bottom: 25px;

--- a/app/views/lessons/previews/show.html.erb
+++ b/app/views/lessons/previews/show.html.erb
@@ -11,7 +11,7 @@
 
     <div class="col-xl-6 col-lg-8">
       <div>
-        <h1 class="lesson-preview__title">Lesson Preview Tool</h1>
+        <h1 class="page-heading-title text-center mx-auto">Lesson Preview Tool</h1>
         <p class="lesson-preview__detail">Paste markdown contents here to check how they'll look on the website!</p>
         <%= react_component("lesson-preview/index", {}) %>
       </div>


### PR DESCRIPTION
#### Because:

- The heading of the page is small:

![image](https://user-images.githubusercontent.com/85733202/149653203-c5d3c4f6-4b8f-4803-86c7-8cfb971cd42e.png)

<!--
If your pull request resolves an open issue, please provide a link to it. For example: Resolves: https://github.com/TheOdinProject/theodinproject/issues/1886
Otherwise, please briefly explain why these changes were made, what problem does it solve?.
-->

#### Changes:

- Fixes the page heading
- [A recent pr](https://github.com/TheOdinProject/theodinproject/pull/2503) created a lesson_preview.scss file. This commit merges the old lesson-preview.scss into the new file
<!--
A bullet point list of one or more items outlining what was done in this pull request to solve the problem.
-->

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [ ] You have included automated tests for your changes where applicable?
