### PR TITLE
Fix: Home Page Hero Section in Dark Mode

### DIFF
--- a/app/assets/stylesheets/dark-mode.css
+++ b/app/assets/stylesheets/dark-mode.css
@@ -42,7 +42,8 @@ body,
 
 .curriculum-details-tile,
 .odin-dark-mobile-menu,
-.odin-dark-nav-item {
+.odin-dark-nav-item,
+.hero {
   background-color: var(--dark-bg-color) !important;
 }
 


### PR DESCRIPTION
Because:
* It was using the bg accent dark colour which did not blend correctly with the navbar.

This commit:
* Change the hero section to use the main dark mode background colour instead of the accent colour.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
