### PR TITLE
Chore: Enable Tailwind Form Plugin for Email CTA.

### DIFF
--- a/app/views/shared/_footer_cta.html.erb
+++ b/app/views/shared/_footer_cta.html.erb
@@ -13,7 +13,7 @@
 
     <%= form_with url: sign_up_path, method: :get do |form| %>
       <div class="p-1 flex rounded-md bg-white focus-within:ring-2 focus-within:ring-indigo-500 border border-gray-300">
-        <%= form.email_field :email, placeholder: 'Email Address', required: true, class: 'w-60 p-2 focus:outline-none bg-white block rounded-none lg:w-80 lg:text-md rounded-l-md' %>
+        <%= form.email_field :email, placeholder: 'Email Address', required: true, class: 'form-input border-none focus:ring-0 w-60 p-2 focus:outline-none bg-white block rounded-none lg:w-80 lg:text-md rounded-l-md' %>
         <%= form.submit 'Get Started!', class: 'button button--primary py-2' %>
       </div>
     <% end %>


### PR DESCRIPTION
Because:
* We will be enabling the Tailwind form plugin for all form fields by default.

This commit:
* Enabled the TW form plugin for the email cta field manually and fixes styling.