### PR TITLE
Fix: Nested heading threes breaking detail lists

### DIFF
--- a/lib/kramdown/converter/html_sections.rb
+++ b/lib/kramdown/converter/html_sections.rb
@@ -2,6 +2,7 @@ require './lib/kramdown/content_section'
 
 class Kramdown::Converter::HtmlSections < Kramdown::Converter::Html
   H3_HEADER = 3
+  TOP_LEVEL_ELEMENT = 0
 
   def convert(element, _indent = -@indent)
     @content_sections = []
@@ -10,7 +11,7 @@ class Kramdown::Converter::HtmlSections < Kramdown::Converter::Html
   end
 
   def convert_header(element, indent)
-    if element.options[:level].to_i == H3_HEADER
+    if element.options[:level].to_i == H3_HEADER && indent == TOP_LEVEL_ELEMENT
       @content_sections << Kramdown::ContentSection.new(
         title: generate_id(element.options[:raw_text]),
         header_location: element.options[:location]

--- a/spec/lib/kramdown/document_sections_spec.rb
+++ b/spec/lib/kramdown/document_sections_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Kramdown::DocumentSections do
 
           ### Second header
           Test second header
+            ### nested header
 
           ### Third header
           Test third header
@@ -31,6 +32,7 @@ RSpec.describe Kramdown::DocumentSections do
 
           </section><section id='second-header' class='scrollspy' markdown='1'>### Second header
           Test second header
+            ### nested header
 
           </section><section id='third-header' class='scrollspy' markdown='1'>### Third header
           Test third header


### PR DESCRIPTION
Because:
* We were making sections for all heading 3's in the document.

This commit:
* Only make sections with the top level headings 3's.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [ ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [ ] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [ ] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable
