### PR TITLE
Feature: Add Moderation matrix static page

### DIFF
--- a/app/views/static_pages/community_moderation.html.erb
+++ b/app/views/static_pages/community_moderation.html.erb
@@ -1,5 +1,5 @@
-<%= title('Help Yourself Before Asking Others') %>
-<% filename = 'app/views/static_pages/dashboard_steps/before_asking.md' %>
+<%= title('Community Moderation') %>
+<% filename = 'app/views/static_pages/dashboard_steps/moderation_matrix.md' %>
 
 <div class="gradient pb-1">
   <div class="col-xl-8 offset-xl-2">

--- a/app/views/static_pages/community_rules.html.erb
+++ b/app/views/static_pages/community_rules.html.erb
@@ -1,11 +1,13 @@
-<%= title('Community Expectations') %>
+<%= title('Community Rules') %>
+<% filename = 'app/views/static_pages/dashboard_steps/community_rules.md' %>
 
 <div class="gradient pb-1">
   <div class="col-xl-8 offset-xl-2">
     <div class="lesson-content">
-      <% f = File.open('app/views/static_pages/dashboard_steps/community_rules.md', 'r:UTF-8') %>
+      <% f = File.open(filename, 'r:UTF-8') %>
       <%= MarkdownConverter.new(f.read).as_html.html_safe %>
       <% f.close %>
     </div>
+    <%= render "static_pages/dashboard_steps/github_link", filename: filename  %>
   </div>
 </div>

--- a/app/views/static_pages/dashboard_steps/_github_link.html.erb
+++ b/app/views/static_pages/dashboard_steps/_github_link.html.erb
@@ -1,0 +1,9 @@
+<div class="lesson-content flex justify-center">
+  <%= link_to github_link("theodinproject/blob/main/#{filename}"),
+    target: :_blank,
+    rel: 'noreferrer noopener',
+    class: 'lesson-functions__edit-lesson-link' do %>
+    <span class="fab fa-github mr-1"></span>
+    <span> Suggest improvements for this page on GitHub</span>
+  <% end %>
+</div>

