### PR TITLE
fix: update form input validator to remove errors if appropriate on re-validation

### DIFF
--- a/app/javascript/controllers/form_validation_controller.js
+++ b/app/javascript/controllers/form_validation_controller.js
@@ -38,6 +38,8 @@ export default class FormValidation extends ValidationController {
     if (this.errors.has(attr)) {
       FormValidation.applyErrorStylesTo(el);
       FormValidation.errorMessageEl(el).textContent = this.errorMessage(attr);
+    } else {
+      FormValidation.removeError(el);
     }
   }
 
@@ -59,6 +61,26 @@ export default class FormValidation extends ValidationController {
       'placeholder-red-300',
       'focus:ring-red-500',
       'focus:border-red-500',
+    );
+  }
+
+  static removeError(el) {
+    const errorField = el.parentElement.nextElementSibling;
+    errorField.classList.add('hidden');
+    errorField.textContent = '';
+    el.classList.remove(...el.classList);
+    el.classList.add(
+      'block',
+      'w-full',
+      'border',
+      'rounded-md',
+      'py-2',
+      'px-3',
+      'focus:outline-none',
+      'border-gray-300',
+      'focus:ring-blue-600',
+      'focus:border-blue-600',
+      'dark-form-input',
     );
   }
 }

--- a/app/javascript/controllers/form_validation_controller.js
+++ b/app/javascript/controllers/form_validation_controller.js
@@ -3,6 +3,14 @@ import { Application } from 'stimulus';
 /* eslint-enable */
 import { ValidationController } from 'stimulus-validation';
 
+const invalidFieldClasses = [
+  'border-red-300',
+  'text-red-900',
+  'placeholder-red-300',
+  'focus:ring-red-500',
+  'focus:border-red-500',
+];
+
 export default class FormValidation extends ValidationController {
   static rules = {
     email: { email: { message: '^is not a valid email' } },
@@ -55,33 +63,14 @@ export default class FormValidation extends ValidationController {
   }
 
   static applyErrorStylesTo(el) {
-    el.classList.add(
-      'border-red-300',
-      'text-red-900',
-      'placeholder-red-300',
-      'focus:ring-red-500',
-      'focus:border-red-500',
-    );
+    el.classList.add(...invalidFieldClasses);
   }
 
   static removeError(el) {
     const errorField = el.parentElement.nextElementSibling;
     errorField.classList.add('hidden');
     errorField.textContent = '';
-    el.classList.remove(...el.classList);
-    el.classList.add(
-      'block',
-      'w-full',
-      'border',
-      'rounded-md',
-      'py-2',
-      'px-3',
-      'focus:outline-none',
-      'border-gray-300',
-      'focus:ring-blue-600',
-      'focus:border-blue-600',
-      'dark-form-input',
-    );
+    el.classList.remove(...invalidFieldClasses);
   }
 }
 

--- a/app/javascript/controllers/form_validation_controller.js
+++ b/app/javascript/controllers/form_validation_controller.js
@@ -53,7 +53,7 @@ export default class FormValidation extends ValidationController {
 
   static errorMessageEl(el) {
     const errorField = el.parentElement.nextElementSibling;
-    errorField.classList.remove('hidden');
+    errorField.classList.toggle('hidden');
 
     return errorField;
   }
@@ -68,7 +68,7 @@ export default class FormValidation extends ValidationController {
 
   static removeError(el) {
     const errorField = el.parentElement.nextElementSibling;
-    errorField.classList.add('hidden');
+    errorField.classList.toggle('hidden');
     errorField.textContent = '';
     el.classList.remove(...invalidFieldClasses);
   }

--- a/app/javascript/controllers/form_validation_controller.js
+++ b/app/javascript/controllers/form_validation_controller.js
@@ -53,7 +53,7 @@ export default class FormValidation extends ValidationController {
 
   static errorMessageEl(el) {
     const errorField = el.parentElement.nextElementSibling;
-    errorField.classList.toggle('hidden');
+    errorField.classList.remove('hidden');
 
     return errorField;
   }
@@ -68,7 +68,7 @@ export default class FormValidation extends ValidationController {
 
   static removeError(el) {
     const errorField = el.parentElement.nextElementSibling;
-    errorField.classList.toggle('hidden');
+    errorField.classList.add('hidden');
     errorField.textContent = '';
     el.classList.remove(...invalidFieldClasses);
   }

--- a/spec/system/sign_up_spec.rb
+++ b/spec/system/sign_up_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Sign Up', type: :system do
   end
 
   context 'when invalid' do
-    it 'validates the sign in fields' do
+    it 'validates the sign up fields' do
       find(:test_id, 'username_field').fill_in(with: 'c')
       find(:test_id, 'email_field').fill_in(with: 'codesquad64@')
       find(:test_id, 'password_field').fill_in(with: 'partyparrot128')
@@ -32,6 +32,15 @@ RSpec.describe 'Sign Up', type: :system do
       expect(page).to have_content('is not a valid email')
       expect(page).to have_content('The passwords do not match')
       expect(page).to have_current_path(sign_up_path)
+    end
+
+    it 're-validates sign up fields and updates UI' do
+      find(:test_id, 'email_field').fill_in(with: 'codesquad64@')
+      expect(page).to have_content('is not a valid email')
+
+      find(:test_id, 'email_field').fill_in(with: 'codesquad64@example.com')
+      find(:test_id, 'username_field').fill_in(with: 'needtotriggerblur')
+      expect(page).not_to have_content('is not a valid email')
     end
   end
 

--- a/spec/system/user_login_spec.rb
+++ b/spec/system/user_login_spec.rb
@@ -30,6 +30,19 @@ RSpec.describe 'User login', type: :system do
 
         expect(page).to have_content('is not a valid email')
       end
+
+      it 'removes the message once a user fixes their email address' do
+        visit root_path
+
+        find(:test_id, 'nav-login').click
+
+        find(:test_id, 'email-field').fill_in with: 'aaaaa'
+        expect(page).to have_content('is not a valid email')
+
+        find(:test_id, 'email-field').fill_in with: user.email
+        find(:test_id, 'password-field').click
+        expect(page).not_to have_content('is not a valid email')
+      end
     end
 
     context 'with a password less than 6 characters' do

--- a/spec/system/user_settings_spec.rb
+++ b/spec/system/user_settings_spec.rb
@@ -47,6 +47,19 @@ RSpec.describe 'User Profile', type: :system do
         expect(page).to have_content('is not a valid email')
         expect(page).to have_content('is too short (minimum is 4 characters)')
       end
+
+      it 're-validates and removes the error once a field is corrected' do
+        find(:test_id, 'username-field').fill_in(with: 'zz')
+        find(:test_id, 'email-field').fill_in(with: 'zz')
+        find(:test_id, 'save-profile-btn').click
+
+        expect(page).to have_content('is not a valid email')
+
+        find(:test_id, 'email-field').fill_in(with: 'valid@example.com')
+        find(:test_id, 'save-profile-btn').click
+
+        expect(page).not_to have_content('is not a valid email')
+      end
     end
   end
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable

<hr>

**1. Because:**
Form validation controller was not removing error messages on re-validation after identifying an error which is then corrected by the user.

**2. This PR:**
* Updates `form_validation_controller.js` to remove form errors, and re-adjust input style after validation if there are no errors present in the field.
* Adds re-validation tests to confirm behavior to the following spec files:
  * `sign_up_spec.rb`
  * `user_login_spec.rb`
  * `user_settings_spec.rb`


**3. Additional Information:**
<!-- Any additional information about the PR, such as a link to a Discord discussion, etc. -->
Thread here: https://discord.com/channels/505093832157691914/1026938313610907779
