### PR TITLE
Chore: Add null constraint to course badge_uri field

### DIFF
--- a/db/migrate/20220618032614_add_null_constraint_to_course_badge_uri.rb
+++ b/db/migrate/20220618032614_add_null_constraint_to_course_badge_uri.rb
@@ -1,0 +1,5 @@
+class AddNullConstraintToCourseBadgeUri < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :courses, :badge_uri, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_04_125616) do
+ActiveRecord::Schema.define(version: 2022_06_18_032614) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,7 +46,7 @@ ActiveRecord::Schema.define(version: 2022_05_04_125616) do
     t.string "identifier_uuid", default: "", null: false
     t.integer "path_id"
     t.boolean "show_on_homepage", default: false, null: false
-    t.string "badge_uri"
+    t.string "badge_uri", null: false
     t.index ["identifier_uuid"], name: "index_courses_on_identifier_uuid", unique: true
     t.index ["path_id"], name: "index_courses_on_path_id"
     t.index ["slug"], name: "index_courses_on_slug"

--- a/spec/lib/seeds/course_seeder_spec.rb
+++ b/spec/lib/seeds/course_seeder_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Seeds::CourseSeeder do
       course.identifier_uuid = 'course_uuid'
       course.title = 'Foundations'
       course.description = 'a foundation course'
+      course.badge_uri = 'foo-ndations.svg'
     end
   end
 

--- a/spec/lib/seeds/path_seeder_spec.rb
+++ b/spec/lib/seeds/path_seeder_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe Seeds::PathSeeder do
           course.identifier_uuid = 'course_uuid'
           course.title = 'Ruby'
           course.description = 'A Ruby course'
+          course.badge_uri = 'ruby-soho.jpeg'
         end
       end.to change { path.courses.count }.from(0).to(1)
     end
@@ -77,18 +78,21 @@ RSpec.describe Seeds::PathSeeder do
           course.identifier_uuid = 'course_uuid_1'
           course.title = 'Ruby'
           course.description = 'A Ruby course'
+          course.badge_uri = 'ruby-soho.jpeg'
         end
 
         course_two = path_seeder.add_course do |course|
           course.identifier_uuid = 'course_uuid_2'
           course.title = 'Rails'
           course.description = 'A Rails course'
+          course.badge_uri = 'choo-choo-choose-you.bmp'
         end
 
         course_three = path_seeder.add_course do |course|
           course.identifier_uuid = 'course_uuid_3'
           course.title = 'JS'
           course.description = 'A JS course'
+          course.badge_uri = 'jolly-smith.jpg'
         end
 
         expect(course_one.course.position).to eq(1)
@@ -106,6 +110,7 @@ RSpec.describe Seeds::PathSeeder do
 
       path_seeder.add_course do |course|
         course.identifier_uuid = 'course_uuid_2'
+        course.badge_uri = 'nothing-to-see-here.svg'
       end
 
       path_seeder.delete_removed_courses


### PR DESCRIPTION
Because:
* Originally done in PR #2889, but need to stagger to avoid
a chicken/egg problem when changing the null constraint

This commit:
* Add a null constraint now all courses in prod have a non null value

Follow up from #2889 / #2883