### PR TITLE
Fix: Code Blocks in Lesson Panel Background

### DIFF
--- a/app/javascript/stylesheets/lesson-content.css
+++ b/app/javascript/stylesheets/lesson-content.css
@@ -11,6 +11,10 @@
     @apply bg-gray-200;
   }
 
+  .lesson-content__panel pre code {
+    @apply bg-transparent;
+  }
+
   .lesson-note {
     @apply bg-gray-50 p-4 border-l-4 border-gold;
   }


### PR DESCRIPTION
Because:
* It is incorrectly applying a gray background to code blocks in pre tags.

This commit:
* Ensure code blocks within pre elements use the pre element background.

