### PR TITLE
Fix: Rendering Images on User Welcome Email

### DIFF
--- a/.slugcleanup
+++ b/.slugcleanup
@@ -1,5 +1,4 @@
 app/javascript
-app/assets/images
 app/assets/javascripts
 app/assets/stylesheets
 node_modules

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -3,18 +3,11 @@ class UserMailer < ApplicationMailer
 
   def send_welcome_email_to(user)
     @user = user
-    attachments.inline['logo.svg'] = logo_path
 
     mail(
       subject: 'Getting started with The Odin Project',
       to: user.email,
       template_name: 'welcome_email',
     )
-  end
-
-  private
-
-  def logo_path
-    File.read(Rails.root.join('app/assets/images/logo.svg'))
   end
 end

--- a/app/views/user_mailer/welcome_email.html.erb
+++ b/app/views/user_mailer/welcome_email.html.erb
@@ -36,8 +36,8 @@
       <table class="outer" align="center" style="background-color: #ffffff; border: 1px solid black; border-spacing: 0; color: #333333; font-family: sans-serif; max-width: 600px; width: 100%;">
         <tr>
           <td class="full-width-image center" style="padding: 0; text-align: center;">
-            <%=  image_tag attachments['logo.svg'].url, alt: 'home page banner' %>
-              <p class="main-heading" style="color: #cc9543; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 28px; font-weight: bold; margin: 10px 0 20px 0; vertical-align: center;">The Odin Project</p>
+            <%=  image_tag('logo.svg', alt: 'home page banner') %>
+            <p class="main-heading" style="color: #cc9543; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 28px; font-weight: bold; margin: 10px 0 20px 0; vertical-align: center;">The Odin Project</p>
           </td>
         </tr>
         <tr>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,6 +68,7 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
   config.action_mailer.default_url_options = { host: 'www.theodinproject.com', protocol: 'https' }
+  config.asset_host = 'https://www.theodinproject.com'
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -10,14 +10,6 @@ RSpec.describe UserMailer, type: :mailer do
       expect(welcome_email.from).to eql(['contact@theodinproject.com'])
     end
 
-    it 'includes an attachment' do
-      expect(welcome_email.attachments.count).to eq(1)
-    end
-
-    it 'renders the correct attachment' do
-      expect(welcome_email.attachments[0].filename).to eql('logo.svg')
-    end
-
     it 'renders the correct subject' do
       expect(welcome_email.subject)
         .to eql('Getting started with The Odin Project')


### PR DESCRIPTION
Because:
* We have removed the assets/images folder from our slug.

This commit:
* Render the image from the public directory (as it should be) for the user welcome email.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable