### PR TITLE
Added missing project submissions in intermediate and advanced HTML/CSS

### DIFF
--- a/db/fixtures/lessons/html_and_css_lessons.rb
+++ b/db/fixtures/lessons/html_and_css_lessons.rb
@@ -392,6 +392,8 @@ def html_and_css_lessons
       title: 'Sign-up Form',
       description: 'Learn about how browsers style your HTML.',
       is_project: true,
+      accepts_submission: true,
+      has_live_preview: true,
       url: '/html_css/project-sign-up-form/project-sign-up-form.md',
       identifier_uuid: '91ab41f2-9c9d-449a-8461-329a5f7ecb1e'
     },
@@ -457,6 +459,8 @@ def html_and_css_lessons
       title: 'Admin Dashboard',
       description: "Use what you've learned to Complete this project",
       is_project: true,
+      accepts_submission: true,
+      has_live_preview: true,
       url: 'html_css/grid-lessons/project-dashboard/project-dashboard.md',
       identifier_uuid: 'c35f0b7b-4d21-4d26-91e2-4af78519ae5f'
     },
@@ -493,6 +497,8 @@ def html_and_css_lessons
       title: 'Personal Portfolio',
       description: 'Create a fully responsive personal portfolio.',
       is_project: true,
+      accepts_submission: true,
+      has_live_preview: true,
       url: '/html_css/project_portfolio/project-portfolio.md',
       identifier_uuid: 'd99b0c9d-cc6c-44e6-bab0-1c9a83edcfa3'
     },


### PR DESCRIPTION
#### Because:
Resolves #2600 

<!--
If your pull request resolves an open issue, please provide a link to it. For example: Resolves: https://github.com/TheOdinProject/theodinproject/issues/1886
Otherwise, please briefly explain why these changes were made, what problem does it solve?.
-->

#### This commit
- Added `accepts_submission` and  `has_live_preview` booleans in the lessons within the db directory.
- The booleans were added to 3 projects, Sign-up Form and Admin Dashboard within the intermediate section and Personal Portfolio within the advanced section.
- How the project pages looked before:
<img width="1237" alt="Screen Shot 2022-02-04 at 8 54 37 AM" src="https://user-images.githubusercontent.com/64395142/152467239-5941a87c-8b1a-4eea-82fc-f4c7e6915285.png">
- How the project pages looks with this PR:
<img width="1217" alt="Screen Shot 2022-02-04 at 9 07 29 AM" src="https://user-images.githubusercontent.com/64395142/152467259-deef5ea2-9eca-4b8f-aabc-17f1a48f5c4a.png">

<!--
A bullet point list of one or more items outlining what was done in this pull request to solve the problem.
-->

#### Checklist
 - [X] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [X] You have verified the tests and linters all pass against your changes?
 - [X] You have included automated tests for your changes where applicable?
