### PR TITLE
Fix: Missing style for darkmode login page

### DIFF
--- a/app/assets/stylesheets/components/form/form_divider.scss
+++ b/app/assets/stylesheets/components/form/form_divider.scss
@@ -9,5 +9,6 @@
   &__text {
     background: $white;
     padding: 0 20px;
+    text-transform: uppercase;
   }
 }

--- a/app/assets/stylesheets/dark-mode.css
+++ b/app/assets/stylesheets/dark-mode.css
@@ -147,10 +147,6 @@ pre:not(.line-numbers) code {
   color: var(--dark-font-color) !important;
 }
 
-.button--clear {
-  color: var(--dark-font-color);
-}
-
 .form-divider__text {
   background: var(--dark-bg-color);
 }

--- a/app/assets/stylesheets/dark-mode.css
+++ b/app/assets/stylesheets/dark-mode.css
@@ -1,8 +1,8 @@
 :root {
-  --dark-bg-color: #1A1A1B;
+  --dark-bg-color: #1a1a1b;
   --dark-bg-accent: #222;
-  --dark-font-color: rgb(215, 218, 220);
-  --dark-header-color: #D7DADC;
+  --dark-font-color: #d7dadc;
+  --dark-header-color: #d7dadc;
   --dark-pseudocode-color: #e83e8c;
   --dark-input-bg-color: #313131;
 }
@@ -145,4 +145,12 @@ pre:not(.line-numbers) code {
 
 .skill__sub-title {
   color: var(--dark-font-color) !important;
+}
+
+.button--clear {
+  color: var(--dark-font-color);
+}
+
+.form-divider__text {
+  background: var(--dark-bg-color);
 }

--- a/app/views/devise/sessions/_form.html.erb
+++ b/app/views/devise/sessions/_form.html.erb
@@ -25,7 +25,7 @@
   <% end %>
 
   <div class="form-divider text-center">
-    <span class="form-divider__text">OR LOG IN WITH</span>
+    <span class="form-divider__text">or log in with</span>
   </div>
 
   <div class="text-center">


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable

<hr>

**1. Because:**
It was a white rectangle with grey text. It is now the same bg colour as its container.
![image](https://user-images.githubusercontent.com/95392008/179680304-13ca7f72-e306-4e4a-bff2-56eda5d815ba.png)

**2. This PR:**
- Adds `.form-divider__text` to dark-mode.css
- Changed the text of `form-divider__text` to lowercase and added `text-transform: uppercase` to its selector

**3. Additional Information:**
This page on both light mode and dark mode is rough. In light mode, it does not pass AA standards of contrast and can be an accessibility issue.

![image](https://user-images.githubusercontent.com/95392008/179680542-cd811810-c5a6-4fc2-8ce6-0dc3a0adea25.png)
