### PR TITLE
Chore: Extract External Link Targets JS

### DIFF
--- a/app/javascript/controllers/external_link_targets_controller.js
+++ b/app/javascript/controllers/external_link_targets_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class ExternalLinkTargetsController extends Controller {
+  connect() {
+    this.element
+      .querySelectorAll('a[href^=http]')
+      .forEach((externalLink) => {
+        externalLink.setAttribute('target', '_blank');
+        externalLink.setAttribute('rel', 'noreferrer');
+      });
+  }
+}

--- a/app/javascript/src/js/lessons.js
+++ b/app/javascript/src/js/lessons.js
@@ -56,13 +56,6 @@ function filterHeadings() {
     .filter(isCommonHeading);
 }
 
-function setTargetForExternalLinks() {
-  getElements('.lesson-content a[href^=http]').forEach((externalLink) => {
-    externalLink.setAttribute('target', '_blank');
-    externalLink.setAttribute('rel', 'noreferrer');
-  });
-}
-
 function addActiveClass() {
   const links = getElements('.lesson-navigation__link');
 
@@ -148,7 +141,6 @@ function spyLessonSections() {
 document.addEventListener('DOMContentLoaded', () => {
   if (!isLessonPage()) return;
 
-  setTargetForExternalLinks();
   constructLessonSections();
 
   if (!window.matchMedia('(min-width: 992px)').matches) {

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -16,7 +16,7 @@
     </div>
 
     <div class="col-xl-6 col-lg-8">
-      <div class="lesson-content" data-controller="clickable-images syntax-highlighting">
+      <div class="lesson-content" data-controller="clickable-images syntax-highlighting external-link-targets">
         <%= @lesson.content.html_safe %>
       </div>
     </div>


### PR DESCRIPTION
Because:
* We are modularizing the lessons.js file behaviour into separate Stimulus controllers as part of the move to Tailwind.

This commit:
* Move JS for setting external link targets out of lessons.js into a Stimulus controller.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable
