### PR TITLE
Fix: project submissions renders 'no submissions' message when the current user's submission is the only submission

### DIFF
--- a/app/javascript/components/project-submissions/components/__tests__/submissions-list.test.jsx
+++ b/app/javascript/components/project-submissions/components/__tests__/submissions-list.test.jsx
@@ -46,7 +46,7 @@ describe('submissions list', () => {
       expect(screen.queryAllByTestId('submission')[2].textContent).toBe('baz');
     });
 
-    it('does not render any submissions when array is empty, an instead renders a no submissions message', () => {
+    it('does not render any submissions when array is empty and user submission not provided, and instead renders a no submissions message', () => {
       render(
         <ProjectSubmissionContext.Provider value={{ allSubmissionsPath: '#' }}>
           <SubmissionsList
@@ -98,6 +98,25 @@ describe('submissions list', () => {
       expect(screen.queryAllByTestId('submission').length).toBe(3);
       expect(screen.queryByText('foobar')).not.toBeInTheDocument();
     });
+
+    it('does not render no submissions message when array is empty but user submission is provided', () => {
+      render(
+        <ProjectSubmissionContext.Provider value={{ allSubmissionsPath: '#' }}>
+          <SubmissionsList
+            submissions={[]}
+            userSubmission={userSubmission}
+            handleDelete={handleDelete}
+            handleUpdate={handleUpdate}
+            handleLikeToggle={handleLikeToggle}
+          />
+        </ProjectSubmissionContext.Provider>,
+      );
+
+      expect(screen.getByText('foobar')).toBeInTheDocument();
+      expect(
+        screen.queryByText('No Submissions yet, be the first!'),
+      ).not.toBeInTheDocument();
+    })
   });
 
   describe('context', () => {

--- a/app/javascript/components/project-submissions/components/submissions-list.jsx
+++ b/app/javascript/components/project-submissions/components/submissions-list.jsx
@@ -19,7 +19,7 @@ const SubmissionsList = ({
   userSubmission,
 }) => {
   const { allSubmissionsPath } = useContext(ProjectSubmissionContext);
-  const hasSubmissions = submissions.length > 0;
+  const hasSubmissions = submissions.length > 0 || Boolean(userSubmission);
 
   return (
     <div data-test-id="submissions-list">


### PR DESCRIPTION
#### Because:

- `submissions-list.jsx` component renders this message: "No Submissions yet, be the first!" even when there are no `submissions` but there exists a `userSubmission`
<!--
If your pull request resolves an open issue, please provide a link to it. For example: Resolves: https://github.com/TheOdinProject/theodinproject/issues/1886
Otherwise, please briefly explain why these changes were made, what problem does it solve?.
-->

#### This commit will

- have the `hasSubmissions` variable inside the component account for the `userSubmission`
- add a test case to verify the expected behavior
<!--
A bullet point list of one or more items outlining what was done in this pull request to solve the problem.
-->

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
