### PR TITLE
Fix: Course Card Lessons Count Alignment

### DIFF
--- a/app/views/courses/_course.html.erb
+++ b/app/views/courses/_course.html.erb
@@ -10,7 +10,7 @@
       <div class="flex flex-col items-center space-y-4 md:flex-row md:space-x-6 text-center md:space-y-0">
         <%= render ProgressBadgeComponent.new(course: course, current_user: current_user, url: courses_progress_path(course.id)) %>
 
-        <%= link_to path_course_url(course.path, course), class: '' do %>
+        <%= link_to path_course_url(course.path, course), class: 'flex flex-col md:items-start' do %>
           <h2 id=<%= course.title.parameterize %> class="font-bold text-lg uppercase md:text-left">
             <%= course.title %>
           </h2>


### PR DESCRIPTION
Because:
* It was centered under the course title instead of being left aligned.

This commit:
* Left aligns the lesson count on medium and above screen sizes.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable
------
<img width="980" alt="Screenshot 2022-07-10 at 15 13 10" src="https://user-images.githubusercontent.com/7963776/178148776-34ed22c0-2f03-493d-8814-3378c96112c7.png">


