### PR TITLE
Chore: add dashboard button tracking analytics & remove jQuery analytics

### DIFF
--- a/app/javascript/src/js/analytics.js
+++ b/app/javascript/src/js/analytics.js
@@ -5,65 +5,23 @@
 // for the code doing that.
 // format: ('_trackEvent', category, action, label, value)
 
-$(() => {
-  // Fire a custom analytics event whenever any link is clicked
-  $('a').on('click', (e) => {
-    const $target = $(e.target);
-    let href = $target.attr('href');
-
-    // manually set href for elements wrapped in anchor tags
-    // this is because the click event target is actually the
-    // internal element, e.g. an <h3> tag wrapped in <a> tags
-    // will register a click target of <h3> not <a> so the
-    // 'href' property will be undefined and we must check its
-    // parents to acquire the href.
-    if (!href) {
-      href = $target.parents('a').attr('href');
-    }
-
-    // Send separate events for internal and external link clicks
-    const regexp = /^https?:/;
-    if (regexp.test(href)) {
-      _gaq.push(['_trackEvent', 'external_link', 'click', href, 1]);
-    } else {
-      _gaq.push(['_trackEvent', 'internal_link', 'click', href, 1]);
-    }
-  });
-
-  // Fire an event whenever a user marks a lesson completed on the lessons index page
-  // else whenever a student marks a lesson not completed on the lessons index page
-  $('[id^=section-lessons__]').on('click', function (e) {
-    if ($(this).children(':first').data('method') === 'post') {
-      _gaq.push(['_trackEvent', 'lesson_completion', 'mark_completed', $(this).children(':first')[0].href, 1]);
-    } else if (($(this).children(':first').data('method') === 'delete')) {
-      _gaq.push(['_trackEvent', 'lesson_completion', 'mark_not_completed', $(this).children(':first')[0].href, 1]);
-    }
-  });
-
+window.addEventListener('DOMContentLoaded', () => {
   // see_lesson_buttons.html.erb for lesson button analytics
 
-  // Fire an event when a user clicks on the Discord chat link in the individual lesson page
-  $("a:contains('Open Discord')").on('click', (e) => {
-    _gaq.push(['_trackEvent', 'chat', 'click_chat_link', 'lesson_page', 1]);
-  });
-
-  // Fire an event when a user clicks on the floating chat button
-  $('.chat-floating-btn').click((e) => {
-    _gaq.push(['_trackEvent', 'chat', 'click_chat_floating_button', 'global', 1]);
-  });
-
-  // Fire an event when a user clicks on the Discord chat link in the navbar
-  $('.discord-chat-link').on('click', (e) => {
-    _gaq.push(['_trackEvent', 'chat', 'click_chat_link', 'navbar', 1]);
+  // Fire an event when a user clicks on any discord invite link
+  document.querySelectorAll('[href^="https://discord.gg/"]').forEach((a) => {
+    a.addEventListener('click', () => {
+      _gaq.push(['_trackEvent', 'chat', 'click_chat_link', 'lesson_page', 1]);
+    });
   });
 
   // Fire an event whenever someone tries to sign in the standard way
-  $('[value="Login"]').on('click', (e) => {
+  document.querySelector('input[value="Login"]')?.addEventListener('click', (e) => {
     _gaq.push(['_trackEvent', 'signin_buttons', 'click_normal_signin_button', 'signin_button', 1]);
   });
 
   // Fire an event whenever someone tries to sign up else sign in with Github by clicking the Github button
-  $('.button--github').on('click', (e) => {
+  document.querySelector('.button--github')?.addEventListener('click', () => {
     if (window.location.pathname === '/sign_up') {
       _gaq.push(['_trackEvent', 'signup_buttons', 'click_github_signup button', 'github_signup_button', 1]);
     } else if (window.location.pathname === '/login') {
@@ -72,7 +30,7 @@ $(() => {
   });
 
   // Fire an event whenever someone tries to sign up else sign in with Google by clicking the Google button
-  $('.button--google').on('click', (e) => {
+  document.querySelector('.button--google')?.addEventListener('click', () => {
     if (window.location.pathname === '/sign_up') {
       _gaq.push(['_trackEvent', 'signup_buttons', 'click_google_signup button', 'google_signup_button', 1]);
     } else if (window.location.pathname === '/login') {
@@ -81,27 +39,52 @@ $(() => {
   });
 
   // Fire an event whenever someone clicks the normal sign up button (e.g. not step 2 of the github flow)
-  $('[value="Sign up"]').on('click', (e) => {
+  document.querySelector('input[value="Sign up"]')?.addEventListener('click', () => {
     _gaq.push(['_trackEvent', 'signup_buttons', 'sign_up', 'main_signup_button', 1]);
   });
 
   // Fire an event whenever an ad is clicked
-  $('.ad').on('click', (e) => {
-    adId = $(e.target).parents('.ad').data('ad-id');
-    _gaq.push(['_trackEvent', 'ad', 'click', adId, 1]);
+  document.querySelectorAll('[href^="https://www.thinkful.com/?utm_source=odin"]').forEach((ad) => {
+    ad.addEventListener('click', (e) => {
+      adId = e.target.closest('[href^="https://www.thinkful.com/?utm_source=odin"]').dataset['adId']
+      _gaq.push(['_trackEvent', 'ad', 'click', adId, 1]);
+    });
   });
 
-  $('[title="Mark lesson complete"]').on('click', (e) => {
-    _gaq.push(['_trackEvent', 'lesson_completion', 'mark_completed', window.location.href, 1]);
-  });
-
-  // Fire an event whenever a user marks a lesson  uncompleted on the individual lesson page
-  $('[title="Mark lesson incomplete"]').on('click', (e) => {
-    _gaq.push(['_trackEvent', 'lesson_completion', 'mark_not_completed', window.location.href, 1]);
+  // Fire an event when a lesson is marked either complete or incomplete  
+  document.querySelectorAll('[data-complete-button-is-completed-value]').forEach((complete) => {
+    complete.addEventListener('click', () => {
+      if (complete.dataset.completeButtonIsCompletedValue === 'true') {
+        _gaq.push(['_trackEvent', 'lesson_completion', 'mark_not_completed', window.location.href, 1]);
+      } else if (complete.dataset.completeButtonIsCompletedValue === 'false') {
+        _gaq.push(['_trackEvent', 'lesson_completion', 'mark_completed', window.location.href, 1]);
+      }
+    });
   });
 
   // Fire an event when a user clicks on the next lesson navigation link in the individual lesson page
-  $('[title^="Move on to"]').on('click', (e) => {
+  document.querySelector('[data-test-id="next-lesson-btn"]')?.addEventListener('click', () => {
     _gaq.push(['_trackEvent', 'lesson_navigation', 'click_next_lesson_link', 'lesson_page', 1]);
+  });
+
+  // Fire an event when a user clicks on dashboard resume button
+  document.querySelectorAll('[data-test-id*="resume-btn"]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      _gaq.push(['_trackEvent', 'dashboard_buttons', 'resume', 'dashboard', 1]);
+    });
+  });
+
+  // Fire an event when a user clicks on dashboard start button
+  document.querySelectorAll('[data-test-id*="start-btn"]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      _gaq.push(['_trackEvent', 'dashboard_buttons', 'start', 'dashboard', 1]);
+    });
+  });
+
+  // Fire an event when a user clicks on dashboard open button
+  document.querySelectorAll('[data-test-id*="open-btn"]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      _gaq.push(['_trackEvent', 'dashboard_buttons', 'open', 'dashboard', 1]);
+    });
   });
 });


### PR DESCRIPTION

-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable

<hr>

**1. Because:**
Closes https://github.com/TheOdinProject/theodinproject/issues/3194


**2. This PR:**
- Adds analytics tracking for dashboard buttons
- Refactors analytics js script to no longer use jQuery


**3. Additional Information:**
- Removed this function as there were no id's in the repo matching the selector

![image](https://user-images.githubusercontent.com/24649589/187054825-8ce11b7a-7e27-4af4-a557-b3b5b09b22b2.png)

- I refactored the separate discord tracking links to all use the same tracking function. This also includes the link from clicking the discord logo in the left of the footer which was previously un-tracked.

- The mark lesson complete / incomplete and next lesson button tracking was previously broken, this is now fixed.


