### PR TITLE
Fix: Profile dropdown hidden behind flash messages

### DIFF
--- a/app/components/user/profile_dropdown_component.html.erb
+++ b/app/components/user/profile_dropdown_component.html.erb
@@ -14,7 +14,7 @@
     data-transition-leave="transition ease-in duration-75"
     data-transition-leave-start="transform opacity-100 scale-100"
     data-transition-leave-end="transform opacity-10 scale-95"
-    class="odin-dark-dropdown-menu hidden origin-top-right absolute right-0 mt-2 w-48 rounded-md shadow-lg py-1 bg-white ring-1 ring-black ring-opacity-5 focus:outline-none"
+    class="odin-dark-dropdown-menu hidden origin-top-right absolute right-0 mt-2 w-48 rounded-md shadow-lg py-1 bg-white ring-1 ring-black ring-opacity-5 focus:outline-none z-50"
     role="menu"
     aria-orientation="vertical"
     aria-labelledby="user-menu-button"


### PR DESCRIPTION
Because:
* When flash messages are present and the user opens their profile dropdown, the flash message will overlay the dropdown.

This commit:
* Increases the z-index of the profile dropdown menu.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [ ] You have included automated tests for your changes where applicable?
