### PR TITLE
Fix: Bottom CTA Max Width

### DIFF
--- a/app/views/shared/_bottom_cta.html.erb
+++ b/app/views/shared/_bottom_cta.html.erb
@@ -1,5 +1,5 @@
-<div class="py-20 text-center">
-  <p class="text-4xl mb-4 font-light"><%= heading %></p>
+<div class="py-20 text-center max-w-4xl mx-auto">
+  <p class="text-3xl mb-4 font-light leading-10"><%= heading %></p>
   <p class="font-normal mb-10"><%= sub_heading %></p>
   <%= button %>
 </div>


### PR DESCRIPTION
Because:
* The text content was taking the full width of the page on the about page.

This commit:
* Constrains the width of the bottom cta by giving it a max width.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable
