### PR TITLE
Chore: Only validate live preview is allowed if it is present

### DIFF
--- a/app/models/project_submission.rb
+++ b/app/models/project_submission.rb
@@ -26,6 +26,8 @@ class ProjectSubmission < ApplicationRecord
   private
 
   def live_preview_allowed
+    return if live_preview_url.blank?
+
     unless lesson && lesson.has_live_preview?
       errors.add(:live_preview_url, 'Live preview is not allowed for this project')
     end


### PR DESCRIPTION
Because:
* This validation only needs to run when the live preview is present.

This commit:
* Add guard clause to validation to return if the live preview is blank.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
