### PR TITLE
Fix: Update list styling in lessons

### DIFF
--- a/app/assets/stylesheets/components/lesson/lesson_content.scss
+++ b/app/assets/stylesheets/components/lesson/lesson_content.scss
@@ -47,18 +47,18 @@
 
   ul,
   ol {
-    line-height: 1.9;
-  }
-
-  ul, ol {
+    border: none;
     padding-left: 1.25em;
     color: $grey;
     line-height: 1.9;
     margin-bottom: 50px;
+  }
 
-    li {
-      border: none;
-      list-style-type: disc;
+  ul {
+    list-style-type: disc;
+
+    ul {
+      list-style-type: circle;
     }
   }
 
@@ -69,8 +69,10 @@
   }
 
   ol {
-    li {
-      list-style: decimal;
+    list-style-type: decimal;
+
+    ol {
+      list-style-type: lower-latin;
     }
   }
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable

<hr>

**1. Because:**
<!--
If this PR closes an open issue, replace the XXXXX below with the issue number, e.g. Closes #2013. Or if the issue is in another TOP repo replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

Otherwise, provide a clear and concise reason for your pull request, e.g. what problem it solves or what benefit it provides. If this PR is related to, but does not close, another issue or PR, you can also link it as above without the 'Closes' keyword, e.g. "Related to #2013".
 -->
Closes #XXXXX
Lists in lessons weren't being styled correctly. Namely, nested lists didn't have more appropriate markers (ordered lists within ordered lists had the same `decimal` marker as the outter-most list, and unordered lists within ordered lists also had the `decimal` marker rather than a `disc` marker).

**2. This PR:**
<!--
A bullet point list of one or more items outlining what was done in this PR to solve the problem(s) or implement the feature/enhancement.
 -->
- Updates nested lists so that they have the correct marker, either a decimal or lowercase letter for ordered lists, and a disc or hollow circle for unordered lists.

**3. Additional Information:**
<!-- Any additional information about the PR, such as a link to a Discord discussion, etc. -->

