### PR TITLE
Chore: Update and improve bin scripts

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if ! command -v foreman &> /dev/null
+then
+  echo 'Installing foreman...'
+  gem install foreman
+fi
+
+foreman start -f Procfile.dev

--- a/bin/setup
+++ b/bin/setup
@@ -9,8 +9,8 @@ def system!(*args)
 end
 
 FileUtils.chdir APP_ROOT do
-  # This script is a way to setup or update your development environment automatically.
-  # This script is idempotent, so that you can run it at anytime and get an expectable outcome.
+  # This script is a way to set up or update your development environment automatically.
+  # This script is idempotent, so that you can run it at any time and get an expectable outcome.
   # Add necessary setup steps to this file.
 
   puts '== Installing dependencies =='
@@ -18,15 +18,13 @@ FileUtils.chdir APP_ROOT do
   system('bundle check') || system!('bundle install')
 
   # Install JavaScript dependencies
-  # system('bin/yarn')
-
-  # puts "\n== Copying sample files =="
-  # unless File.exist?('config/database.yml')
-  #   FileUtils.cp 'config/database.yml.sample', 'config/database.yml'
-  # end
+  system! 'bin/yarn'
 
   puts "\n== Preparing database =="
   system! 'bin/rails db:prepare'
+
+  puts "\n== Importing curriculum =="
+  system! 'rails curriculum:update_content'
 
   puts "\n== Removing old logs and tempfiles =="
   system! 'bin/rails log:clear tmp:clear'

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+
+puts "\n== Running linters =="
+puts 'Rubocop:'
+system 'bundle exec rubocop'
+puts 'ESlint:'
+system 'yarn eslint'
+
+puts "\n== Running specs =="
+puts 'Rspec:'
+system 'bundle exec rspec'
+puts 'Jest:'
+system 'yarn test'

--- a/bin/update
+++ b/bin/update
@@ -18,8 +18,17 @@ chdir APP_ROOT do
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
 
+  # Update JavaScript dependencies
+  system! 'bin/yarn'
+
   puts "\n== Updating database =="
   system! 'bin/rails db:migrate'
+
+  puts "\n== Updating seeds =="
+  system! 'bin/rails db:seed'
+
+  puts "\n== Updating curriculum =="
+  system! 'rails curriculum:update_content'
 
   puts "\n== Removing old logs and tempfiles =="
   system! 'bin/rails log:clear tmp:clear'

--- a/bin/yarn
+++ b/bin/yarn
@@ -1,9 +1,15 @@
 #!/usr/bin/env ruby
 APP_ROOT = File.expand_path('..', __dir__)
 Dir.chdir(APP_ROOT) do
-  begin
-    exec "yarnpkg", *ARGV
-  rescue Errno::ENOENT
+  yarn = ENV["PATH"].split(File::PATH_SEPARATOR).
+    select { |dir| File.expand_path(dir) != __dir__ }.
+    product(["yarn", "yarn.cmd", "yarn.ps1"]).
+    map { |dir, file| File.expand_path(file, dir) }.
+    find { |file| File.executable?(file) }
+
+  if yarn
+    exec yarn, *ARGV
+  else
     $stderr.puts "Yarn executable was not detected in the system."
     $stderr.puts "Download Yarn at https://yarnpkg.com/en/docs/install"
     exit 1


### PR DESCRIPTION
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable

<hr>

**1. Because:**
It provides several optional but convenient shortcuts that streamline several common workflows

**2. This PR:**
* Regenerate default rails binstubs
* Tweak setup and update scripts to use yarn and run curriculum import task
* Add foreman convenience stub (copied verbatim from Rails 7 default)
* Add script to run all linting and test tasks

**3. Additional Information:**
<!-- Any additional information about the PR, such as a link to a Discord discussion, etc. -->

If people like this I think it could be added to the wiki as a way to streamline the process for people wanting to run the app locally. My guess is getting postgres started will be the tricky part for most people, but this streamlines everything else.

Everything except the test / linting task is a tweak of the default Rails scripts. 

There's one (very minor) issue with the setup script - in theory it should still work without issues on an existing database, but it won't rerun seeds. Just a limitation of how our seeds are setup and how `db:prepare` works. Still valuable and works for the intended purpose.
