### PR TITLE
Fix: Broken Course Links on Homepage

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -145,43 +145,43 @@ module ApplicationHelper
         badge_image_url: 'badge-javascript.svg',
         badge_alt_text: 'javascript badge',
         title: 'JavaScript',
-        path: '/courses/javascript'
+        path: '/paths/full-stack-javascript/courses/javascript'
       },
       {
         badge_image_url: 'badge-git.svg',
         badge_alt_text: 'git badge',
         title: 'Git',
-        path: '/courses/web-development-101#git-basics'
+        path: '/paths/foundations/courses/foundations#git-basics'
       },
       {
         badge_image_url: 'badge-database.svg',
         badge_alt_text: 'databases badge',
         title: 'Databases',
-        path: '/courses/databases'
+        path: '/paths/full-stack-ruby-on-rails/courses/databases'
       },
       {
         badge_image_url: 'badge-ruby.svg',
         badge_alt_text: 'ruby badge',
         title: 'Ruby',
-        path: '/courses/ruby-programming'
+        path: '/paths/full-stack-ruby-on-rails/courses/ruby-programming'
       },
       {
         badge_image_url: 'badge-ruby-on-rails.svg',
         badge_alt_text: 'ruby on rails badge',
         title: 'Ruby on Rails',
-        path: '/courses/ruby-on-rails'
+        path: '/paths/full-stack-ruby-on-rails/courses/ruby-on-rails'
       },
       {
         badge_image_url: 'badge-nodejs.svg',
         badge_alt_text: 'nodejs badge',
         title: 'NodeJS',
-        path: '/courses/nodejs'
+        path: '/paths/full-stack-javascript/courses/nodejs'
       },
       {
         badge_image_url: 'badge-getting-hired.svg',
         badge_alt_text: 'getting hired badge',
         title: 'Getting Hired',
-        path: '/courses/getting-hired'
+        path: '/paths/full-stack-javascript/courses/getting-hired'
       }
     ]
   end


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable

<hr>

Because:
* These course links on the homepage were using the old /courses/ URL structure.
* These links are hard-coded and went unnoticed when they broke.

This commit:
* Update homepage course links to use the correct paths.


**3. Additional Information:**
<!-- Any additional information about the PR, such as a link to a Discord discussion, etc. -->

