### PR TITLE
Fix: Lesson Preview Styling

### DIFF
--- a/app/controllers/lessons/previews_controller.rb
+++ b/app/controllers/lessons/previews_controller.rb
@@ -6,7 +6,7 @@ module Lessons
       if content.present?
         render json: { content: MarkdownConverter.new(params[:content]).as_html }
       else
-        render json: { content: 'Nothing to preview' }
+        render json: { content: '<p>Nothing to preview</p>' }
       end
     end
 

--- a/app/javascript/components/lesson-preview/components/lesson-content-input.jsx
+++ b/app/javascript/components/lesson-preview/components/lesson-content-input.jsx
@@ -8,7 +8,7 @@ const LessonContentInput = ({ onChange, content }) => {
 
   return (
     <textarea
-      className="w-full min-h-screen p-4 form-element"
+      className="w-full min-h-screen block rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 dark-form-input"
       placeholder="Lesson content..."
       onChange={handleOnChange}
       value={content}

--- a/app/javascript/components/lesson-preview/index.jsx
+++ b/app/javascript/components/lesson-preview/index.jsx
@@ -8,8 +8,6 @@ import LessonContentInput from './components/lesson-content-input';
 import LessonContentPreview from './components/lesson-content-preview';
 import axios from '../../src/js/axiosWithCsrf';
 
-import 'react-tabs/style/react-tabs.css';
-
 import { generateLink, encodeContent, decodeContent } from '../../src/js/previewShare';
 
 const LessonPreview = () => {
@@ -56,10 +54,10 @@ const LessonPreview = () => {
   }, [content]);
 
   return (
-    <Tabs>
-      <TabList>
-        <Tab onClick={() => setOnPreviewTab(false)}>Write</Tab>
-        <Tab onClick={fetchLessonPreview}>Preview</Tab>
+    <Tabs selectedTabClassName="text-gray-900 bg-gray-100 hover:bg-gray-200 odin-dark-page-nav-item-active">
+      <TabList className="flex items-center mb-3">
+        <Tab onClick={() => setOnPreviewTab(false)} className="odin-dark-page-nav-item text-gray-500 hover:text-gray-900 bg-white hover:bg-gray-100 rounded-md border border-transparent px-3 py-1.5 font-medium cursor-pointer">Write</Tab>
+        <Tab onClick={fetchLessonPreview} className="ml-2 odin-dark-page-nav-item text-gray-500 hover:text-gray-900 bg-white hover:bg-gray-100 rounded-md border border-transparent px-3 py-1.5 font-medium cursor-pointer">Preview</Tab>
       </TabList>
 
       <TabPanel>


### PR DESCRIPTION
Because:
* We recently enabled the Tailwind form plugin by default which applies a form reset to all form fields.

This commit:
* Updates the styling of the lesson content/preview to match the new form design we are using across the site.
* Updates styling for react tabs to match the overall design.