### PR TITLE
Chore: Create Content Sections During Markdown to HTML Processing

### DIFF
--- a/app/javascript/src/js/lessons.js
+++ b/app/javascript/src/js/lessons.js
@@ -97,30 +97,7 @@ function isLessonPage() {
 function constructLessonSections() {
   const lessonHeadings = getElements('.lesson-content h3');
 
-  lessonHeadings.forEach(buildScrollSpy);
   lessonHeadings.forEach(constructInternalLinks);
-}
-
-function buildScrollSpy(heading) {
-  const id = heading.getAttribute('id');
-  heading.removeAttribute('id');
-  const section = document.createElement('div');
-  section.setAttribute('id', id);
-
-  if (isCommonHeading(heading.innerText)) {
-    section.classList.add('scrollspy');
-  }
-
-  heading.parentNode.insertBefore(section, heading);
-
-  while (
-    heading.nextElementSibling !== null &&
-    heading.nextElementSibling.tagName !== 'H3'
-  ) {
-    section.appendChild(heading.nextElementSibling);
-  }
-
-  section.insertBefore(heading, section.firstChild);
 }
 
 function constructInternalLinks(heading) {

--- a/app/services/markdown_converter.rb
+++ b/app/services/markdown_converter.rb
@@ -1,10 +1,18 @@
+require './lib/kramdown/document_sections'
+
 class MarkdownConverter
   def initialize(markdown)
     @markdown = markdown
   end
 
   def as_html
-    Kramdown::Document.new(markdown).to_html
+    sections = Kramdown::DocumentSections.new(markdown).all_sections
+
+    if sections.any?
+      sections.map { |section| Kramdown::Document.new(section.content).to_html }.join
+    else
+      Kramdown::Document.new(markdown).to_html
+    end
   end
 
   private

--- a/lib/kramdown/content_section.rb
+++ b/lib/kramdown/content_section.rb
@@ -1,0 +1,42 @@
+module Kramdown
+  class ContentSection
+    HEADER_LINE = 1
+    HEADER_AND_NEWLINE = 2
+
+    attr_reader :title, :header_location
+
+    def initialize(title:, header_location: nil, content: nil)
+      @title = title
+      @header_location = header_location
+      @content = content
+    end
+
+    def content
+      "<section id='#{title.parameterize}' class='scrollspy' markdown='1'>#{formatted_content}</section>"
+    end
+
+    def start
+      return if header_location.nil?
+
+      header_location - HEADER_LINE
+    end
+
+    def end_of_previous_section
+      return if header_location.nil?
+
+      header_location - HEADER_AND_NEWLINE
+    end
+
+    def start_of_document?
+      start.zero?
+    end
+
+    private
+
+    def formatted_content
+      return @content if @content.ends_with?("\n")
+
+      "#{@content}\n"
+    end
+  end
+end

--- a/lib/kramdown/converter/html_sections.rb
+++ b/lib/kramdown/converter/html_sections.rb
@@ -1,0 +1,22 @@
+require './lib/kramdown/content_section'
+
+class Kramdown::Converter::HtmlSections < Kramdown::Converter::Html
+  H3_HEADER = 3
+
+  def convert(element, _indent = -@indent)
+    @content_sections = []
+    super
+    @content_sections
+  end
+
+  def convert_header(element, indent)
+    if element.options[:level].to_i == H3_HEADER
+      @content_sections << Kramdown::ContentSection.new(
+        title: generate_id(element.options[:raw_text]),
+        header_location: element.options[:location]
+      )
+    end
+
+    super
+  end
+end

--- a/lib/kramdown/document_sections.rb
+++ b/lib/kramdown/document_sections.rb
@@ -1,0 +1,59 @@
+require './lib/kramdown/converter/html_sections'
+require './lib/kramdown/content_section'
+
+class Kramdown::DocumentSections < Kramdown::Document
+  START_OF_CONTENT = 0
+  END_OF_CONTENT = -1
+
+  def initialize(source, options = {})
+    @source = source
+    super
+  end
+
+  def all_sections
+    return [] if sections.none?
+
+    [
+      unsectionable_content,
+      sectionable_content
+    ].flatten.compact
+  end
+
+  private
+
+  def sections
+    @sections ||= Kramdown::Converter::HtmlSections.convert(@root, @options).first
+  end
+
+  def unsectionable_content
+    return if sections.any? && sections.any?(&:start_of_document?)
+
+    Kramdown::ContentSection.new(
+      title: 'content', content: content_between(START_OF_CONTENT, end_of_unsectionable_content)
+    )
+  end
+
+  def end_of_unsectionable_content
+    return END_OF_CONTENT if sections.none?
+
+    sections.first.end_of_previous_section
+  end
+
+  def sectionable_content
+    sections.map.with_index do |section, index|
+      next_section = sections[index + 1]
+
+      if next_section.present?
+        Kramdown::ContentSection.new(
+          title: section.title, content: content_between(section.start, next_section.end_of_previous_section)
+        )
+      else
+        Kramdown::ContentSection.new(title: section.title, content: content_between(section.start, END_OF_CONTENT))
+      end
+    end
+  end
+
+  def content_between(first_line, last_line)
+    @source.lines.to_a[first_line..last_line].join
+  end
+end

--- a/spec/lib/kramdown/content_section_spec.rb
+++ b/spec/lib/kramdown/content_section_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+require './lib/kramdown/content_section'
+
+RSpec.describe Kramdown::ContentSection do
+  describe '#content' do
+    it 'returns content for the section' do
+      section = described_class.new(title: 'section title', content: "some markdown\n")
+
+      expect(section.content).to eq(
+        "<section id='section-title' class='scrollspy' markdown='1'>some markdown\n</section>"
+      )
+    end
+
+    context 'when section content does not end with a newline' do
+      it 'adds a newline to the end of the content' do
+        section = described_class.new(title: 'section title', content: 'some markdown')
+
+        expect(section.content).to eq(
+          "<section id='section-title' class='scrollspy' markdown='1'>some markdown\n</section>"
+        )
+      end
+    end
+  end
+
+  describe '#start' do
+    it 'returns start location of the section' do
+      expect(described_class.new(title: 'New Section', header_location: 1).start).to eq(0)
+    end
+
+    context 'when there is not header location' do
+      it 'returns nil' do
+        expect(described_class.new(title: 'Section').start).to be_nil
+      end
+    end
+  end
+
+  describe '#end_of_previous_section' do
+    it 'returns end location of the previous section' do
+      expect(described_class.new(title: 'Section', header_location: 10)
+        .end_of_previous_section).to eq(8)
+    end
+
+    context 'when there is not header location' do
+      it 'returns nil' do
+        expect(described_class.new(title: 'Section').end_of_previous_section).to be_nil
+      end
+    end
+  end
+
+  describe '#start_of_document?' do
+    subject(:section) { described_class.new(title: 'Section', header_location: location) }
+
+    context 'when section is at the start of the document' do
+      let(:location) { 1 }
+
+      it { is_expected.to be_start_of_document }
+    end
+
+    context 'when section is not at the start of document' do
+      let(:location) { 10 }
+
+      it { is_expected.not_to be_start_of_document }
+    end
+  end
+end

--- a/spec/lib/kramdown/document_sections_spec.rb
+++ b/spec/lib/kramdown/document_sections_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+require './lib/kramdown/document_sections'
+
+RSpec.describe Kramdown::DocumentSections do
+  describe '#all_sections' do
+    context "when content has sectionable headings(h3's)" do
+      let(:markdown) do
+        <<~MARKDOWN
+          ### First header
+          Test first header
+
+          ### Second header
+          Test second header
+
+          ### Third header
+          Test third header
+        MARKDOWN
+      end
+
+      it 'creates a section for each heading' do
+        expect(described_class.new(markdown).all_sections.map(&:title)).to contain_exactly(
+          'first-header', 'second-header', 'third-header'
+        )
+      end
+
+      it 'creates sections that contain the source content' do
+        result = <<~SECTIONS.strip
+          <section id='first-header' class='scrollspy' markdown='1'>### First header
+          Test first header
+
+          </section><section id='second-header' class='scrollspy' markdown='1'>### Second header
+          Test second header
+
+          </section><section id='third-header' class='scrollspy' markdown='1'>### Third header
+          Test third header
+          </section>
+        SECTIONS
+
+        expect(described_class.new(markdown).all_sections.map(&:content).join).to eq(result)
+      end
+    end
+
+    context "when document starts with headings that can't be turned into sections" do
+      it 'creates a generic section for the beginning content in the document' do
+        markdown = <<~MARKDOWN
+          # First header
+          Test first header
+
+          ### Second header
+          Test second header
+
+          # Third header
+          Test third header
+        MARKDOWN
+
+        expect(described_class.new(markdown).all_sections.map(&:title)).to contain_exactly(
+          'content', 'second-header'
+        )
+      end
+    end
+
+    context "when markdown does not contain any sectionable headings(h3's)" do
+      it 'returns nothing' do
+        markdown = <<~MARKDOWN
+          # First header
+          Test first header
+
+          # Second header
+          Test second header
+
+          # Third header
+          Test third header
+        MARKDOWN
+
+        expect(described_class.new(markdown).all_sections).to eq([])
+      end
+    end
+  end
+end

--- a/spec/services/markdown_converter_spec.rb
+++ b/spec/services/markdown_converter_spec.rb
@@ -1,12 +1,44 @@
 require 'rails_helper'
+require './lib/kramdown/document_sections'
 
 RSpec.describe MarkdownConverter do
   describe '#as_html' do
-    it 'returns html' do
-      markdown = 'Some markdown'
-      markdown_converter = described_class.new(markdown)
+    it 'converts the markdown to html with sections' do
+      markdown = <<~MARKDOWN
+        # First header
+        Test first header
 
-      expect(markdown_converter.as_html).to eql("<p>Some markdown</p>\n")
+        ## Second header
+        Test second header
+
+        ### Third header
+        Test third header
+      MARKDOWN
+
+      result = <<~HTML
+        <section id="content" class="scrollspy">
+          <h1 id="first-header">First header</h1>
+          <p>Test first header</p>
+
+          <h2 id="second-header">Second header</h2>
+          <p>Test second header</p>
+
+        </section>
+        <section id="third-header" class="scrollspy">
+          <h3 id="third-header">Third header</h3>
+          <p>Test third header</p>
+        </section>
+      HTML
+
+      expect(described_class.new(markdown).as_html).to eq(result)
+    end
+
+    context 'when the markdown does not have any sections' do
+      it 'converts the markdown to html without sections' do
+        markdown = 'some content'
+
+        expect(described_class.new(markdown).as_html).to eq("<p>some content</p>\n")
+      end
     end
   end
 end


### PR DESCRIPTION
Because:
* Currently, we create sections in lesson content using a JS script so that scrollspy knows which section the user is currently on.
* It is much more efficient to create the sections while processing the markdown in a background job instead of on client side.
* This opens the door to move more of our lesson content processing such as setting external link attributes and wrapping images in anchor tags into Kramdown extensions.

This commit:
* Extend Kramdown to create sections when it encounters a level 3 heading in markdown.
* When the content does not start with a level 3 heading, create a generic content section for the beginning content.
* When the content does not have any level 3 headings, do not create any sections.
* Remove build scrollspy sections function from lesson js.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable