### PR TITLE
Chore: Update Rspec config with example persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ pickle-email-*.html
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+
+# Spec example persistence / failure tracking
+/spec/examples.txt

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -19,4 +19,5 @@ RSpec.configure do |config|
   config.infer_base_class_for_anonymous_controllers = false
   config.filter_rails_from_backtrace!
   config.order = 'random'
+  config.example_status_persistence_file_path = './spec/examples.txt'
 end


### PR DESCRIPTION
Because:
* It allows us to use the handy `--only-failures` feature of Rspec

Credit to the book 'Effective Testing with Rspec 3' for the idea

Usage: After updating, run specs at least once. You can now pass `--only-failures` or `--next-failure` to only run failed specs from the last run. `--next-failure` will bail after hitting one failure whereas `--only-failures` will run all previously failed specs

```
# Example usage
bundle exec rspec --only-failures
bin/rails spec:jobs --next-failure
```