### PR TITLE
Fix: Progress Badge Percentage Visibility

### DIFF
--- a/app/components/progress/badge_component.html.erb
+++ b/app/components/progress/badge_component.html.erb
@@ -6,7 +6,7 @@
       data-progress-percent-value="0"
       data-progress-circumference-value="<%= circumference %>"
       data-progress-loading-value="false"
-      data-progress-loaded-class="opacity-100"
+      data-progress-loading-class="opacity-0"
       data-action="update-progress@window->progress#fetchProgress"
       data-test-id='progress-badge'
       class="inline-flex items-center justify-center group h-24 w-24 sm:h-28 sm:w-28"

--- a/app/javascript/controllers/progress_controller.js
+++ b/app/javascript/controllers/progress_controller.js
@@ -7,7 +7,7 @@ axios.defaults.headers.common['Content-Type'] = 'application/json';
 export default class ProgressController extends Controller {
   static targets = ['percentage', 'progressCircle', 'loading'];
 
-  static classes = ['loaded'];
+  static classes = ['loading'];
 
   static values = {
     url: String,
@@ -33,7 +33,7 @@ export default class ProgressController extends Controller {
       this.loadingValue = false;
       this.percentValue = percentage;
       this.percentageTarget.textContent = `${percentage}% Complete`;
-      this.percentageTarget.classList.add(this.loadedClass);
+      this.percentageTarget.classList.remove(this.loadingClass);
     });
   }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,7 @@ const colors = require('tailwindcss/colors');
 module.exports = {
   content: [
     './app/**/*.html.erb',
-    './app/components/*.html.erb',
+    './app/components/**/*',
     './app/components/*.rb',
     './app/javascript/components/**/*.jsx',
     'app/assets/images/icons/*.svg',


### PR DESCRIPTION
Because:
* We recently upgraded to Tailwind 3 which changes how some things work like class overriding and where Tailwind checks for classes that are used.

This commit:
* Check all view component files for Tailwind classes.
* Remove the opacity-0 instead of overriding it with opacity-100 when the progress badge is loaded.