--- a/app/views/static_pages/dashboard_steps/moderation_matrix.md
+++ b/app/views/static_pages/dashboard_steps/moderation_matrix.md
@@ -1,0 +1,102 @@
+### Moderation Matrix
+This matrix correlates with the [Community Rules](https://www.theodinproject.com/community_rules) that are required to be followed in order to participate in the community. Some rules have different levels of severity, so you may see references to them under different numbers of zaps.
+
+This matrix is not all encompassing and zaps are given at the discretion of the moderator team. Zaps are private to the user and the moderation team, and are distributed through Dyno. Zaps accumulate over time if rules continue to be broken.
+
+10 total zaps result in a ban.
+
+#### 0 Zaps (Heads Up)
+
+* Dog piling/short circuiting a teaching moment (E.g jumping in to help when someone else is already helping out, giving an answer when someone is leading someone to think critically about their problem)
+* Asking about or encouraging the use of Windows
+* "Chat bombing", aka posting many short (ususally 4-5 or fewer words) messages in rapid succession, repeatedly sending parts of thoughts (incomplete, non-standalone sentences or fragments) in new messages. (Use shift + enter and send ONE message where possible or edit your message)
+* Discussing mental health issues in depth or seeking mental health help from other users
+* Inappropriate usernames and profile pictures (E.g. suggestive or inappropriate memes)
+
+#### 1 Zap (WARNING)
+
+Minor violations such as:
+
+* A second infraction of any 0 Zap issues above
+* "Mini-modding"
+  * Enforcement of any of the rules instead of notifying moderators (see example below)
+  * Please leave moderation action to the moderators
+  * Use ModMail to report rule breaking or if you see something you’re unsure about in the community
+* Asking for advice/help on projects unrelated to The Odin Project, or asking about topics unrelated to our Discord channels
+* Mild unprofessionalism:
+  * Drug related conversation
+  * Treating others on the server disrespectfully
+  * Relationship advice
+
+#### 2 Zaps (WARNING)
+
+Medium severity violations such as:
+
+* Suggesting piracy
+* Unsolicited pings/DM/friend request
+* Political or religious topics
+* Mild toxicity:
+  * Directed insults
+  * Provoking/baiting other users
+  * Passive aggression
+  * Naming & shaming
+* Self promo without permission (ask with Modmail)
+  * Do not share resources you have created solely for personal or monetary gain
+  * Examples: "Fill out my survey" (does not help the goals of Odin), "Join my boot camp/program/server" (Could mislead learners), "Why PHP is superior" (unrelated blog post)
+
+#### 5 Zaps (SEVERE WARNING)
+
+High severity violations such as:
+
+* Posting about any illegal activities
+* Publicly arguing about receiving moderation activity after being asked to take it to ModMail/discuss privately
+* Excessive toxicity (targeted harassment, inciting drama, aggressively arguing purposefully, etc.)
+
+#### 10 Zaps (Immediate Ban)
+
+Extreme severity violations such as:
+
+* Bigotry (racism, homophobia, hate speech etc)
+* Continued harassment
+* NSFW or otherwise highly offensive imagery in posts, profile pictures, or usernames
+* Spamming
+  * Discord Nitro spam
+  * Self promotion (joining just to promote material, no prior chat history)
+  * Repeated random nonsensical messages (copypasta)
+* Doxxing
+* Any other behavior deemed unacceptable and deserving of a ban by the moderation team
+* Piracy
+
+#### Decay Example
+
+Zaps decay at a rate of 1 zap per week. E.g., if you receive 5 zaps on a Friday, the following Friday you will have 4, the Friday after that you will have 3, and so forth. This means higher level infractions remain on record for a longer period of time, and more strongly jeopardize your ability to participate in the server if rules are continued to be broken.
+
+#### Zap Examples
+
+**Repeated offenses increase to the next penalty tier.**
+
+**Scenario:**
+
+1. Kierra is warned about dogpiling once, which earns her zero zaps as it is a first warning for a minor violation.
+2. Two days later, Kierra is warned about dogpiling again, and earns a single zap as she has already been warned. She now has 1 zap.
+3. The next day, Kierra is once again warned about dogpiling. This now earns her two zaps for a total of 3 zaps.
+4. The day after that, Kierra is warned about dogpiling and earns 5 zaps, for a total of 8 zaps.
+5. The next time Kierra is warned about dogpiling, she earns 10 zaps and is now banned from the server as she has accumulated 18 zaps.
+
+
+**What is mini-modding?**
+
+While we love having a community that can hold one another accountable and point individuals to the right direction, ultimately moderation should be done by moderators, not regular users, so we can maintain a welcoming and friendly chat environment. Mini-modding means that a non-moderator user is enforcing the rules or speaking for the team of which they are not a part of. When individuals who are not part of the moderation team or who do not maintain the platform begin enforcing rules or speaking for the team, it is up to the team to mitigate any public arguments that often occur, or to correct users who have spoken out of turn for the team.
+
+**Scenario:**
+
+1. Darius posts a question about Rock Paper Scissors in #odin-general and in #javascript-help-1
+2. Jacob replies to Darius saying, "No crossposting, see the #rules"
+3. Darius is now upset because of the terseness of Jacob's reply and the two are now arguing.
+
+Jacob should have instead reported this to @ModMail so the proper individuals can notify Darius of the rules in private.
+
+This is not a comprehensive list of all possible scenarios and zaps are made at the discretion of the moderation team if particular behaviors are inappropriate but not otherwise explicitly covered. Please DM @ModMail if you would like to discuss this matrix or any moderation activity (whether you are on the receiving end or not).
+
+#### Regarding the Moderation Team
+The moderation team, as well as the Core and Maintainer team, are also subject to the rules. If you see any issues amongst the team, please report it to @ModMail with a link to the issue and brief description of what you feel may have been violated. *Please do not argue publicly, take it to the correct channels of communication to deal with this.* Please note that the entire TOP team has visibility on ModMail. If it makes you more comfortable, you may DM one member of the team with your concerns, or email the team at theodinproject@gmail.com.

--- a/app/views/static_pages/how_to_ask.html.erb
+++ b/app/views/static_pages/how_to_ask.html.erb
@@ -1,11 +1,13 @@
 <%= title('How to Ask Technical Questions') %>
+<% filename = 'app/views/static_pages/dashboard_steps/how_to_ask.md' %>
 
 <div class="gradient pb-1">
   <div class="col-xl-8 offset-xl-2">
     <div class="lesson-content">
-      <% f = File.open('app/views/static_pages/dashboard_steps/how_to_ask.md', 'r:UTF-8') %>
+      <% f = File.open(filename, 'r:UTF-8') %>
       <%= MarkdownConverter.new(f.read).as_html.html_safe %>
       <% f.close %>
     </div>
+    <%= render "static_pages/dashboard_steps/github_link", filename: filename  %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Rails.application.routes.draw do
   get 'styleguide' => 'static_pages#style_guide'
   get 'success_stories' => 'static_pages#success_stories'
   get 'community_rules' => 'static_pages#community_rules'
+  get 'community_moderation' => 'static_pages#community_moderation'
   get 'before_asking' => 'static_pages#before_asking'
   get 'how_to_ask' => 'static_pages#how_to_ask'
   get 'sitemap' => 'sitemap#index', defaults: { format: 'xml' }


### PR DESCRIPTION
Complete the following REQUIRED checkboxes:
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable

<hr>

**1. Because:**
With the implementation of the moderation matrix, we do not currently have it on our website and we need it.

In addition, it has been suggested that these files are hard to find, since they are not on the curriculum repo, so I added links at the bottom to take a user directly to the markdown file on this repo.

**2. This PR:**
* Adds community_moderation as another community static_page.
* Add github links to each community static page so people can easily find files.

**3. Additional Information:**

Screenshot of the additional link on each of the static pages:

<img width="1059" alt="Screen Shot 2022-03-20 at 4 32 02 PM" src="https://user-images.githubusercontent.com/33227096/159187772-3ba17f0e-92ac-48e2-8f5a-2621c714d027.png">

