### PR TITLE
Chore: Use Github Action to Deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,22 @@
+name: Deploy
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://www.theodinproject.com/
+    name: Deploy production
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Push to Heroku
+        run: git push https://heroku:$HEROKU_API_KEY@git.heroku.com/$HEROKU_APP_NAME.git main
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+          HEROKU_APP_NAME: theodinproject


### PR DESCRIPTION
Because
* [Heroku's GitHub integration has been disabled until further notice](https://status.heroku.com/incidents/2413).

This commit:
* Trigger Heroku deploy Github action when push to main event happens.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable

<hr>