### PR TITLE
downgrade react-tabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "react-flip-move": "^3.0.4",
     "react-hook-form": "7.28.1",
     "react-scrolllock": "^5.0.1",
-    "react-tabs": "^4.0.1",
+    "react-tabs": "3.2.3",
     "react_ujs": "^2.6.1",
     "regenerator-runtime": "^0.13.9",
     "stickyfilljs": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8818,10 +8818,10 @@ react-scrolllock@^5.0.1:
   dependencies:
     exenv "^1.2.2"
 
-react-tabs@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/react-tabs/-/react-tabs-4.0.1.tgz#d833438629cfab9f156bf5bec5a653ce21d4348e"
-  integrity sha512-Xldj56RHhaRd37iftOwnnjsFEemHY2R07EQ9x5EqOApGauxhdLi7fc/sEKJrtFANHnasNXzSnCWdJ0ulEamMoQ==
+react-tabs@3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/react-tabs/-/react-tabs-3.2.3.tgz#ccbb3e1241ad3f601047305c75db661239977f2f"
+  integrity sha512-jx325RhRVnS9DdFbeF511z0T0WEqEoMl1uCE3LoZ6VaZZm7ytatxbum0B8bCTmaiV0KsU+4TtLGTGevCic7SWg==
   dependencies:
     clsx "^1.1.0"
     prop-types "^15.5.0"


### PR DESCRIPTION
Problem:
https://github.com/TheOdinProject/theodinproject/issues/2717

Due to a bug that was introduced into the `react-tabs` dependency. 

This commit:
- Downgrades React-Tabs, such that the Lesson Previewer works as intended.