### PR TITLE
Chore: Remove lightning bolt icon

### DIFF
--- a/app/assets/images/icons/lightning-bolt.svg
+++ b/app/assets/images/icons/lightning-bolt.svg
@@ -1,3 +1,0 @@
-<svg fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path>
-</svg>


### PR DESCRIPTION
Because:
* We don't use it anywhere.
