### PR TITLE
Feature: Support JSX Syntax Hightlighting

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,7 @@
 {
   "plugins": [
     ["prismjs", {
-        "languages": ["ruby", "javascript", "css", "markup", "sql", "erb"],
+        "languages": ["ruby", "javascript", "css", "markup", "sql", "erb", "jsx"],
         "plugins": ["line-numbers"],
         "theme": "tomorrow",
         "css": true


### PR DESCRIPTION
Because:
* For the code examples in the new React course.
