### PR TITLE
Fix: CSS sometimes not loading

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,18 +17,18 @@
     <link rel="manifest" href="/manifest.json">
     <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
 
-    <%= stylesheet_link_tag 'application_stylesheet', media: 'all'  %>
-    <%= stylesheet_pack_tag 'application' %>
-
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,300;1,400;1,500;1,600;1,700;1,800&display=swap" rel="stylesheet">
 
+    <%= stylesheet_link_tag 'application_stylesheet', media: 'all'  %>
     <%= stylesheet_pack_tag 'application' %>
-    <%= javascript_pack_tag 'application' %>
+
     <% if cookies[:theme] == "dark" %>
       <%= stylesheet_link_tag 'dark-mode', media: 'all' %>
     <% end %>
+
+    <%= javascript_pack_tag 'application', defer: true %>
   </head>
 
   <body class="line-numbers h-full">


### PR DESCRIPTION
Because:
* Some users are reporting the site is unstyled when opening it in a new browser session.

This commit:
* Load fonts first.
* Load dark mode after the asset pipeline and tailwind.
* Defer loading JS until the page is parsed in the browser.

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
