### PR TITLE
Chore: Rename announcements expires column to expires_at

### DIFF
--- a/app/admin/announcements.rb
+++ b/app/admin/announcements.rb
@@ -1,10 +1,10 @@
 ActiveAdmin.register Announcement do
-  permit_params :message, :expires
+  permit_params :message, :expires_at
 
   form do |f|
     f.inputs do
       f.input :message
-      f.input :expires, as: :datepicker
+      f.input :expires_at, as: :datepicker
     end
     f.actions
   end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,9 +1,7 @@
 class Announcement < ApplicationRecord
   validates :message, presence: true
-  validates :expires, presence: true
+  validates :expires_at, presence: true
 
-  scope :unexpired_messages, -> { order('created_at desc').where('expires >= ?', Time.zone.now) }
-  scope :showable_messages, lambda { |disabled_announcement_ids|
-    unexpired_messages.where.not(id: disabled_announcement_ids)
-  }
+  scope :unexpired_messages, -> { where(expires_at: Time.zone.now..Float::INFINITY).order(created_at: :desc) }
+  scope :showable_messages, ->(disabled_ids) { unexpired_messages.where.not(id: disabled_ids) }
 end

--- a/app/views/shared/_announcement.html.erb
+++ b/app/views/shared/_announcement.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <% Announcement.showable_messages(disabled_announcement_ids).each do |announcement|  %>
     <div class="alert alert-success fade show announcement">
-      <button class="close" data-controller="announcement" data-announcement-expires-at-value="<%= announcement.expires.to_datetime %>" data-announcement-id-value="<%= announcement.id %>" data-dismiss="alert" data-action="click->announcement#hide" data-flash-target="close">&times;</button>
+      <button class="close" data-controller="announcement" data-announcement-expires-at-value="<%= announcement.expires_at.to_datetime %>" data-announcement-id-value="<%= announcement.id %>" data-dismiss="alert" data-action="click->announcement#hide" data-flash-target="close">&times;</button>
       <%= announcement.message.html_safe %>
     </div>
   <% end %>

--- a/db/migrate/20220414212627_rename_announcements_expires_column.rb
+++ b/db/migrate/20220414212627_rename_announcements_expires_column.rb
@@ -1,0 +1,6 @@
+class RenameAnnouncementsExpiresColumn < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :announcements, :expires, :expires_at
+    change_column_null :announcements, :expires_at, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_13_201217) do
+ActiveRecord::Schema.define(version: 2022_04_14_212627) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,7 +33,7 @@ ActiveRecord::Schema.define(version: 2022_04_13_201217) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "message", limit: 255
-    t.datetime "expires"
+    t.datetime "expires_at", null: false
   end
 
   create_table "courses", id: :serial, force: :cascade do |t|

--- a/spec/factories/announcements.rb
+++ b/spec/factories/announcements.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :announcement do
     message { 'a message for all users' }
-    expires { 1.day.from_now }
+    expires_at { 1.day.from_now }
   end
 end

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -2,13 +2,13 @@ require 'rails_helper'
 
 RSpec.describe Announcement do
   it { is_expected.to validate_presence_of(:message) }
-  it { is_expected.to validate_presence_of(:expires) }
+  it { is_expected.to validate_presence_of(:expires_at) }
 
   describe '.unexpired_messages' do
     it 'returns unexpired messages' do
-      announcement_expires_tomorrow = create(:announcement, expires: 1.day.from_now)
-      announcement_expires_next_week = create(:announcement, expires: 1.week.from_now)
-      create(:announcement, expires: 1.hour.ago)
+      announcement_expires_tomorrow = create(:announcement, expires_at: 1.day.from_now)
+      announcement_expires_next_week = create(:announcement, expires_at: 1.week.from_now)
+      create(:announcement, expires_at: 1.hour.ago)
 
       expect(described_class.unexpired_messages).to contain_exactly(
         announcement_expires_tomorrow, announcement_expires_next_week
@@ -18,9 +18,9 @@ RSpec.describe Announcement do
 
   describe '.showable_messages' do
     it 'returns messages that the user has not seen yet' do
-      seen_unexpired_message = create(:announcement, expires: 1.week.from_now)
-      unseen_unexpired_message = create(:announcement, expires: 1.day.from_now)
-      create(:announcement, expires: 1.day.ago)
+      seen_unexpired_message = create(:announcement, expires_at: 1.week.from_now)
+      unseen_unexpired_message = create(:announcement, expires_at: 1.day.from_now)
+      create(:announcement, expires_at: 1.day.ago)
 
       disabled_announcement_ids = [seen_unexpired_message.id]
 

--- a/spec/system/admin/announcements_spec.rb
+++ b/spec/system/admin/announcements_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Announcements', type: :system do
     before do
       visit new_admin_announcement_path
       fill_in :announcement_message, with: 'Test Message'
-      fill_in :announcement_expires, with: 10.days.from_now.to_date.to_s(:db)
+      fill_in :announcement_expires_at, with: 10.days.from_now.to_date.to_s(:db)
       find_button('Create Announcement').trigger('click')
     end
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable

<hr>

Because:
* Rails conventions.

This commit:
* Rename announcements expires column to expires_at
* Add not null constraint to the same column
* Refactors the unexpired_messages scope to use a date range

