### PR TITLE
Chore: Replace Hardcoded Prose Color with Theme Color in Tailwind Config

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,7 +8,7 @@ module.exports = {
       typography: (theme) => ({
         DEFAULT: {
           css: {
-            color: '#334155',
+            color: theme('colors.blue-gray.600'),
             code: {
               color: theme('colors.pink'),
               backgroundColor: theme('colors.gray.100'),
@@ -26,6 +26,7 @@ module.exports = {
               a: {
                 color: '#0f172a',
                 'text-decoration': 'none',
+                'font-weight': '600',
               },
             },
             details: {


### PR DESCRIPTION
Because
* Just some tidying.

This commit:
* Replace the hardcoded color for the prose class with its equivalent color in the Tailwind theme object.
* Change h3 font weight to its default of 600 - the heading contains a link which is reducing font weight.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable
