### PR TITLE
Fix: Lesson Side Navigation on Safari

### DIFF
--- a/app/javascript/src/js/lessons.js
+++ b/app/javascript/src/js/lessons.js
@@ -44,11 +44,12 @@ function getInnerText(heading) {
 }
 
 function isCommonHeading(heading) {
-  return LESSON_HEADINGS.indexOf(heading) > -1;
+  return LESSON_HEADINGS.includes(heading.trim());
 }
 
 function filterHeadings() {
   const lessonHeadings = getElements('.lesson-content h3');
+
   return Array.prototype.slice
     .call(lessonHeadings)
     .map(getInnerText)


### PR DESCRIPTION
Because:
* The heading content was including carriage returns, this prevented the common headings from being found.

This commit:
* Trim any carriage returns from the heading content when checking if it's a common heading.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
