### PR TITLE
Skip the pipeline when rendering the user avatar

### DIFF
--- a/spec/components/user/avatar_component_spec.rb
+++ b/spec/components/user/avatar_component_spec.rb
@@ -3,12 +3,12 @@ require 'rails_helper'
 RSpec.describe User::AvatarComponent, type: :component do
   context 'when the user has an avatar' do
     it 'renders the users avatar' do
-      user = create(:user, avatar: 'avatar.png')
+      user = create(:user, avatar: 'http://github/avatar.png')
       component = described_class.new(current_user: user, classes: 'w-12')
 
       render_inline(component)
 
-      expect(rendered_component).to have_css("img[src*='avatar.png']")
+      expect(rendered_component).to have_selector("img[src*='http://github/avatar.png']")
     end
   end
 


### PR DESCRIPTION
#### Because:
The user_avatar component spec tests were trying to look up, in the asset pipeline, the dummy 'avatar.png' used in the test

#### This commit
  - Makes the user avatar name in the test a full url to illustrate where the avatar is expected to come from.
  - Changes the test from have_css to have_selector as it is an element being matched and not any css

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?

Closes #2574