### PR TITLE
Fix: Gap Between Content and Nav on Lesson page

### DIFF
--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -4,8 +4,8 @@
 
   <%= render 'lessons/header', lesson: @lesson %>
 
-  <main class="grid grid-cols-12">
-    <article class="col-span-full md:col-span-8 md:col-start-3 xl:col-span-8 xl:col-start-2">
+  <main class="grid grid-cols-12 gap-x-6">
+    <article class="col-span-full md:col-span-8 md:col-start-3 xl:col-span-8 xl:col-start-2 ">
       <div class="lesson-content max-w-prose text-xl" data-controller="clickable-images syntax-highlighting external-link-targets">
         <%= @lesson.content.html_safe %>
       </div>


### PR DESCRIPTION
Because:
* The nav was able to slightly overlap the content between breakpoints.

This commit:
* Add a horizontal gap to the lesson content and nav grid.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable

