### PR TITLE
Fix: Path Buttons Sizing on Mobile

### DIFF
--- a/app/views/paths/index.html.erb
+++ b/app/views/paths/index.html.erb
@@ -29,8 +29,8 @@
 
     <% card.footer do |card| %>
       <div class="flex space-x-6 justify-center sm:items-center sm:justify-start md:hidden">
-        <%= render Paths::SelectButtonComponent.new(current_user: current_user, path: @foundations, classes: 'px-16')%>
-        <%= render Paths::ViewButtonComponent.new(current_user: current_user, path: @foundations, classes: 'px-16') %>
+        <%= render Paths::SelectButtonComponent.new(current_user: current_user, path: @foundations, classes: 'px-10')%>
+        <%= render Paths::ViewButtonComponent.new(current_user: current_user, path: @foundations, classes: 'px-10') %>
       </div>
     <% end %>
   <% end %>
@@ -73,8 +73,8 @@
 
         <% card.footer do %>
           <div class="flex space-x-6 items-center justify-center sm:justify-start">
-            <%= render Paths::SelectButtonComponent.new(current_user: current_user, path: path, classes: 'px-16 md:px-8 lg:px-12') %>
-            <%= render Paths::ViewButtonComponent.new(current_user: current_user, path: path, classes: 'px-16 md:px-8 lg:px-12') %>
+            <%= render Paths::SelectButtonComponent.new(current_user: current_user, path: path, classes: 'px-10 lg:px-12') %>
+            <%= render Paths::ViewButtonComponent.new(current_user: current_user, path: path, classes: 'px-10 lg:px-12') %>
           </div>
         <% end %>
       <% end %>


### PR DESCRIPTION
Because:
* The action and view path buttons had too much padding on smaller screens.

This commit:
* Reduce button padding on smaller breakpoints.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [ ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [ ] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [ ] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable
