### PR TITLE
Feature: Convert Sign up Page Styles to Tailwind

### DIFF
--- a/app/components/oauth/connect_button_component.html.erb
+++ b/app/components/oauth/connect_button_component.html.erb
@@ -1,0 +1,6 @@
+<div>
+  <%= button_to omniauth_authorize_path(resource_name, provider), class: 'button button--clear odin-dark-clear-button w-full py-2 px-4 text-sm font-medium text-gray-500 focus:ring-0', title: provider, data: { test_id: "#{provider}-btn" } do %>
+    <span class="sr-only">Sign in with <%= provider.capitalize %></span>
+    <%= inline_svg_tag "icons/#{provider}.svg", class: "h-5 w-5", aria: true, title: "#{provider} icon" %>
+  <% end %>
+</div>

--- a/app/components/oauth/connect_button_component.rb
+++ b/app/components/oauth/connect_button_component.rb
@@ -1,0 +1,15 @@
+module Oauth
+  class ConnectButtonComponent < ViewComponent::Base
+    with_collection_parameter :provider
+    delegate :omniauth_authorize_path, to: :helpers
+
+    def initialize(provider:, resource_name:)
+      @provider = provider
+      @resource_name = resource_name
+    end
+
+    private
+
+    attr_reader :provider, :resource_name
+  end
+end

--- a/app/views/shared/_omniauth_buttons.html.erb
+++ b/app/views/shared/_omniauth_buttons.html.erb
@@ -1,9 +1,0 @@
-<%= button_to omniauth_authorize_path(resource_name, :github), class: "button button--github oauth-button full-width push-down", data: { test_id: "github-btn" } do %>
-  <i class="fab fa-github mr-2"></i>
-  Github
-<% end %>
-
-<%= button_to omniauth_authorize_path(resource_name, :google), class: "button button--google oauth-button full-width push-down", data: { test_id: "google-btn" } do %>
-  <i class="fab fa-google mr-2"></i>
-  Google
-<% end %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,54 +1,67 @@
-<%= title('Sign Up') %>
+<%= title('Sign up') %>
 
+<div class="bg-gray-50 h-full odin-dark-bg">
+  <div class="page-container">
 
-<div class="container tmp-container-spacer">
-  <div class="col-lg-6 col-md-10 offset-lg-3 offset-md-1">
-    <h1 class="page-heading-title">Sign Up for Free</h1>
-
-    <div class="card-main odin-dark-bg-accent">
-      <%= form_for resource, as: resource_name, url: registration_path(resource_name), builder: TailwindFormBuilder, data: { controller: 'form-validation', action: 'submit->form-validation#validateAll' } do |form| %>
-        <div class="grid grid-cols-6 gap-6">
-          <div class="col-span-6">
-            <%= form.label :username %>
-            <%= form.text_field :username, required: true, autofocus: params[:email].present?, class: 'dark-form-input', data: { test_id: 'username_field', attr: 'form-validation.username', action: 'blur->form-validation#validate' } %>
-          </div>
-
-          <div class="col-span-6">
-            <%= form.label :email %>
-            <%= form.email_field :email, required: true, value: params[:email], class: 'dark-form-input', data: { test_id: 'email_field', attr: 'form-validation.email', action: 'blur->form-validation#validate' } %>
-          </div>
-
-          <div class="col-span-6">
-            <%= form.label :password %>
-            <%= form.password_field :password, required: true, class: 'dark-form-input', data: { test_id: 'password_field', attr: 'form-validation.password', action: 'blur->form-validation#validate' } %>
-          </div>
-
-          <div class="col-span-6">
-            <%= form.label :password_confirmation %>
-            <%= form.password_field :password_confirmation, required: true, class: 'dark-form-input', data: { test_id: 'password_confirmation_field', attr: 'form-validation.password_confirmation', action: 'blur->form-validation#validate' } %>
-          </div>
-
-          <div class="col-span-6 text-center">
-            <%= link_to 'By signing up, you agree to our terms of use.', terms_of_use_path, class: 'font-medium text-gray-600 hover:underline text-sm odin-dark-text' %>
-          </div>
-        </div>
-
-        <div class="form__button-section">
-          <%= form.submit 'Sign up', class: 'button button--primary full-width', data: {test_id: 'submit_btn', disable_with: false } %>
-        </div>
-      <% end %>
-
-      <div class="form-divider text-center">
-        <span class="form-divider__text">OR SIGN UP WITH</span>
-      </div>
-
-      <%= render 'shared/omniauth_buttons' %>
+    <div class="sm:mx-auto sm:w-full sm:max-w-md">
+      <h2 class="mt-6 text-center text-3xl font-bold tracking-tight text-gray-900">Sign up for free</h2>
+      <span class="block mt-2 text-center text-sm text-gray-600 odin-dark-text">
+        Or
+        <%= link_to 'sign in to your existing account', login_path, class: 'font-medium text-gold-600 hover:text-gold-500' %>
+      </span>
     </div>
 
-    <%= render 'shared/bottom_cta',
-      button: login_button,
-      heading: 'Have an account?',
-      sub_heading: ''
-    %>
+    <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+      <%= render CardComponent.new(classes: 'odin-dark-bg-accent') do |card| %>
+        <%= card.body do %>
+          <%= form_for resource, as: resource_name, url: registration_path(resource_name), builder: TailwindFormBuilder, data: { controller: 'form-validation', action: 'submit->form-validation#validateAll' } do |form| %>
+            <div class="space-y-6">
+              <div>
+                <%= form.label :username %>
+                <%= form.text_field :username, required: true, autofocus: params[:email].present?, class: 'dark-form-input', data: { test_id: 'username_field', attr: 'form-validation.username', action: 'blur->form-validation#validate' } %>
+              </div>
+
+              <div>
+                <%= form.label :email %>
+                <%= form.email_field :email, required: true, value: params[:email], class: 'dark-form-input', data: { test_id: 'email_field', attr: 'form-validation.email', action: 'blur->form-validation#validate' } %>
+              </div>
+
+              <div>
+                <%= form.label :password %>
+                <%= form.password_field :password, required: true, class: 'dark-form-input', data: { test_id: 'password_field', attr: 'form-validation.password', action: 'blur->form-validation#validate' } %>
+              </div>
+
+              <div>
+                <%= form.label :password_confirmation %>
+                <%= form.password_field :password_confirmation, required: true, class: 'dark-form-input', data: { test_id: 'password_confirmation_field', attr: 'form-validation.password_confirmation', action: 'blur->form-validation#validate' } %>
+              </div>
+
+              <div class="text-center">
+                <%= link_to 'By signing up, you agree to our terms of use.', terms_of_use_path, class: 'font-medium text-gray-600 hover:underline text-sm odin-dark-text' %>
+              </div>
+
+              <div>
+                <%= form.submit 'Sign up', class: 'button button--primary w-full py-2 px-4 text-sm', data: {test_id: 'submit_btn', disable_with: false } %>
+              </div>
+            </div>
+          <% end %>
+
+          <div class="mt-6">
+            <div class="relative">
+              <div class="absolute inset-0 flex items-center">
+                <div class="w-full border-t border-gray-300"></div>
+              </div>
+              <div class="relative flex justify-center text-sm">
+                <span class="bg-white px-2 text-gray-500 odin-dark-bg-accent odin-dark-text">Or continue with</span>
+              </div>
+            </div>
+          </div>
+
+          <div class="mt-6 grid grid-cols-2 gap-3">
+            <%= render(Oauth::ConnectButtonComponent.with_collection([:github, :google], resource_name: resource_name)) %>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -5,7 +5,7 @@
 
     <div class="sm:mx-auto sm:w-full sm:max-w-md">
       <h2 class="mt-6 text-center text-3xl font-bold tracking-tight text-gray-900">Sign in to your account</h2>
-      <span class="block mt-2 text-center text-sm text-gray-600">
+      <span class="block mt-2 text-center text-sm text-gray-600 odin-dark-text">
         Or
         <%= link_to 'sign up for a new account', sign_up_path, class: 'font-medium text-gold-600 hover:text-gold-500' %>
       </span>
@@ -55,19 +55,7 @@
           </div>
 
           <div class="mt-6 grid grid-cols-2 gap-3">
-            <div>
-              <%= button_to omniauth_authorize_path(resource_name, :github), class: 'button button--clear odin-dark-clear-button w-full py-2 px-4 text-sm font-medium text-gray-500 focus:ring-0', title: "GitHub", data: { test_id: "github-btn" } do %>
-                <span class="sr-only">Sign in with GitHub</span>
-                <%= inline_svg_tag "icons/github.svg", class: "h-5 w-5", aria: true, title: 'GitHub icon' %>
-              <% end %>
-            </div>
-
-            <div>
-              <%= button_to omniauth_authorize_path(resource_name, :google), class: 'button button--clear odin-dark-clear-button w-full py-2 px-4 text-sm font-medium text-gray-500 focus:ring-0', title: "Google", data: { test_id: "google-btn" } do %>
-                <span class="sr-only">Sign in with Google</span>
-                <%= inline_svg_tag "icons/google.svg", class: "h-5 w-5", aria: true, title: 'Google icon' %>
-              <% end %>
-            </div>
+            <%= render(Oauth::ConnectButtonComponent.with_collection([:github, :google], resource_name: resource_name)) %>
           </div>
         <% end %>
       <% end %>

--- a/spec/components/oauth/connect_button_component_spec.rb
+++ b/spec/components/oauth/connect_button_component_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Oauth::ConnectButtonComponent, type: :component do
+  it 'renders a oauth provider connect button' do
+    component = described_class.new(provider: :github, resource_name: 'user')
+
+    render_inline(component)
+
+    expect(page).to have_content('Sign in with Github')
+  end
+end


### PR DESCRIPTION
Because:
* We are moving all of our CSS to Tailwind.
* Closes: https://github.com/TheOdinProject/top-meta/issues/207

This commit:
* Change all styles on the sign up view to use Tailwind classes.
* Refactor oauth buttons shared between sign up/in pages to a single component.
* Remove old shared oauth buttons partial.
* 
<img width="1288" alt="Screenshot 2022-09-23 at 13 48 44" src="https://user-images.githubusercontent.com/7963776/191963849-f9f6db4d-c70e-4001-b284-483c22c5f8c7.png">

