### PR TITLE
Feature: Convert Lesson Content Layout to use Tailwind

### DIFF
--- a/app/assets/stylesheets/components/lesson/_navigation.scss
+++ b/app/assets/stylesheets/components/lesson/_navigation.scss
@@ -5,11 +5,6 @@
 }
 
 .lesson-navigation {
-  padding-bottom: 82px;
-  position: -webkit-sticky;
-  position: sticky;
-  top: 50px;
-
   &__item {
     margin-bottom: 32px;
     display: flex;

--- a/app/assets/stylesheets/components/lesson/lesson_content.scss
+++ b/app/assets/stylesheets/components/lesson/lesson_content.scss
@@ -4,9 +4,9 @@
   h3 {
     margin-bottom: 20px;
     margin-top: 50px;
-    font-weight: bold;
+    font-weight: 600;
     color: $text-primary;
-    font-size: 1.5em;
+    font-size: 1.25em;
     width: fit-content;
 
     &:first-child {
@@ -22,7 +22,7 @@
 
   h4 {
     margin-bottom: 10px;
-    font-weight: bold;
+    font-weight: 500;
     color: $text-primary;
     font-size: 18px;
     letter-spacing: 0.3px;
@@ -130,9 +130,9 @@
   }
 
   details .dropDown-header {
-    font-size: 1.5em;
+    font-size: 1.25em;
     margin-bottom: 1em;
-    font-weight: bold;
+    font-weight: 500;
     color: $text-primary;
     cursor: pointer;
 

--- a/app/components/progress_badge_component.html.erb
+++ b/app/components/progress_badge_component.html.erb
@@ -39,13 +39,13 @@
           <div class="w-2 h-2 bg-gray-300 rounded-full"></div>
           <div class="w-2 h-2 bg-gray-400 rounded-full"></div>
         </div>
-        <p class="transition-opacity delay-200 duration-500 ease-in-out opacity-0 text-sm text-gray-400 leading-5 break-words w-20 text-center font-semibold" data-progress-target="percentage"></p>
+        <p class="transition-opacity delay-200 duration-500 ease-in-out opacity-0 text-xs sm:text-sm text-gray-400 leading-5 break-words w-16 sm:w-20 text-center font-semibold" data-progress-target="percentage"></p>
       </span>
     </div>
   <% end %>
 <% else %>
   <%= link_to path_course_path(course.path, course) do %>
-    <div class="shadow-md rounded-full flex h-24 w-24 sm:h-28 sm:w-28" data-test-id='default-badge'>
+    <div class="shadow-md rounded-full flex h-24 w-24 sm:h-28 sm:w-28 odin-dark-bg-accent" data-test-id='default-badge'>
       <%= image_tag badge, alt: "#{course.title} badge", class: 'p-2.5' %>
     </div>
   <% end %>

--- a/app/javascript/src/js/lessons.js
+++ b/app/javascript/src/js/lessons.js
@@ -76,10 +76,7 @@ function constructLessonNavigation() {
   const commonHeadings = filterHeadings();
 
   if (commonHeadings.length < 2) {
-    const navigationColumn = document.querySelector('.lesson .col-lg-3');
-    const lessonColumn = document.querySelector('.lesson .row');
-    navigationColumn.classList.add('d-none');
-    lessonColumn.classList.add('justify-content-center');
+    return;
   } else {
     const lessonNavigationHTML = lessonNavigation(commonHeadings);
     const lessonNavigationElement =

--- a/app/views/lessons/_header.html.erb
+++ b/app/views/lessons/_header.html.erb
@@ -1,0 +1,21 @@
+<header class="mb-16 grid grid-cols-12">
+  <div class="flex space-x-4 items-center col-span-full md:col-start-3 xl:col-start-2">
+    <%= render ProgressBadgeComponent.new(
+        course: lesson.course,
+        current_user: current_user,
+        url: courses_progress_path(lesson.course.id)
+    )%>
+
+    <div>
+      <h1 class="text-2xl font-bold capitalize text-gray-700 min-w-full" data-test-id="lesson-title-header">
+        <%= lesson.title %>
+      </h1>
+
+      <%= link_to path_course_url(lesson.course.path, lesson.course), class: 'no-underline' do %>
+        <h2 class="min-w-full text-lg text-gray-500" data-test-id="course-title-header">
+          <%= lesson.course.title %> Course
+        </h2>
+      <% end %>
+    </div>
+  </div>
+</header>

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -1,26 +1,20 @@
 <%= title(@lesson.title) %>
 
-<div class="container lesson-container lesson tmp-container-spacer">
-  <div class="row">
-    <div class="col-12">
-      <div class="lesson-header">
-        <%= render 'courses/course/banner', course: @lesson.course %>
-        <h2 class="lesson-header__title accent" data-test-id="lesson-title-header"><%= @lesson.title %></h2>
-      </div>
-    </div>
+<div class="page-container lesson">
 
-    <div class="col-lg-3 lesson-nav-wrapper">
-      <div>
-        <div class="d-none d-lg-block d-xl-block lesson-navigation"></div>
-      </div>
-    </div>
+  <%= render 'lessons/header', lesson: @lesson %>
 
-    <div class="col-xl-6 col-lg-8">
-      <div class="lesson-content" data-controller="clickable-images syntax-highlighting external-link-targets">
+  <main class="grid grid-cols-12">
+    <article class="col-span-full md:col-span-8 md:col-start-3 xl:col-span-8 xl:col-start-2">
+      <div class="lesson-content max-w-prose text-xl" data-controller="clickable-images syntax-highlighting external-link-targets">
         <%= @lesson.content.html_safe %>
       </div>
-    </div>
-  </div>
+    </article>
+
+     <aside class="col-span-4 col-start-10 hidden xl:block">
+      <div class="sticky top-12 pb-20 lesson-navigation"></div>
+    </aside>
+  </main>
 </div>
 
 <div class="lesson-functions">


### PR DESCRIPTION
Because:
* We are moving all of our CSS to Tailwind.

This commit:
* Align lesson content slighter more left instead of on center for greater balance and fit between lesson nav and lesson content side by side.
* Move lesson nav right of lesson content for better reading experience.
* Move lesson nav within alignment of outer edges of page navbar in larger screens
* Adjust boldness in the lesson content headings to be a little lighter.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable

