### PR TITLE
Fix: Review App's Failing on Release Phase During Deploy

### DIFF
--- a/config/initializers/patch_enable_extension.rb
+++ b/config/initializers/patch_enable_extension.rb
@@ -1,0 +1,19 @@
+require 'active_record/connection_adapters/postgresql_adapter'
+
+# NOTE: patch for https://devcenter.heroku.com/changelog-items/2446
+# Source: https://stackoverflow.com/questions/73214844/error-extension-btree-gist-must-be-installed-in-schema-heroku-ext/73289426#73289426
+module EnableExtensionHerokuPatch
+  def enable_extension(name, **)
+    return super unless schema_exists?('heroku_ext')
+
+    exec_query("CREATE EXTENSION IF NOT EXISTS \"#{name}\" SCHEMA heroku_ext").tap { reload_type_map }
+  end
+end
+
+module ActiveRecord
+  module ConnectionAdapters
+    class PostgreSQLAdapter
+      prepend EnableExtensionHerokuPatch
+    end
+  end
+end


### PR DESCRIPTION
Because:
* Heroku recently changed how they handle Postgresql extensions which has introduced breaking changes when running rails db:schema:load
* https://devcenter.heroku.com/changelog-items/2446

This commit:
* Patches the issue as described in this [Stack Overflow thread](https://stackoverflow.com/questions/73214844/error-extension-btree-gist-must-be-installed-in-schema-heroku-ext/73289426#73289426) until a longer term fix can be found.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable
