### PR TITLE
Fix: Broken Knowledge Check Links

### DIFF
--- a/app/services/markdown_converter.rb
+++ b/app/services/markdown_converter.rb
@@ -10,7 +10,7 @@ class MarkdownConverter
     sections = Kramdown::DocumentSections.new(markdown).all_sections
 
     if sections.any?
-      sections.map { |section| Kramdown::Document.new(section.content, auto_ids: false).to_html }.join
+      sections.map { |section| Kramdown::Document.new(section.content).to_html }.join
     else
       Kramdown::Document.new(markdown).to_html
     end

--- a/lib/kramdown/converter/odin_html.rb
+++ b/lib/kramdown/converter/odin_html.rb
@@ -1,4 +1,4 @@
-# All Kramdown methods that can be overridden are listed here: https://kramdown.gettalong.org/rdoc/Kramdown/Element.html
+# All Kramdown methods that can be overridden are listed here: https://kramdown.gettalong.org/rdoc/Kramdown/Converter/Html.html
 require 'kramdown/converter/html'
 
 module Kramdown
@@ -25,7 +25,7 @@ module Kramdown
 
       def convert_header(element, indent)
         if element.options[:level] == LEVEL_THREE_HEADER
-          section_anchor = "##{generate_id(element.options[:raw_text])}"
+          section_anchor = "##{generate_id(element.options[:raw_text]).parameterize}"
           body = "<a#{html_attributes({ href: section_anchor, class: 'internal-link' })}>#{inner(element, indent)}</a>"
 
           format_as_block_html('h3', element.attr, body, indent)

--- a/spec/services/markdown_converter_spec.rb
+++ b/spec/services/markdown_converter_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe MarkdownConverter do
 
         html_result = <<~HTML
           <section id="content" class="scrollspy">
-            <h1>Unsectionable Header</h1>
+            <h1 id="unsectionable-header">Unsectionable Header</h1>
             <p>some content</p>
 
           </section>


### PR DESCRIPTION
Because:
* We use h4's for some of the knowledge checks but aren't generating id's for those headings at the moment.

This commit:
* Generate ids for all headings, we were being overly cautious by turning off auto ids incase they conflicted with the section ids.
* Call parameterize on the generated id used for links wrapping h3's to ensure they are always the same as the section ids.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable
