### PR TITLE
Chore: Suppress Progress Bar Output in Specs

### DIFF
--- a/spec/tasks/curriculum_spec.rb
+++ b/spec/tasks/curriculum_spec.rb
@@ -5,6 +5,7 @@ describe ':curriculum' do
   before do
     Rake.application.rake_require 'tasks/curriculum'
     Rake::Task.define_task(:environment)
+    allow($stdout).to receive(:write)
   end
 
   describe 'curriculum:update_content' do


### PR DESCRIPTION
Because:
* The import task progress bar does not need to be displayed in the specs.

This commit:
* Stubs out stdout in the curriculum rake task.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable

