### PR TITLE
Feature: Announcements Redesign

### DIFF
--- a/app/admin/announcements.rb
+++ b/app/admin/announcements.rb
@@ -1,5 +1,5 @@
 ActiveAdmin.register Announcement do
-  permit_params :message, :expires_at, :user_id
+  permit_params :message, :expires_at, :user_id, :learn_more_url
 
   index do
     selectable_column
@@ -18,6 +18,7 @@ ActiveAdmin.register Announcement do
     f.inputs do
       f.input :message
       f.input :expires_at, as: :datepicker
+      f.input :learn_more_url
       f.input :user_id, input_html: { value: f.current_user.id }, as: :hidden
     end
     f.actions

--- a/app/assets/images/icons/x.svg
+++ b/app/assets/images/icons/x.svg
@@ -1,0 +1,3 @@
+<svg class="" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+</svg>

--- a/app/assets/stylesheets/dark-mode.css
+++ b/app/assets/stylesheets/dark-mode.css
@@ -202,3 +202,15 @@ pre code {
   color: var(--dark-font-color) !important;
   background-color: var(--dark-bg-accent) !important;
 }
+
+.odin-dark-font-color {
+  color: white !important;
+}
+
+.odin-dark-border {
+  border-color: #4B5563 !important;
+}
+
+.odin-dark-close-button:hover {
+  background-color: #4B5563 !important;
+}

--- a/app/components/announcement_component.html.erb
+++ b/app/components/announcement_component.html.erb
@@ -1,0 +1,24 @@
+<div class="relative bg-gray-50 border-b border-gray-200 odin-dark-bg-accent odin-dark-border" data-controller="announcement" data-announcement-expires-at-value="<%= announcement.expires_at.to_datetime %>" data-announcement-id-value="<%= announcement.id %>">
+  <div class="mx-auto max-w-7xl py-3 px-3 sm:px-6 lg:px-8">
+    <div class="pr-16 sm:px-16 sm:text-center">
+      <div class="font-medium text-gray-700 odin-dark-text flex flex-col justify-center items-start sm:flex-row sm:items-center">
+        <span class="hidden items-center rounded bg-gold-100 px-2 py-0.5 text-xs font-medium text-gold-800 mr-2 sm:inline-flex">New!</span>
+        <span><%= announcement.message %></span>
+        <% if announcement.learn_more_url.present? %>
+          <span class="block sm:ml-2 sm:inline-block">
+            <a href="<%= announcement.learn_more_url %>" class="font-bold text-gold-600 underline">
+              Learn more
+              <span aria-hidden="true"> &rarr;</span>
+            </a>
+          </span>
+        <% end %>
+      </div>
+    </div>
+    <div class="absolute inset-y-0 right-0 flex items-start pt-1 pr-1 sm:items-start sm:pt-1 sm:pr-2">
+      <button type="button" class="-mr-1 flex p-2 rounded-md hover:bg-gray-200 odin-dark-close-button focus:outline-none focus:ring-2 focus:ring-white" data-action="click->announcement#dismiss">
+        <span class="sr-only">Dismiss</span>
+        <%= inline_svg_tag 'icons/x.svg', class: 'h-6 w-6 text-gray-700 odin-dark-text', aria: true, title: 'dismiss', desc: 'dismiss icon' %>
+      </button>
+    </div>
+  </div>
+</div>

--- a/app/components/announcement_component.rb
+++ b/app/components/announcement_component.rb
@@ -1,0 +1,13 @@
+class AnnouncementComponent < ViewComponent::Base
+  def initialize(announcement:)
+    @announcement = announcement
+  end
+
+  def render?
+    announcement.present?
+  end
+
+  private
+
+  attr_reader :announcement
+end

--- a/app/javascript/controllers/announcement_controller.js
+++ b/app/javascript/controllers/announcement_controller.js
@@ -6,8 +6,9 @@ export default class AnnouncementController extends Controller {
     id: Number,
   };
 
