### PR TITLE
Fix: OAuth Buttons Have no Styling

### DIFF
--- a/app/javascript/layouts/buttons.css
+++ b/app/javascript/layouts/buttons.css
@@ -24,7 +24,11 @@
   }
 
   .button--dark {
-    @apply bg-gray-700  hover:bg-gray-800 focus:ring-gray-600
+    @apply bg-gray-700 hover:bg-gray-800 focus:ring-gray-600
+  }
+
+  .button--medium {
+    @apply px-4 py-2
   }
 
   .button--github {
@@ -33,10 +37,6 @@
 
   .button--google {
     @apply bg-blue-500 hover:bg-blue-600 focus:ring-blue-400
-  }
-
-  .button--medium {
-    @apply px-4 py-2
   }
 }
 

--- a/app/views/shared/_omniauth_buttons.html.erb
+++ b/app/views/shared/_omniauth_buttons.html.erb
@@ -1,6 +1,9 @@
-<% resource_class.omniauth_providers.each do |provider| %>
-  <%= button_to omniauth_authorize_path(resource_name, provider), class: "button button--#{provider} oauth-button full-width push-down", data: { test_id: "#{provider}-btn" } do %>
-    <i class="fab fa-<%= provider%> mr-2"></i>
-    <%= provider.to_s.titleize %>
-  <% end %>
+<%= button_to omniauth_authorize_path(resource_name, :github), class: "button button--github oauth-button full-width push-down", data: { test_id: "github-btn" } do %>
+  <i class="fab fa-github mr-2"></i>
+  Github
+<% end %>
+
+<%= button_to omniauth_authorize_path(resource_name, :google), class: "button button--google oauth-button full-width push-down", data: { test_id: "google-btn" } do %>
+  <i class="fab fa-google mr-2"></i>
+  Google
 <% end %>


### PR DESCRIPTION
Because:
* The OAuth buttons had their classes applied by interpolating the OAuth provider. This was causing purge CSS to not see those classes being used and removing them during the asset compilation phase during deploys.

This commit:
* Explicitly define the OAuth buttons instead of rendering them in a loop and interpolating the provider.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable

<hr>

**1. Because:**
<!--
If this PR closes an open issue, replace the XXXXX below with the issue number, e.g. Closes #2013. Or if the issue is in another TOP repo replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

Otherwise, provide a clear and concise reason for your pull request, e.g. what problem it solves or what benefit it provides. If this PR is related to, but does not close, another issue or PR, you can also link it as above without the 'Closes' keyword, e.g. "Related to #2013".
 -->
Closes #XXXXX


**2. This PR:**
<!--
A bullet point list of one or more items outlining what was done in this PR to solve the problem(s) or implement the feature/enhancement.
 -->


**3. Additional Information:**
<!-- Any additional information about the PR, such as a link to a Discord discussion, etc. -->

