### PR TITLE
Adds hover effect to course tiles on home page.

### DIFF
--- a/app/assets/stylesheets/components/home/curriculum_details.scss
+++ b/app/assets/stylesheets/components/home/curriculum_details.scss
@@ -33,6 +33,11 @@
       text-align: center;
       width: 254px;
       text-decoration: none;
+      transition: .1s ease-out;
+
+      &:hover {
+        @include box-shadow(0 10px 22px 0 rgba(0, 0, 0, 0.5));
+      }
 
       img {
         height: 160px;

--- a/app/assets/stylesheets/dark-mode.css
+++ b/app/assets/stylesheets/dark-mode.css
@@ -49,6 +49,11 @@ body,
   background-color: var(--dark-bg-color) !important;
 }
 
+.curriculum-details-tile:hover {
+  box-shadow: 0 10px 22px 0 rgba(100, 100, 100, 0.3) !important;
+  -webkit-box-shadow: 0 10px 22px 0 rgba(100, 100, 100, 0.3) !important;
+}
+
 h1,
 h2,
 h2.bold,


### PR DESCRIPTION
#### Because:
Resolves Issue #2343 

#### This commit
Adds box-shadow CSS for the .curriculum-details-tile class on hover. Screenshot examples are documented in the issue of both light and dark mode versions.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
