### PR TITLE
Fix: headings don't align in center when screen width reduced

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -2,7 +2,7 @@
 
 <div class="gradient pb-1">
   <div class="container">
-    <h1 class="text-center accent page-heading-title">Settings</h1>
+    <h1 class="text-center accent page-heading-title mx-auto">Settings</h1>
     <div class='col-lg-10 offset-lg-1'>
 
       <%= render 'devise/registrations/profile', user: @user %>

--- a/app/views/static_pages/about.html.erb
+++ b/app/views/static_pages/about.html.erb
@@ -31,7 +31,7 @@
   <div id="about">
     <div class="container">
       <div class="page-intro">
-        <h1 class="page-intro__title page-heading-title">About The Odin Project</h1>
+        <h1 class="page-intro__title page-heading-title mx-auto">About The Odin Project</h1>
         <p class="page-intro__text">
           The Odin Project is one of those "What I wish I had when I was learning" resources.  Not everyone has access to a computer science education or the funds to attend an intensive coding school and neither of those is right for everyone anyway.  This project is designed to fill in the gap for people who are trying to hack it on their own but still want a high quality education.
         </p>

--- a/app/views/static_pages/contributing.html.erb
+++ b/app/views/static_pages/contributing.html.erb
@@ -2,7 +2,7 @@
 
 <div class="container">
   <div class="page-intro">
-    <h1 class="page-intro__title page-heading-title">How to Contribute</h1>
+    <h1 class="page-intro__title page-heading-title mx-auto">How to Contribute</h1>
     <p class="page-intro__text">
       The Odin Project is an Open Source project, built and maintained by volunteers who dedicate their time and skills to making The Odin Project one of the best free education platforms on the web. We are always working on projects to improve Odin and are always looking for people who want to join our growing team of maintainers.</a>
     </p>

--- a/app/views/static_pages/faq.html.erb
+++ b/app/views/static_pages/faq.html.erb
@@ -4,7 +4,7 @@
   <div class="container">
     <div class="row">
       <div class="col-md-10 offset-md-1">
-        <h1 class="text-center page-heading-title mb-16">Frequently Asked Questions</h1>
+        <h1 class="text-center page-heading-title mb-16 mx-auto">Frequently Asked Questions</h1>
         <%= render 'static_pages/faq/faq_accordion'%>
       </div>
     </div> <!-- /.row -->

--- a/app/views/static_pages/success_stories.html.erb
+++ b/app/views/static_pages/success_stories.html.erb
@@ -4,7 +4,7 @@
   <div class="container">
     <div class="success-stories-page">
       <div class="success-stories-title-full">
-        <h1 class="text-center page-heading-title">Success Stories</h1>
+        <h1 class="text-center page-heading-title mx-auto">Success Stories</h1>
       </div>
 
       <div class="row">


### PR DESCRIPTION
#### Because:

- Headings don't align in center when screen width reduced
<!--
If your pull request resolves an open issue, please provide a link to it. For example: Resolves: https://github.com/TheOdinProject/theodinproject/issues/1886
Otherwise, please briefly explain why these changes were made, what problem does it solve?.
-->

#### This commit will

 - Add mx-auto class to affected headings
<!--
A bullet point list of one or more items outlining what was done in this pull request to solve the problem.
-->

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [ ] You have included automated tests for your changes where applicable?
