### PR TITLE
Chore: Heroku Slug Cleanup

### DIFF
--- a/.slugcleanup
+++ b/.slugcleanup
@@ -3,5 +3,4 @@ app/assets/images
 app/assets/javascripts
 app/assets/stylesheets
 node_modules
-spec
-tmp/cache
+tmp

--- a/.slugignore
+++ b/.slugignore
@@ -1,3 +1,8 @@
+spec
+doc
+.github
+.rubocop
+
 # Ignore any javascript test files outside of spec/
 *.test.js
 *.test.jsx

--- a/app.json
+++ b/app.json
@@ -8,7 +8,8 @@
       "buildpacks": [
         { "url": "https://github.com/gaffneyc/heroku-buildpack-jemalloc.git" },
         { "url": "heroku/nodejs" },
-        { "url": "heroku/ruby" }
+        { "url": "heroku/ruby" },
+        { "url": "https://github.com/devforce/heroku-buildpack-cleanup" }
       ],
       "addons": [
         "heroku-postgresql:hobby-dev",


### PR DESCRIPTION
Because:
* To ensure our slug size is always small

This commit:
* Add the cleanup buildpack which is needed for the .slugcleanup file to work.
* Add spec, github and docs directories to slugignore as they are not needed to build the app.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable