### PR TITLE
Split rails backend lesson to serve them depending on the path

### DIFF
--- a/db/fixtures/lessons/javascript_lessons.rb
+++ b/db/fixtures/lessons/javascript_lessons.rb
@@ -200,7 +200,7 @@ def javascript_lessons
       title: "Where's Waldo (A Photo Tagging App)",
       description: "Pull together everything you've learned so far to create a \"Where's Waldo?\" game.",
       is_project: true,
-      url: '/javascript/js-rails/project_rails_backend.md',
+      url: '/javascript/js-and-the-backend/project_rails_backend.md',
       accepts_submission: true,
       has_live_preview: true,
       identifier_uuid: '386dd44a-31dc-45dc-a535-cd5508365c86',

--- a/db/fixtures/lessons/javascript_lessons.rb
+++ b/db/fixtures/lessons/javascript_lessons.rb
@@ -196,13 +196,6 @@ def javascript_lessons
       has_live_preview: true,
       identifier_uuid: '62702165-7705-47ba-a308-dd39c561e057',
     },
-    'Using Ruby on Rails or BaaS For Your Back End' => {
-      title: 'Using Ruby on Rails or BaaS For Your Back End',
-      description: "You've got experience working with APIs, now it's time to treat your app like one.",
-      is_project: false,
-      url: '/javascript/js-rails/rails_backend.md',
-      identifier_uuid: '80eda4a3-02c9-489f-acef-bea2ba628e09',
-    },
     "Where's Waldo (A Photo Tagging App)" => {
       title: "Where's Waldo (A Photo Tagging App)",
       description: "Pull together everything you've learned so far to create a \"Where's Waldo?\" game.",
@@ -227,6 +220,20 @@ def javascript_lessons
       is_project: false,
       url: '/javascript/finishing-up/conclusion.md',
       identifier_uuid: '4b881c82-4cba-4090-a819-17aac12ccb46',
-    }
+    },
+    'Using Ruby on Rails For Your Back End' => {
+      title: 'Using Ruby on Rails For Your Back End',
+      description: "You've got experience working with APIs, now it's time to treat your app like one.",
+      is_project: false,
+      url: '/javascript/js-and-the-backend/rails_backend.md',
+      identifier_uuid: 'a7c364d4-c890-4b56-be03-f1091d56ded6',
+    },
+    'Using BaaS For Your Back End' => {
+      title: 'Using BaaS For Your Back End',
+      description: "You've got experience working with APIs, now it's time to treat your app like one.",
+      is_project: false,
+      url: '/javascript/js-and-the-backend/backend_as_a_service.md',
+      identifier_uuid: '754d54ae-c5b8-423a-8d1e-a9e0f192afcc',
+    },
   }
 end

--- a/db/fixtures/paths/full_stack_javascript/courses/javascript.rb
+++ b/db/fixtures/paths/full_stack_javascript/courses/javascript.rb
@@ -124,7 +124,7 @@ course.add_section do |section|
   section.identifier_uuid = 'f9b2f981-7f7e-4058-9053-03fe199cc06c'
 
   section.add_lessons(
-    javascript_lessons.fetch('Using Ruby on Rails or BaaS For Your Back End'),
+    javascript_lessons.fetch('Using BaaS For Your Back End'),
     javascript_lessons.fetch("Where's Waldo (A Photo Tagging App)"),
   )
 end

--- a/db/fixtures/paths/full_stack_javascript/courses/javascript.rb
+++ b/db/fixtures/paths/full_stack_javascript/courses/javascript.rb
@@ -120,7 +120,7 @@ end
 # ++++++++++++++++++++++++++++++++++++
 course.add_section do |section|
   section.title = 'JavaScript and the Backend'
-  section.description = "A real web app needs a back end in order to persist its data and do sensitive operations. Here you'll learn how to use ajax to send data requests to your Rails back end or how to outsource your backend to a Backend-as-a-Service company like Firebase."
+  section.description = "A real web app needs a back end in order to persist its data and do sensitive operations. Here you'll learn how to outsource your backend to a Backend-as-a-Service company like Firebase."
   section.identifier_uuid = 'f9b2f981-7f7e-4058-9053-03fe199cc06c'
 
   section.add_lessons(

--- a/db/fixtures/paths/full_stack_rails/courses/javascript.rb
+++ b/db/fixtures/paths/full_stack_rails/courses/javascript.rb
@@ -120,7 +120,7 @@ end
 # ++++++++++++++++++++++++++++++++++++
 course.add_section do |section|
   section.title = 'JavaScript and the Backend'
-  section.description = "A real web app needs a back end in order to persist its data and do sensitive operations. Here you'll learn how to use ajax to send data requests to your Rails back end or how to outsource your backend to a Backend-as-a-Service company like Firebase."
+  section.description = "A real web app needs a back end in order to persist its data and do sensitive operations. Here you'll learn how to use ajax to send data requests to your Rails back end."
   section.identifier_uuid = '490be3db-7c28-43d8-a530-328a0ba8188b'
 
   section.add_lessons(

--- a/db/fixtures/paths/full_stack_rails/courses/javascript.rb
+++ b/db/fixtures/paths/full_stack_rails/courses/javascript.rb
@@ -124,7 +124,7 @@ course.add_section do |section|
   section.identifier_uuid = '490be3db-7c28-43d8-a530-328a0ba8188b'
 
   section.add_lessons(
-    javascript_lessons.fetch('Using Ruby on Rails or BaaS For Your Back End'),
+    javascript_lessons.fetch('Using Ruby on Rails For Your Back End'),
     javascript_lessons.fetch("Where's Waldo (A Photo Tagging App)"),
   )
 end


### PR DESCRIPTION
#### Because:
<!--
If your pull request resolves an open issue, please provide a link to it. For example: Resolves: https://github.com/TheOdinProject/theodinproject/issues/1886
Otherwise, please briefly explain why these changes were made, what problem does it solve?.
-->
It's has been decided that the rails backend lesson needs to be split into two lessons and displayed depending on the path.

Relevant PR: https://github.com/TheOdinProject/curriculum/pull/23607
#### This commit
<!--
A bullet point list of one or more items outlining what was done in this pull request to solve the problem.
-->
- updates the seed files to facilitate the splitting
- updates section description of 'JavaScript and the Backend' section

#### Note

Do not merge until the curriculum changes are merged through this PR: https://github.com/TheOdinProject/curriculum/pull/23607

#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [ ] You have included automated tests for your changes where applicable?
