### PR TITLE
Chore: Use Page Container on Notification Index

### DIFF
--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,6 +1,6 @@
 <%= title("Notifications") %>
 
-<div class="container tmp-container-spacer h-full">
+<div class="page-container h-full">
   <h1 class="page-heading-title">Notifications</h1>
   <ul class="space-y-3">
     <% unless @notifications.empty? %>


### PR DESCRIPTION
Because:
* To keep this page consistent with the rest.
