### PR TITLE
Fix grammar in Ruby Git section

### DIFF
--- a/db/fixtures/paths/full_stack_rails/courses/ruby.rb
+++ b/db/fixtures/paths/full_stack_rails/courses/ruby.rb
@@ -141,11 +141,11 @@ course.add_section do |section|
 end
 
 # +++++++++++++
-# SECTION - GIT
+# SECTION - Intermediate Git
 # +++++++++++++
 course.add_section do |section|
-  section.title = 'GIT'
-  section.description = "You should be familiar with the basic Git workflow since you've been using it to save your projects along the way (right?!). This section will start preparing you for for the more intermediate-level uses of Git that you'll find yourself doing."
+  section.title = 'Intermediate Git'
+  section.description = "You should be familiar with the basic Git workflow since you've been using it to save your projects along the way (right?!). This section will start preparing you for the more intermediate-level uses of Git that you'll find yourself doing."
   section.identifier_uuid = '4e059547-a8fd-426d-b546-24c2222106c6'
 
   section.add_lessons(


### PR DESCRIPTION
My original motivation for this was just to fix the capitalisation of
Git, but I noticed and fixed the 'for for' typo while I was here,
and figured the title could be slightly more descriptive too

#### Because:
There were grammar errors

#### This commit
Fixes capitalisation, removes an extra word and makes the title more descriptive

#### Checklist
 - [ x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [ x] You have verified the tests and linters all pass against your changes?
 - [ x] You have included automated tests for your changes where applicable?
