### PR TITLE
Fix: Lodash kebabCase is not compatible with how section id's are bui…

### DIFF
--- a/app/javascript/controllers/lesson_toc_controller.js
+++ b/app/javascript/controllers/lesson_toc_controller.js
@@ -1,5 +1,4 @@
 import { Controller } from '@hotwired/stimulus';
-import { kebabCase } from 'lodash';
 
 export default class LessonTocController extends Controller {
   static targets = ['toc', 'lessonContent'];
@@ -43,14 +42,14 @@ export default class LessonTocController extends Controller {
     return (
       Array
         .from(this.lessonContentTarget.querySelectorAll('h3'))
-        .map((heading) => heading.innerText)
-        .filter((heading) => heading)
+        .map((heading) => heading)
+        .filter((heading) => heading.innerText)
     );
   }
 
   tocItem(heading) {
-    const id = kebabCase(heading.toLowerCase());
+    const id = heading.firstChild.getAttribute('href');
 
-    return `<li class="p-2 pl-4"><a class="${this.itemClassesValue}" href="#${id}">${heading}</a></li>`;
+    return `<li class="p-2 pl-4"><a class="${this.itemClassesValue}" href="${id}">${heading.innerText}</a></li>`;
   }
 }


### PR DESCRIPTION
…lt in markdown.

Because:
* The kebabCase function inserts spaces around numbers which breaks some toc items, for example "es6 modules"

This commit:
* Use the heading link href for the toc item href instead of rebuilding it.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable
