### PR TITLE
Fix: Dashboard Open Course Button on Dark Mode

### DIFF
--- a/app/assets/stylesheets/dark-mode.css
+++ b/app/assets/stylesheets/dark-mode.css
@@ -142,3 +142,7 @@ pre:not(.line-numbers) code {
 .odin-dark-clear-button:hover {
   color: black !important;
 }
+
+.skill__sub-title {
+  color: var(--dark-font-color) !important;
+}

--- a/app/views/users/_skill.html.erb
+++ b/app/views/users/_skill.html.erb
@@ -19,7 +19,7 @@
 
   <div class="pt-4 md:pt-0">
     <% if course_completed_by_user?(course, current_user) %>
-      <%= link_to 'Open', path_course_path(course.path, course), class: 'button button--clear button--medium', data: { test_id: "#{course.title.downcase}-open-btn" } %>
+      <%= link_to 'Open', path_course_path(course.path, course), class: 'button button--clear button--medium odin-dark-clear-button', data: { test_id: "#{course.title.downcase}-open-btn" } %>
     <% elsif current_user.started_course?(course) %>
       <%= link_to 'Resume',
         lesson_url(next_lesson_to_complete(course, current_user.lesson_completions_for_course(course))),


### PR DESCRIPTION
Because
* The text was dark gray instead of white when dark mode is enabled.

This commit:
* Give the open course button the odin-dark-clear-button helper class.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable