### PR TITLE
Fix: Lesson Content Width on Medium Breakpoint

### DIFF
--- a/app/views/lessons/_header.html.erb
+++ b/app/views/lessons/_header.html.erb
@@ -1,12 +1,12 @@
 <header class="mb-16 grid grid-cols-12">
-  <div class="flex space-x-4 items-center col-span-full md:col-start-3 xl:col-start-2">
+  <div class="flex space-y-4 items-center flex-col col-span-full justify-center xl:space-x-4 xl:flex-row xl:justify-start xl:col-start-2">
     <%= render ProgressBadgeComponent.new(
         course: lesson.course,
         current_user: current_user,
         url: courses_progress_path(lesson.course.id)
     )%>
 
-    <div>
+    <div class="text-center xl:text-left">
       <h1 class="text-2xl font-bold capitalize text-gray-700 min-w-full" data-test-id="lesson-title-header">
         <%= lesson.title %>
       </h1>

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -5,8 +5,8 @@
   <%= render 'lessons/header', lesson: @lesson %>
 
   <main class="grid grid-cols-12 gap-x-6">
-    <article class="col-span-full md:col-span-8 md:col-start-3 xl:col-span-8 xl:col-start-2 ">
-      <div class="lesson-content max-w-prose text-lg" data-controller="clickable-images syntax-highlighting external-link-targets">
+    <article class="col-span-full xl:col-span-8 xl:col-start-2">
+      <div class="lesson-content max-w-prose mx-auto xl:mx-0 text-lg" data-controller="clickable-images syntax-highlighting external-link-targets">
         <%= @lesson.content.html_safe %>
       </div>
     </article>


### PR DESCRIPTION
Because:
* It was too narrow.

This commit:
* Content can take up as much width as max-width-prose allows on medium breakpoints and below.
* Center the header badge and title on md breakpoint and below.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable
