### PR TITLE
Fix: Lesson Content Ordered List Style

### DIFF
--- a/app/assets/stylesheets/components/lesson/lesson_content.scss
+++ b/app/assets/stylesheets/components/lesson/lesson_content.scss
@@ -69,7 +69,9 @@
   }
 
   ol {
-    list-style: decimal;
+    li {
+      list-style-type: decimal;
+    }
   }
 
   img {


### PR DESCRIPTION
Because:
* Ordered lists were displayed as bullet lists instead.

This commit:
* Explicitly set order list items to use decimals.


#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
