### PR TITLE
Fix: Progress Cirlce Misaligned When Zoomed out on Safari

### DIFF
--- a/app/components/progress_badge_component.html.erb
+++ b/app/components/progress_badge_component.html.erb
@@ -11,10 +11,10 @@
       data-test-id='progress-badge'
       class="inline-flex items-center justify-center group h-24 w-24 sm:h-28 sm:w-28"
     >
-      <svg height="100%" width="100%" class="overflow-visible z-30" viewBox="0 0 20 20">
+      <svg height="100%" width="100%" class="overflow-visible z-30 transform-gpu origin-center -rotate-90" viewBox="0 0 20 20">
         <circle class="text-gray-200" stroke-width="1.3" stroke="currentColor" fill="none" r="9" cx="50%" cy="50%" />
         <circle
-          class="text-odin-green transform-gpu origin-center -rotate-90 transition-stroke-dashoffset ease-in duration-500"
+          class="text-odin-green transition-stroke-dashoffset ease-in duration-500"
           data-progress-target="progressCircle"
           stroke-width="1.4"
           stroke-linecap="round"


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable

<hr>

Because:
* Safari is miscalculating transforms and transform-origin on the inner progress circle element when zoomed.

This commit:
* Apply the transform to the parent svg of the inner progress circle.

