### PR TITLE
Fix: Tailwind Logo Text Classes being Purged

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -28,6 +28,7 @@ module.exports = {
     content: [
       "./app/**/*.html.erb",
       "./app/components/*.html.erb",
+      "./app/components/*.rb",
       "app/assets/images/icons/*svg"
     ],
   },


### PR DESCRIPTION
Because:
* Tailwind does not check within view component objects for classes to ignore during the purge.

This commit:
* Adds the view component ruby files to the paths Tailwind should inspect before purging unused classes.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