-  hide() {
+  dismiss() {
     const expiresAt = new Date(this.expiresAtValue).toUTCString();
     document.cookie = `announcement_${this.idValue}=disabled; expires=${expiresAt}; path=/`;
+    this.element.remove();
   }
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,8 +35,8 @@
   </head>
 
   <body class="line-numbers h-full">
+    <%= render AnnouncementComponent.new(announcement: Announcement.showable_messages(disabled_announcement_ids).first) %>
     <%= render 'shared/navbar' %>
-    <%= render 'shared/announcement'%>
     <%= render 'shared/flash', flash: flash if flash.any? %>
 
     <%= yield %>

--- a/app/views/shared/_announcement.html.erb
+++ b/app/views/shared/_announcement.html.erb
@@ -1,8 +1,0 @@
-<div class="container">
-  <% Announcement.showable_messages(disabled_announcement_ids).each do |announcement|  %>
-    <div class="alert alert-success fade show announcement">
-      <button class="close" data-controller="announcement" data-announcement-expires-at-value="<%= announcement.expires_at.to_datetime %>" data-announcement-id-value="<%= announcement.id %>" data-dismiss="alert" data-action="click->announcement#hide" data-flash-target="close">&times;</button>
-      <%= announcement.message.html_safe %>
-    </div>
-  <% end %>
-</div>

--- a/db/migrate/20220917151628_add_learn_more_url_to_announcements.rb
+++ b/db/migrate/20220917151628_add_learn_more_url_to_announcements.rb
@@ -1,0 +1,5 @@
+class AddLearnMoreUrlToAnnouncements < ActiveRecord::Migration[6.1]
+  def change
+    add_column :announcements, :learn_more_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_15_061812) do
+ActiveRecord::Schema.define(version: 2022_09_17_151628) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 2022_09_15_061812) do
     t.string "message", limit: 255
     t.datetime "expires_at", null: false
     t.bigint "user_id"
+    t.string "learn_more_url"
     t.index ["user_id"], name: "index_announcements_on_user_id"
   end
 

--- a/spec/components/announcement_component_spec.rb
+++ b/spec/components/announcement_component_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe AnnouncementComponent, type: :component do
+  context 'with an announcement' do
+    it 'renders the announcement' do
+      announcement = create(:announcement, message: 'Hello, world!')
+      component = described_class.new(announcement:)
+
+      render_inline(component)
+
+      expect(page).to have_content('Hello, world!')
+    end
+  end
+
+  context 'with no announcement' do
+    it 'does not render anything' do
+      component = described_class.new(announcement: nil)
+      expect(render_inline(component).inner_html).to eq('')
+    end
+  end
+
+  context 'when the announcement has a learn more url' do
+    it 'renders the learn more link' do
+      announcement = create(:announcement, learn_more_url: 'https://example.com')
+      component = described_class.new(announcement:)
+
+      render_inline(component)
+
+      expect(page).to have_link('Learn more', href: 'https://example.com')
+    end
+  end
+
+  context 'when the announcement does not have a learn more url' do
+    it 'renders the announcement without a learn more link' do
+      announcement = create(:announcement, learn_more_url: nil)
+      component = described_class.new(announcement:)
+
+      render_inline(component)
+
+      expect(page).not_to have_link('Learn more')
+    end
+  end
+end

--- a/spec/factories/announcements.rb
+++ b/spec/factories/announcements.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     message { 'a message for all users' }
     expires_at { 1.day.from_now }
     user { create(:user) }
+    learn_more_url { 'https://example.com' }
   end
 end


### PR DESCRIPTION
Because:
* The old Announcements had the same styles as our flash messages, making it easy to confuse them as toast messages.
closes: https://github.com/TheOdinProject/top-meta/issues/213

This commit:
* Redesign announcements to be a banner at the top of pages.
* Add learn more url to announcement model so we don't need to add raw links to the message.
* Move announcement partial markup into a view component so we can test it and choose to render it or not easily.
* Only display the latest announcements one at a time until dismissed - before it was possible to have a list of announcements display.

Before: 
<img width="1325" alt="Screenshot 2022-09-18 at 11 48 48" src="https://user-images.githubusercontent.com/7963776/190898472-3db272cc-e345-4a3f-b462-4760def6f45a.png">

After:
<img width="1465" alt="Screenshot 2022-09-18 at 11 48 00" src="https://user-images.githubusercontent.com/7963776/190898477-6d61d8b8-dfc1-4518-8052-296e8cac15eb.png">
