### PR TITLE
Fix: Temporary workaround for excessive JS errors in Sentry (#3048)

### DIFF
--- a/app/javascript/packs/error_tracking.js
+++ b/app/javascript/packs/error_tracking.js
@@ -10,6 +10,12 @@ Sentry.init({
   allowUrls: [
     /https?:\/\/(www\.)?theodinproject\.com/,
   ],
+  ignoreErrors: [
+    'Possible side-effect in debug-evaluate',
+    'Unexpected end of input',
+    'Invalid or unexpected token',
+    'missing ) after argument list',
+  ],
 });
 
 Sentry.configureScope((scope) => {


### PR DESCRIPTION
**Because:**
* The bug reduces our ability to see real errors

**This commit:**
* Implements one of the fixes suggested here https://github.com/getsentry/sentry-javascript/issues/5179

**Notes:**
* Unsure how to thoroughly test this aside from pushing it and seeing what happens, but open to ideas
* Should probably revisit once an official fix is found