### PR TITLE
Chore: Add null constraint to path badge uri (#3054)

### DIFF
--- a/db/migrate/20220706080835_add_null_constraint_to_path_badge_uri.rb
+++ b/db/migrate/20220706080835_add_null_constraint_to_path_badge_uri.rb
@@ -1,0 +1,5 @@
+class AddNullConstraintToPathBadgeUri < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :paths, :badge_uri, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_02_170539) do
+ActiveRecord::Schema.define(version: 2022_07_06_080835) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -154,7 +154,7 @@ ActiveRecord::Schema.define(version: 2022_07_02_170539) do
     t.boolean "default_path", default: false, null: false
     t.string "identifier_uuid", default: "", null: false
     t.string "short_title"
-    t.string "badge_uri"
+    t.string "badge_uri", null: false
     t.index ["identifier_uuid"], name: "index_paths_on_identifier_uuid", unique: true
     t.index ["slug"], name: "index_paths_on_slug", unique: true
   end

--- a/spec/lib/seeds/path_seeder_spec.rb
+++ b/spec/lib/seeds/path_seeder_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Seeds::PathSeeder do
       path.description = 'a foundation path'
       path.position = 1
       path.default_path = true
+      path.badge_uri = 'foundations_path_badge.svg'
     end
   end
 


### PR DESCRIPTION
Because:
* Paths should always have a badge. Follow up to #3053

