### PR TITLE
Fix: Sign Up Form Height

### DIFF
--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,6 +1,6 @@
 <%= title('Sign up') %>
 
-<div class="bg-gray-50 h-full odin-dark-bg">
+<div class="bg-gray-50 odin-dark-bg">
   <div class="page-container">
 
     <div class="sm:mx-auto sm:w-full sm:max-w-md">


### PR DESCRIPTION
Because:
* The sign up form card  was overflowing into the footer.

This commit:
* Remove h-full utility from sign up page container. It is not needed on this page and causing the overflow issue.