### PR TITLE
Feature: Autofocus on the  user name field when visiting sign up page

### DIFF
--- a/app/views/devise/registrations/_form.html.erb
+++ b/app/views/devise/registrations/_form.html.erb
@@ -3,7 +3,7 @@
 
     <div class="form__section">
       <span class="fas fa-user form__icon"></span>
-      <%= form.text_field :username, required: true, placeholder: 'Username', class: 'form__element form__element--with-icon', data: {test_id: 'username_field'} %>
+      <%= form.text_field :username, required: true, autofocus: true, placeholder: 'Username', class: 'form__element form__element--with-icon', data: {test_id: 'username_field'} %>
     </div>
     <% if resource.errors[:username].present? %>
       <div class="form__error-message push-down user_username"> <%=resource.errors[:username].first %></div>


### PR DESCRIPTION
Because:
* The user should have their cursor automatically focused on the first input for ease of use.

This commit:
* Adds an autofocus attribute to the username text field on the sign up form.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
