### PR TITLE
Feature: Allow lessons to be marked as installation lessons

### DIFF
--- a/app/controllers/lessons/installation_lessons_controller.rb
+++ b/app/controllers/lessons/installation_lessons_controller.rb
@@ -1,0 +1,7 @@
+module Lessons
+  class InstallationLessonsController < ApplicationController
+    def index
+      @lessons = Lesson.installation_lessons
+    end
+  end
+end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -11,6 +11,7 @@ class Lesson < ApplicationRecord
   has_many :completing_users, through: :lesson_completions, source: :user
 
   scope :most_recent_updated_at, -> { maximum(:updated_at) }
+  scope :installation_lessons, -> { where(installation_lesson: true) }
 
   validates :position, presence: true
 

--- a/app/views/lessons/installation_lessons/index.html.erb
+++ b/app/views/lessons/installation_lessons/index.html.erb
@@ -1,0 +1,9 @@
+<div class="container h-full">
+  <h1 class="page-heading-title">Installation Lessons Appendix</h1>
+
+  <ul>
+    <% @lessons.each do |lesson|%>
+     <li><%= link_to lesson.title, path_course_lesson_path(lesson.path, lesson.course, lesson) %></li>
+    <% end %>
+  </ul>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,7 @@ Rails.application.routes.draw do
 
   namespace :lessons do
     resource :preview, only: %i[show create]
+    resources :installation_lessons, only: %i[index]
   end
 
   namespace :courses do

--- a/db/fixtures/lessons/foundation_lessons.rb
+++ b/db/fixtures/lessons/foundation_lessons.rb
@@ -48,6 +48,7 @@ def foundation_lessons
       is_project: false,
       url: '/foundations/installations/installation_overview.md',
       identifier_uuid: 'ef45c208-6ebf-4fff-ba92-1d7584d3a9f2',
+      installation_lesson: true,
     },
     'Prerequisites' => {
       title: 'Prerequisites',
@@ -55,6 +56,7 @@ def foundation_lessons
       is_project: false,
       url: '/foundations/installations/prerequisites.md',
       identifier_uuid: '93dbf0e1-3c06-46a8-8640-1d537e2e723b',
+      installation_lesson: true,
     },
     'Text Editors' => {
       title: 'Text Editors',
@@ -62,6 +64,7 @@ def foundation_lessons
       is_project: false,
       url: '/foundations/installations/text_editors.md',
       identifier_uuid: 'e65a3229-f1a2-4589-ba7f-c114d8e0c645',
+      installation_lesson: true,
     },
     'Command Line Basics' => {
       title: 'Command Line Basics',

--- a/db/migrate/20220129182526_add_installation_lesson_column_to_lessons.rb
+++ b/db/migrate/20220129182526_add_installation_lesson_column_to_lessons.rb
@@ -1,0 +1,7 @@
+class AddInstallationLessonColumnToLessons < ActiveRecord::Migration[6.1]
+  def change
+    add_column :lessons, :installation_lesson, :boolean, default: false
+
+    add_index :lessons, :installation_lesson
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_29_150146) do
+ActiveRecord::Schema.define(version: 2022_01_29_182526) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -106,8 +106,10 @@ ActiveRecord::Schema.define(version: 2021_12_29_150146) do
     t.boolean "choose_path_lesson", default: false, null: false
     t.string "identifier_uuid", default: "", null: false
     t.bigint "course_id"
+    t.boolean "installation_lesson", default: false
     t.index ["course_id"], name: "index_lessons_on_course_id"
     t.index ["identifier_uuid", "course_id"], name: "index_lessons_on_identifier_uuid_and_course_id", unique: true
+    t.index ["installation_lesson"], name: "index_lessons_on_installation_lesson"
     t.index ["position"], name: "index_lessons_on_position"
     t.index ["slug", "section_id"], name: "index_lessons_on_slug_and_section_id", unique: true
     t.index ["url"], name: "index_lessons_on_url"

--- a/lib/seeds/lesson_seeder.rb
+++ b/lib/seeds/lesson_seeder.rb
@@ -24,6 +24,7 @@ module Seeds
         lesson.position = position
         lesson.course_id = section.course_id
         lesson.choose_path_lesson = attributes.fetch(:choose_path_lesson, false)
+        lesson.installation_lesson = attributes.fetch(:installation_lesson, false)
       end
     end
     # rubocop: enable Metrics/AbcSize, Metrics/MethodLength

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -29,6 +29,18 @@ RSpec.describe Lesson do
     end
   end
 
+  describe '.installation_lessons' do
+    it 'returns all the installation lessons' do
+      installation_lesson_one = create(:lesson, installation_lesson: true)
+      installation_lesson_two = create(:lesson, installation_lesson: true)
+      create(:lesson, installation_lesson: false)
+
+      expect(described_class.installation_lessons).to contain_exactly(
+        installation_lesson_one, installation_lesson_two
+      )
+    end
+  end
+
   describe '#position_in_section' do
     let(:section) { create(:section) }
     let(:first_lesson) { create(:lesson, position: 1, section: section) }


### PR DESCRIPTION
Because:
* We want to create an appendix of installation lessons.

This commit:
* Adds installation_lessons column to the lessons table.
* Adds scope to fetch all lessons marked as installation lessons.
* Adds route, controller and index view boilerplate.
* Marks a couple of lessons in foundations as installation_lessons to test everything is hooked up correctly.

Resolves: https://github.com/TheOdinProject/theodinproject/issues/2580#issue-1118301881

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
