### PR TITLE
Feature: Store Announcement Creator

### DIFF
--- a/app/admin/announcements.rb
+++ b/app/admin/announcements.rb
@@ -1,10 +1,24 @@
 ActiveAdmin.register Announcement do
-  permit_params :message, :expires_at
+  permit_params :message, :expires_at, :user_id
+
+  index do
+    selectable_column
+    id_column
+
+    column :created_at
+    column :updated_at
+    column :message
+    column :expires_at
+    column 'Created By', :user_id, sortable: :user_id do |announcement|
+      announcement.user&.username || '🤷'
+    end
+  end
 
   form do |f|
     f.inputs do
       f.input :message
       f.input :expires_at, as: :datepicker
+      f.input :user_id, input_html: { value: f.current_user.id }, as: :hidden
     end
     f.actions
   end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -4,4 +4,6 @@ class Announcement < ApplicationRecord
 
   scope :unexpired_messages, -> { where(expires_at: Time.zone.now..Float::INFINITY).order(created_at: :desc) }
   scope :showable_messages, ->(disabled_ids) { unexpired_messages.where.not(id: disabled_ids) }
+
+  belongs_to :user, optional: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,7 @@ class User < ApplicationRecord
   has_many :user_providers, dependent: :destroy
   has_many :flags, foreign_key: :flagger_id, dependent: :destroy, inverse_of: :flagger
   has_many :notifications, as: :recipient, dependent: :destroy
+  has_many :announcements, dependent: nil
   belongs_to :path, optional: true
 
   def progress_for(course)

--- a/db/migrate/20220621121447_add_created_by_to_announcements.rb
+++ b/db/migrate/20220621121447_add_created_by_to_announcements.rb
@@ -1,0 +1,5 @@
+class AddCreatedByToAnnouncements < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :announcements, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_19_133130) do
+ActiveRecord::Schema.define(version: 2022_06_21_121447) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,8 @@ ActiveRecord::Schema.define(version: 2022_06_19_133130) do
     t.datetime "updated_at", null: false
     t.string "message", limit: 255
     t.datetime "expires_at", null: false
+    t.bigint "user_id"
+    t.index ["user_id"], name: "index_announcements_on_user_id"
   end
 
   create_table "courses", id: :serial, force: :cascade do |t|
@@ -255,6 +257,7 @@ ActiveRecord::Schema.define(version: 2022_06_19_133130) do
     t.index ["voter_id", "voter_type", "vote_scope"], name: "index_votes_on_voter_id_and_voter_type_and_vote_scope"
   end
 
+  add_foreign_key "announcements", "users"
   add_foreign_key "flags", "project_submissions"
   add_foreign_key "flags", "users", column: "flagger_id"
   add_foreign_key "lesson_completions", "lessons", on_delete: :cascade

--- a/spec/factories/announcements.rb
+++ b/spec/factories/announcements.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :announcement do
     message { 'a message for all users' }
     expires_at { 1.day.from_now }
+    user { create(:user) }
   end
 end


### PR DESCRIPTION
**1. Because:**

Closes #2993 

**2. This PR:**
* `Announcment` now `belongs_to` `user`
* `Announcement` admin form has hidden field to track `user_id`
* Add index view to active admin with `Created by` column + sorting

**3. Additional Information:**
First time working with Active Admin, fairly annoying :laughing: 
If this approach is ok, I can add a bit of extra polish - adding a user field to the search filter and fixing up the naming conventions (`Created By` wants to default to `User` due to how associations are set up, and manually configuring is somewhat tedious.

**Todo**
- [x] Basic functionality working / acceptance criteria complete
- [x] Figure out strategy for existing announcements (optional? A default user?)
- [x] Squash / fix commit format

**Bonus**
- [x] ~~Change foreign key to `created_by` ?~~
- [x] ~~Polish - add `created_by` to filter, possibly show page~~