### PR TITLE
Fix: Losing Preferred Theme Starting a New Browser Session

### DIFF
--- a/app/controllers/themes_controller.rb
+++ b/app/controllers/themes_controller.rb
@@ -5,7 +5,7 @@ class ThemesController < ApplicationController
     theme = params[:theme]
 
     if ALLOWED_THEMES.include?(theme)
-      cookies[:theme] = theme
+      cookies.permanent[:theme] = theme
       redirect_back(fallback_location: root_path)
     else
       redirect_back(fallback_location: root_path, notice: 'Sorry, that theme is not allowed.')


### PR DESCRIPTION
Because:
* We were storing the users preferred theme in a session cookie.

This commit:
* Use a permanent cookie (20-year expiry) which will persist between browser sessions.


#### Checklist
 - [x] You have read [The Odin Projects Contributing Guide](https://github.com/TheOdinProject/theodinproject/wiki/Contributing-Guide)?
 - [x] You have verified the tests and linters all pass against your changes?
 - [x] You have included automated tests for your changes where applicable?
