### PR TITLE
Chore: Update deprecated circleci docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@ executors:
           RAILS_ENV: test
           POSTGRES_USERNAME: postgres
           POSTGRES_PASSWORD: password
-      - image: circleci/redis:alpine
-      - image: circleci/postgres:12.2-ram
+      - image: cimg/redis:6.2.6
+      - image: cimg/postgres:14.2
         environment:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: password


### PR DESCRIPTION

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable

<hr>

**1. Because:**
<!--
If this PR closes an open issue, replace the XXXXX below with the issue number, e.g. Closes #2013. Or if the issue is in another TOP repo replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

Otherwise, provide a clear and concise reason for your pull request, e.g. what problem it solves or what benefit it provides. If this PR is related to, but does not close, another issue or PR, you can also link it as above without the 'Closes' keyword, e.g. "Related to #2013".
 -->
These images are no longer supported and will not be receiving security updates


**2. This PR:**
<!--
A bullet point list of one or more items outlining what was done in this PR to solve the problem(s) or implement the feature/enhancement.
 -->
Updates the deprecated images

**3. Additional Information:**
<!-- Any additional information about the PR, such as a link to a Discord discussion, etc. -->
See this [blog post](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034) for more information about the deprecation.

There is no longer a ram option for the postgres image. I opted to go for the most recent version but can roll it back if that's too agressive (v12 -> 14).

`spec/controllers/api/lesson_completions_controller_spec.rb:67` flaked on me locally for a single run. Nothing major, just a timestamp out by 1 second