### PR TITLE
Feature: Lesson Link Styles

### DIFF
--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -6,7 +6,7 @@
 
   <main class="grid grid-cols-12 gap-x-6" data-controller="lesson-toc" data-lesson-toc-item-classes-value="no-underline font-medium hover:text-blue-gray-800">
     <article class="col-span-full xl:col-span-7 xl:col-start-2">
-      <div class="lesson-content max-w-prose mx-auto xl:mx-0 prose prose-lg prose-gold break-words" data-controller="syntax-highlighting" data-lesson-toc-target="lessonContent">
+      <div class="lesson-content max-w-prose mx-auto xl:mx-0 prose prose-lg break-words" data-controller="syntax-highlighting" data-lesson-toc-target="lessonContent">
         <%= @lesson.content.html_safe %>
       </div>
     </article>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,17 @@ module.exports = {
         DEFAULT: {
           css: {
             color: theme('colors.blue-gray.600'),
+            a: {
+              color: theme('colors.gold.600'),
+              'text-decoration': 'none',
+              '&:hover': {
+                color: theme('colors.gold.600'),
+                'text-decoration': 'underline',
+              },
+              '&:visited': {
+                color: theme('colors.gold.700'),
+              }
+            },
             code: {
               color: theme('colors.pink'),
               backgroundColor: theme('colors.gray.100'),
@@ -26,6 +37,9 @@ module.exports = {
                 color: '#0f172a',
                 'text-decoration': 'none',
                 'font-weight': '600',
+                '&:visited': {
+                  color: 'inherit',
+                }
               },
             },
             details: {


### PR DESCRIPTION
Because:
* We have had many reports of our links being hard to work with on light/darkmode
* The default link style when using Tailwind typography plugin has no hover state which reduces interactivity.

This commit:
* Default style - gold with no underline
* Hover style - underline
* Visited style - darker shade of gold

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable
