### PR TITLE
Chore: Enable Tailwind Form Plugin by Default

### DIFF
--- a/app/javascript/components/project-submissions/components/form/text-area.jsx
+++ b/app/javascript/components/project-submissions/components/form/text-area.jsx
@@ -13,7 +13,7 @@ const TextArea = ({ name, register, errors, rows, autoFocus, placeholder, dataTe
       <textarea
         autoFocus={autoFocus}
         placeholder={placeholder}
-        className={`form-textarea block w-full border rounded-md shadow-sm py-2 px-3 focus:outline-none dark-form-input ${styles()}`}
+        className={`block w-full border rounded-md shadow-sm py-2 px-3 focus:outline-none dark-form-input ${styles()}`}
         rows={rows}
         data-test-id={dataTestId}
         {...register(name, {

--- a/app/javascript/components/project-submissions/components/form/url-field.jsx
+++ b/app/javascript/components/project-submissions/components/form/url-field.jsx
@@ -20,7 +20,7 @@ const UrlField = ({ name, label, icon, register, errors, autoFocus, placeholder 
           type="url"
           autoFocus={autoFocus}
           id={name}
-          className={`form-input block w-full pl-10 rounded-md dark-form-input ${styles()}`}
+          className={`block w-full pl-10 rounded-md dark-form-input ${styles()}`}
           placeholder={placeholder}
           data-test-id={`${kebabCase(name)}-field`}
           {...register(name)}

--- a/app/views/shared/_footer_cta.html.erb
+++ b/app/views/shared/_footer_cta.html.erb
@@ -12,8 +12,8 @@
     <h3 class="text-3xl font-bold pb-6">Start learning for free</h3>
 
     <%= form_with url: sign_up_path, method: :get do |form| %>
-      <div class="p-1 flex rounded-md bg-white focus-within:ring-2 focus-within:ring-indigo-500 border border-gray-300">
-        <%= form.email_field :email, placeholder: 'Email Address', required: true, class: 'form-input border-none focus:ring-0 w-60 p-2 focus:outline-none bg-white block rounded-none lg:w-80 lg:text-md rounded-l-md' %>
+      <div class="dark-form-input p-1 flex rounded-md bg-white focus-within:ring-2 focus-within:ring-indigo-500 border border-gray-300">
+        <%= form.email_field :email, placeholder: 'Email Address', required: true, class: 'dark-form-input border-none focus:ring-0 w-60 p-2 focus:outline-none bg-white block rounded-none lg:w-80 lg:text-md rounded-l-md' %>
         <%= form.submit 'Get Started!', class: 'button button--primary py-2' %>
       </div>
     <% end %>

--- a/app/views/users/passwords/edit.html.erb
+++ b/app/views/users/passwords/edit.html.erb
@@ -10,12 +10,12 @@
 
           <div class="col-span-full">
             <%= form.label :password, 'New password' %>
-            <%= form.password_field :password, required: true, class: 'form-input dark-form-input' %>
+            <%= form.password_field :password, required: true, class: 'dark-form-input' %>
           </div>
 
           <div class="col-span-full">
             <%= form.label :password_confirmation, 'Confirm new password' %>
-            <%= form.password_field :password_confirmation, required: true, class: 'form-input dark-form-input' %>
+            <%= form.password_field :password_confirmation, required: true, class: 'dark-form-input' %>
           </div>
 
           <div class="col-span-full">

--- a/app/views/users/passwords/new.html.erb
+++ b/app/views/users/passwords/new.html.erb
@@ -10,7 +10,7 @@
         <%= form_for resource, as: resource_name, url: password_path(resource_name), builder: TailwindFormBuilder, html: { method: :post } do |form| %>
           <div class="mb-6">
             <%= form.label :email %>
-             <%= form.email_field :email, autofocus: true, required: true, placeholder: 'you@example.com', class: 'form-input dark-form-input' %>
+             <%= form.email_field :email, autofocus: true, required: true, placeholder: 'you@example.com', class: 'dark-form-input' %>
              <div class="mt-2 text-sm text-gray-500">Where should we send the password reset instructions to?</div>
           </div>
 

--- a/app/views/users/profiles/edit.html.erb
+++ b/app/views/users/profiles/edit.html.erb
@@ -25,17 +25,17 @@
 
                 <div class="col-span-6 sm:col-span-3">
                   <%= form.label :username %>
-                  <%= form.text_field :username, class: 'form-input dark-form-input', data: { test_id: 'username-field', attr: 'form-validation.username', action: 'blur->form-validation#validate' } %>
+                  <%= form.text_field :username, class: 'dark-form-input', data: { test_id: 'username-field', attr: 'form-validation.username', action: 'blur->form-validation#validate' } %>
                 </div>
 
                 <div class="col-span-6 sm:col-span-4">
                   <%= form.label :email %>
-                  <%= form.email_field :email, class: 'form-input dark-form-input', data: { test_id: 'email-field', attr: 'form-validation.email', action: 'blur->form-validation#validate' } %>
+                  <%= form.email_field :email, class: 'dark-form-input', data: { test_id: 'email-field', attr: 'form-validation.email', action: 'blur->form-validation#validate' } %>
                 </div>
 
                 <div class="col-span-6 sm:col-span-6">
                   <%= form.label :learning_goal %>
-                  <%= form.text_area :learning_goal, class: 'form-textarea dark-form-input', placeholder: 'I wanna be the very best...', rows: 4, data: { test_id: 'learning-goal-field' } %>
+                  <%= form.text_area :learning_goal, class: 'dark-form-input', placeholder: 'I wanna be the very best...', rows: 4, data: { test_id: 'learning-goal-field' } %>
                 </div>
 
                 <div class="col-span-6">

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -23,18 +23,18 @@
               <div class="grid grid-cols-6 gap-6 grid-flow-row">
                 <div class="col-span-6 sm:col-span-4">
                   <%= form.label :current_password %>
-                  <%= form.password_field :current_password, class: 'form-input dark-form-input', data: { test_id: 'current-password-field', attr: 'form-validation.currentPassword', action: 'blur->form-validation#validate' }
+                  <%= form.password_field :current_password, class: 'dark-form-input', data: { test_id: 'current-password-field', attr: 'form-validation.currentPassword', action: 'blur->form-validation#validate' }
                   %>
                 </div>
 
                 <div class="col-span-6 sm:col-span-4">
                   <%= form.label :password %>
-                  <%= form.password_field :password, class: 'form-input dark-form-input', data: { test_id: 'password-field', attr: 'form-validation.password', action: 'blur->form-validation#validate' } %>
+                  <%= form.password_field :password, class: 'dark-form-input', data: { test_id: 'password-field', attr: 'form-validation.password', action: 'blur->form-validation#validate' } %>
                 </div>
 
                 <div class="col-span-6 sm:col-span-4">
                   <%= form.label :password_confirmation %>
-                  <%= form.password_field :password_confirmation, class: 'form-input dark-form-input', data: { test_id: 'password-confirmation-field', attr: 'form-validation.password_confirmation', action: 'blur->form-validation#validate' } %>
+                  <%= form.password_field :password_confirmation, class: 'dark-form-input', data: { test_id: 'password-confirmation-field', attr: 'form-validation.password_confirmation', action: 'blur->form-validation#validate' } %>
                 </div>
               </div>
             <% end %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -10,22 +10,22 @@
         <div class="grid grid-cols-6 gap-6">
           <div class="col-span-6">
             <%= form.label :username %>
-            <%= form.text_field :username, required: true, autofocus: params[:email].present?, class: 'form-input dark-form-input', data: { test_id: 'username_field', attr: 'form-validation.username', action: 'blur->form-validation#validate' } %>
+            <%= form.text_field :username, required: true, autofocus: params[:email].present?, class: 'dark-form-input', data: { test_id: 'username_field', attr: 'form-validation.username', action: 'blur->form-validation#validate' } %>
           </div>
 
           <div class="col-span-6">
             <%= form.label :email %>
-            <%= form.email_field :email, required: true, value: params[:email], class: 'form-input dark-form-input', data: { test_id: 'email_field', attr: 'form-validation.email', action: 'blur->form-validation#validate' } %>
+            <%= form.email_field :email, required: true, value: params[:email], class: 'dark-form-input', data: { test_id: 'email_field', attr: 'form-validation.email', action: 'blur->form-validation#validate' } %>
           </div>
 
           <div class="col-span-6">
             <%= form.label :password %>
-            <%= form.password_field :password, required: true, class: 'form-input dark-form-input', data: { test_id: 'password_field', attr: 'form-validation.password', action: 'blur->form-validation#validate' } %>
+            <%= form.password_field :password, required: true, class: 'dark-form-input', data: { test_id: 'password_field', attr: 'form-validation.password', action: 'blur->form-validation#validate' } %>
           </div>
 
           <div class="col-span-6">
             <%= form.label :password_confirmation %>
-            <%= form.password_field :password_confirmation, required: true, class: 'form-input dark-form-input', data: { test_id: 'password_confirmation_field', attr: 'form-validation.password_confirmation', action: 'blur->form-validation#validate' } %>
+            <%= form.password_field :password_confirmation, required: true, class: 'dark-form-input', data: { test_id: 'password_confirmation_field', attr: 'form-validation.password_confirmation', action: 'blur->form-validation#validate' } %>
           </div>
 
           <div class="col-span-6 text-center">

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -10,17 +10,17 @@
           <div class="grid grid-cols-6 gap-6 grid-flow-row">
             <div class="col-span-6 sm:col-span-6">
               <%= form.label :email %>
-              <%= form.email_field :email, required: false, class: 'form-input dark-form-input', data: { test_id: 'email-field', attr: 'form-validation.email', action: 'blur->form-validation#validate' } %>
+              <%= form.email_field :email, required: false, class: 'dark-form-input', data: { test_id: 'email-field', attr: 'form-validation.email', action: 'blur->form-validation#validate' } %>
             </div>
 
             <div class="col-span-6 sm:col-span-6">
               <%= form.label :password %>
-              <%= form.password_field :password, required: false, class: 'form-input dark-form-input', data: { test_id: 'password-field', attr: 'form-validation.password', action: 'blur->form-validation#validate' } %>
+              <%= form.password_field :password, required: false, class: 'dark-form-input', data: { test_id: 'password-field', attr: 'form-validation.password', action: 'blur->form-validation#validate' } %>
             </div>
 
             <div class="flex items-center justify-between col-span-6">
               <div class="flex items-center">
-                <%= form.check_box :remember_me, checked: true, class: 'form-checkbox text-teal-600 focus:ring-teal-500' %>
+                <%= form.check_box :remember_me, checked: true, class: 'text-teal-600 focus:ring-teal-500' %>
                 <%= form.label :remember_me, class: 'ml-2 block text-sm text-gray-900 mb-0' %>
               </div>
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -101,8 +101,6 @@ module.exports = {
   },
   plugins: [
     require('@tailwindcss/typography'),
-    require("@tailwindcss/forms")({
-      strategy: 'class', // only generate classes
-    }),
+    require("@tailwindcss/forms"),
   ],
 }


### PR DESCRIPTION
Because:
* We want the Tailwind form styles to be automatically applied to any new form fields in the future.

This commit:
* Enable the Tailwind form plugin by default in Tailwind config.
* Remove the classes used to enable the Tailwind form plugin for individual fields.
* Fix email footer cta dark mode styling.

