### PR TITLE
Feature: Use /Dashbord as the Root URL When Authenticated

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -16,9 +16,9 @@
       <div class="hidden md:ml-6 md:flex sm:items-center">
         <% if user_signed_in? %>
           <div class="hidden sm:ml-6 sm:flex sm:space-x-8">
+             <%= render Nav::ItemComponent.new(path: dashboard_path, text: 'Dashboard', test_id: 'nav-dashboard') %>
             <%= render Nav::ItemComponent.new(path: paths_url, text: 'All Paths', test_id: 'nav-all-paths') %>
             <%= render Nav::ItemComponent.new(path: ODIN_CHAT_URL, text: 'Community', test_id: 'nav-community') %>
-            <%= render Nav::ItemComponent.new(path: dashboard_path, text: 'Dashboard', test_id: 'nav-dashboard') %>
           </div>
 
           <%= link_to notifications_path, class: "odin-dark-nav-item ml-3 bg-white p-1 rounded-full text-gray-400 relative hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gold-500", data: { test_id: 'navbar-notification-icon' } do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
   end
 
   authenticated :user do
-    root to: 'users#show', as: :dashboard
+    root to: redirect('/dashboard'), as: :authenticated_root
   end
 
   devise_for :users, controllers: {
@@ -50,7 +50,8 @@ Rails.application.routes.draw do
 
   # failure route if github information returns invalid
   get '/auth/failure' => 'omniauth_callbacks#failure'
-  resources :users, only: %i[show update]
+  resources :users, only: %i[update]
+  get 'dashboard' => 'users#show', as: :dashboard
 
   namespace :users do
     resources :paths, only: :create


### PR DESCRIPTION
Because:
* We set `/` as the dashboard when authenticated which makes it difficult to accurately tell the difference between homepage and dashboard page visits on analytics.

This commit:
* Authenticated root redirects to the /dashboard path instead of setting root as the dashboard.
* Move the dashboard nav link to the first position in the nav when logged in to promote its importance.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable