### PR TITLE
Fix: Checkbox styling

### DIFF
--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -28,7 +28,7 @@
 
               <div class="flex items-center justify-between">
                 <div class="flex items-center">
-                  <%= form.check_box :remember_me, checked: true, class: 'text-teal-700 focus:ring-teal-800' %>
+                  <%= form.check_box :remember_me, checked: true, class: 'form-checkbox text-teal-700 focus:ring-teal-800' %>
                   <%= form.label :remember_me, class: 'ml-2 block text-sm text-gray-900 mb-0' %>
                 </div>
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -86,6 +86,7 @@ module.exports = {
       "app/assets/images/icons/*svg",
       "./config/utility_classes.yml",
       "./app/components/**/*.yml",
+      "./app/builders/**/*.rb",
     ],
     options: {
       safelist: ['lesson-note', 'lesson-content__panel', 'anchor-link', 'toc-item-active'],


### PR DESCRIPTION
Because:
* Checkboxes do not have our custom styles applied in production.

This commit:
* The styles in the tailwind form builder were being purged.
