### PR TITLE
Feature: Lesson Toc Style Tweaks

### DIFF
--- a/app/javascript/stylesheets/lesson-content.css
+++ b/app/javascript/stylesheets/lesson-content.css
@@ -39,15 +39,11 @@
     scroll-margin-top: 40px;
   }
 
-  [data-lesson-toc-target="toc"] li a {
-    @apply hover:text-gold-600;
-  }
-
   [data-lesson-toc-target="toc"] li {
     @apply border-l-2
   }
 
   .toc-item-active {
-    @apply text-blue-gray-800 bg-blue-gray-100 border-l-2 border-blue-gray-600;
+    @apply text-blue-gray-800 bg-blue-gray-100 border-l-2 border-gold;
   }
 }

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -4,7 +4,7 @@
 
   <%= render 'lessons/header', lesson: @lesson %>
 
-  <main class="grid grid-cols-12 gap-x-6" data-controller="lesson-toc" data-lesson-toc-item-classes-value="no-underline hover:text-blue-gray-800">
+  <main class="grid grid-cols-12 gap-x-6" data-controller="lesson-toc" data-lesson-toc-item-classes-value="no-underline font-medium hover:text-blue-gray-800">
     <article class="col-span-full xl:col-span-7 xl:col-start-2">
       <div class="lesson-content max-w-prose mx-auto xl:mx-0 prose prose-lg prose-gold" data-controller="syntax-highlighting" data-lesson-toc-target="lessonContent">
         <%= @lesson.content.html_safe %>
@@ -13,8 +13,8 @@
 
     <aside class="col-span-3 col-start-10 justify-self-end hidden xl:block">
       <div class="sticky top-12 pb-20">
-        <h4 class="text-xl font-semibold pb-4 text-blue-gray-700 odin-dark-light-gray-font">Lesson Contents</h4>
-        <ul class="flex flex-col text-blue-gray-700" data-lesson-toc-target="toc"></ul>
+        <h4 class="text-xl font-semibold pb-4 text-blue-gray-600 odin-dark-light-gray-font">Lesson Contents</h4>
+        <ul class="flex flex-col text-blue-gray-500" data-lesson-toc-target="toc"></ul>
       </div>
     </aside>
   </main>


### PR DESCRIPTION
Because:
* A few tweaks to help the toc blend in while reading the main lesson content.

This commit:
* Lighten the toc item color and heading.
* Use font medium to improve toc item contrast and make them look more "clickable".
* Use gold border for active toc item to stay on brand.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable
