### PR TITLE
Fix: Content Styling on Lesson Preview And Community Pages

### DIFF
--- a/app/javascript/components/lesson-preview/components/lesson-content-preview.jsx
+++ b/app/javascript/components/lesson-preview/components/lesson-content-preview.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const LessonContentInput = ({ content }) => (
-  <div className="lesson-content min-h-screen"><div dangerouslySetInnerHTML={{ __html: content }} /></div>
+  <div className="lesson-content prose prose-lg prose-gold min-h-screen"><div dangerouslySetInnerHTML={{ __html: content }} /></div>
 );
 
 LessonContentInput.defaultProps = {

--- a/app/views/static_pages/before_asking.html.erb
+++ b/app/views/static_pages/before_asking.html.erb
@@ -1,13 +1,11 @@
 <%= title('Help Yourself Before Asking Others') %>
 <% filename = 'app/views/static_pages/dashboard_steps/before_asking.md' %>
 
-<div class="gradient pb-1">
-  <div class="col-xl-8 offset-xl-2">
-    <div class="lesson-content">
-      <% f = File.open(filename, 'r:UTF-8') %>
-      <%= MarkdownConverter.new(f.read).as_html.html_safe %>
-      <% f.close %>
-    </div>
-    <%= render "static_pages/dashboard_steps/github_link", filename: filename  %>
+<div class="page-container">
+  <div class="lesson-content prose prose-lg prose-gold max-w-prose mx-auto">
+    <% f = File.open(filename, 'r:UTF-8') %>
+    <%= MarkdownConverter.new(f.read).as_html.html_safe %>
+    <% f.close %>
   </div>
+  <%= render "static_pages/dashboard_steps/github_link", filename: filename  %>
 </div>

--- a/app/views/static_pages/community_expectations.html.erb
+++ b/app/views/static_pages/community_expectations.html.erb
@@ -1,13 +1,11 @@
 <%= title('Community Expectations') %>
 <% filename = 'app/views/static_pages/dashboard_steps/community_expectations.md' %>
 
-<div class="gradient pb-1">
-  <div class="col-xl-8 offset-xl-2">
-    <div class="lesson-content">
-      <% f = File.open(filename, 'r:UTF-8') %>
-      <%= MarkdownConverter.new(f.read).as_html.html_safe %>
-      <% f.close %>
-    </div>
-    <%= render "static_pages/dashboard_steps/github_link", filename: filename  %>
+<div class="page-container">
+  <div class="lesson-content prose prose-lg prose-gold max-w-prose mx-auto">
+    <% f = File.open(filename, 'r:UTF-8') %>
+    <%= MarkdownConverter.new(f.read).as_html.html_safe %>
+    <% f.close %>
   </div>
+  <%= render "static_pages/dashboard_steps/github_link", filename: filename  %>
 </div>

--- a/app/views/static_pages/community_rules.html.erb
+++ b/app/views/static_pages/community_rules.html.erb
@@ -1,13 +1,11 @@
 <%= title('Community Rules') %>
 <% filename = 'app/views/static_pages/dashboard_steps/community_rules.md' %>
 
-<div class="gradient pb-1">
-  <div class="col-xl-8 offset-xl-2">
-    <div class="lesson-content">
-      <% f = File.open(filename, 'r:UTF-8') %>
-      <%= MarkdownConverter.new(f.read).as_html.html_safe %>
-      <% f.close %>
-    </div>
-    <%= render "static_pages/dashboard_steps/github_link", filename: filename  %>
+<div class="page-container">
+  <div class="lesson-content prose prose-lg prose-gold max-w-prose mx-auto">
+    <% f = File.open(filename, 'r:UTF-8') %>
+    <%= MarkdownConverter.new(f.read).as_html.html_safe %>
+    <% f.close %>
   </div>
+  <%= render "static_pages/dashboard_steps/github_link", filename: filename  %>
 </div>

--- a/app/views/static_pages/dashboard_steps/_github_link.html.erb
+++ b/app/views/static_pages/dashboard_steps/_github_link.html.erb
@@ -1,9 +1,6 @@
-<div class="lesson-content flex justify-center">
-  <%= link_to github_link("theodinproject/blob/main/#{filename}"),
-    target: :_blank,
-    rel: 'noreferrer noopener',
-    class: 'lesson-functions__edit-lesson-link' do %>
+<div class="flex justify-center">
+  <%= link_to  github_link("theodinproject/blob/main/#{filename}"), target: :_blank, rel: 'noreferrer noopener', class: 'text-gold text-lg block mt-14' do %>
     <span class="fab fa-github mr-1"></span>
-    <span> Suggest improvements for this page on GitHub</span>
+    <span>Suggest improvements for this page on GitHub</span>
   <% end %>
 </div>


### PR DESCRIPTION
Because:
* We removed most of the styles hooked to the lesson-content class

This commit:
* Apply Tailwind prose classes to the content in community pages.
* Apply Tailwind prose classes to lesson previews.

Closes: https://github.com/TheOdinProject/theodinproject/issues/3169

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable

<hr>