### PR TITLE
Feature: Move Ruby blocks Lesson Before Custom Enumerables Project

### DIFF
--- a/db/fixtures/paths/full_stack_rails/courses/ruby.rb
+++ b/db/fixtures/paths/full_stack_rails/courses/ruby.rb
@@ -102,8 +102,8 @@ course.add_section do |section|
   section.identifier_uuid = 'bf5655dc-bd79-4cb4-b8c8-6f018f940f08'
 
   section.add_lessons(
-    ruby_lessons.fetch('Blocks'),
     ruby_lessons.fetch('Pattern Matching'),
+    ruby_lessons.fetch('Blocks'),
     ruby_lessons.fetch('Custom Enumerables'),
   )
 end


### PR DESCRIPTION
Because:
* Having the Pattern Matching lesson between the Blocks lesson and Custom Enumerables project has been the cause of some confusion.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable
