### PR TITLE
Feature: Add Lookbook and ViewComponent Previews

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ gem 'view_component', '~> 2.74'
 group :development do
   gem 'letter_opener', '~> 1.8'
   gem 'listen', '~> 3.7'
+  gem 'lookbook', '~> 1.1.0'
   gem 'rack-mini-profiler'
   gem 'rubocop', '~> 1.36', require: false
   gem 'rubocop-performance', '~> 1.15', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,8 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    css_parser (1.12.0)
+      addressable
     cuprite (0.14.2)
       capybara (~> 3.0)
       ferrum (~> 0.12.0)
@@ -215,6 +217,8 @@ GEM
       activesupport (>= 5.2)
     hashdiff (1.0.1)
     hashie (3.6.0)
+    htmlbeautifier (1.4.2)
+    htmlentities (4.3.4)
     http (5.1.0)
       addressable (~> 2.8)
       http-cookie (~> 1.0)
@@ -267,6 +271,19 @@ GEM
     loofah (2.19.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
+    lookbook (1.1.1)
+      actioncable
+      activemodel
+      css_parser
+      htmlbeautifier (~> 1.3)
+      htmlentities (~> 4.3.4)
+      listen (~> 3.0)
+      railties (>= 5.0)
+      redcarpet (~> 3.5)
+      rouge (>= 3.26, < 5.0)
+      view_component (~> 2.0)
+      yard (~> 0.9.25)
+      zeitwerk (~> 2.5)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
@@ -389,6 +406,7 @@ GEM
       execjs
       railties (>= 3.2)
       tilt
+    redcarpet (3.5.1)
     redis (5.0.5)
       redis-client (>= 0.9.0)
     redis-client (0.10.0)
@@ -404,6 +422,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     rexml (3.2.5)
+    rouge (4.0.0)
     rspec-core (3.11.0)
       rspec-support (~> 3.11.0)
     rspec-expectations (3.11.1)
@@ -536,6 +555,8 @@ GEM
       rails (>= 3.2.16)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yard (0.9.28)
+      webrick (~> 1.7.0)
     zeitwerk (2.6.1)
 
 PLATFORMS
@@ -567,6 +588,7 @@ DEPENDENCIES
   kramdown (~> 2.4)
   letter_opener (~> 1.8)
   listen (~> 3.7)
+  lookbook (~> 1.1.0)
   net-imap
   net-pop
   net-smtp

--- a/app/views/layouts/component_preview.html.erb
+++ b/app/views/layouts/component_preview.html.erb
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html style="background-color: <%= params.dig(:lookbook, :display, :bg_color) || 'white' %>">
+  <head>
+    <title>
+      Component Previews
+    </title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <%= stylesheet_link_tag 'application_stylesheet', media: 'all' %>
+    <%= stylesheet_pack_tag 'application' %>
+    <%= javascript_pack_tag 'application', 'data-turbo-track': 'reload', defer: true %>
+  </head>
+  <body style="padding: 20px">
+    <div style="
+    margin-left: auto;
+    margin-right: auto;
+    max-width: <%= params.dig(:lookbook, :display, :max_width) || '100%' %>
+  ">
+      <%= yield %>
+      <%= render 'shared/ga' %>
+    </div>
+</html>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -82,4 +82,8 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  # Settings for view component previews https://viewcomponent.org/guide/previews.html
+  config.view_component.preview_paths << Rails.root.join('spec/components/previews')
+  config.view_component.default_preview_layout = 'component_preview'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,10 @@ Rails.application.routes.draw do
     mount Sidekiq::Web => '/sidekiq'
   end
 
+  if Rails.env.development?
+    mount Lookbook::Engine, at: '/lookbook'
+  end
+
   resource :github_webhooks, only: :create, defaults: { formats: :json }
 
   unauthenticated do

--- a/spec/components/previews/about_page/belief_component_preview.rb
+++ b/spec/components/previews/about_page/belief_component_preview.rb
@@ -1,0 +1,11 @@
+module AboutPage
+  class BeliefComponentPreview < ViewComponent::Preview
+    def with_about_page_collection
+      render(BeliefComponent.with_collection(I18n.t('static_pages.about.beliefs')))
+    end
+
+    def with_contributing_page_collection
+      render(BeliefComponent.with_collection(I18n.t('static_pages.contributing.benefits')))
+    end
+  end
+end

--- a/spec/components/previews/announcement_component_preview.rb
+++ b/spec/components/previews/announcement_component_preview.rb
@@ -1,0 +1,18 @@
+class AnnouncementComponentPreview < ViewComponent::Preview
+  # @param message [String] text "The text to display in the announcement"
+  def with_announcment(message: 'Hello!')
+    render(AnnouncementComponent.new(announcement: default_announcment(message:)))
+  end
+
+  private
+
+  def default_announcment(**opts)
+    defaults = {
+      expires_at: DateTime.tomorrow,
+      user_id: 1,
+      message: opts[:message]
+    }
+
+    Announcement.new(defaults)
+  end
+end

--- a/spec/components/previews/complete/button_component_preview.rb
+++ b/spec/components/previews/complete/button_component_preview.rb
@@ -1,0 +1,7 @@
+module Complete
+  class ButtonComponentPreview < ViewComponent::Preview
+    def default
+      render(ButtonComponent.new(lesson: Lesson.first, current_user: User.first))
+    end
+  end
+end

--- a/spec/components/previews/complete/icon_component_preview.rb
+++ b/spec/components/previews/complete/icon_component_preview.rb
@@ -1,0 +1,7 @@
+module Complete
+  class IconComponentPreview < ViewComponent::Preview
+    def default
+      render(IconComponent.new(lesson: Lesson.first, current_user: User.first))
+    end
+  end
+end

--- a/spec/components/previews/flash_component_preview.rb
+++ b/spec/components/previews/flash_component_preview.rb
@@ -1,0 +1,11 @@
+# @hidden
+# Not currently working, need to figure out how to pass helpers to the context
+class FlashComponentPreview < ViewComponent::Preview
+  def alert
+    render(Alerts::FlashComponent.new(type: :alert, message: 'Alert!'))
+  end
+
+  def notice
+    render(Alerts::FlashComponent.new(type: :notice, message: 'Notice!'))
+  end
+end

--- a/spec/components/previews/lessons/title_link_component_preview.rb
+++ b/spec/components/previews/lessons/title_link_component_preview.rb
@@ -1,0 +1,18 @@
+module Lessons
+  class TitleLinkComponentPreview < ViewComponent::Preview
+    def with_lesson
+      render(TitleLinkComponent.new(lesson: Lesson.first, lesson_number: 1))
+    end
+
+    def with_project
+      render(TitleLinkComponent.new(lesson: Lesson.find(22), lesson_number: 22))
+    end
+
+    # @param lesson_id
+    # @param lesson_number
+    def with_param(lesson_id: 2, lesson_number: 2)
+      lesson = Lesson.find_by(id: lesson_id) || Lesson.first
+      render(TitleLinkComponent.new(lesson:, lesson_number:))
+    end
+  end
+end

--- a/spec/components/previews/paths/select_button_component_preview.rb
+++ b/spec/components/previews/paths/select_button_component_preview.rb
@@ -1,0 +1,7 @@
+module Paths
+  class SelectButtonComponentPreview < ViewComponent::Preview
+    def default
+      render(SelectButtonComponent.new(current_user: User.first, path: Path.first))
+    end
+  end
+end


### PR DESCRIPTION
**Because:**
  - It provides a nice visual interface for testing, designing and otherwise interacting with ViewComponents

**This Commit:**
  - Adds lookbook gem
  - Adds config for ViewComponent previews
  - Adds several previews for individual components

**Notes**
- This PR is intended as a proof of concept / spike to see if this feature would be useful. There's a lot of places it could be polished improved, such as adding move variants to previews, mproving the default layout and adding the entire component library.
- Components with helpers are slightly harder to get working, although likely not impossible. Currently the Flash Preview is broken because it relies on a helper. 
- Adding more previews could be a good Hacktoberfest contribution for people midway+ through Rails
- I explored using [Storybook](https://storybook.js.org/), but Lookbook was significantly easier to implement for seemingly no tradeoff

**Additional Information**
- [Preview Docs](https://viewcomponent.org/guide/previews.html)
- Previews are a default ViewComponent feature that simply require a little bit of boilerplate / setup. They function very similar to mailer previews, and can be seen at `http://localhost:3000/rails/view_components/` by default.

![image](https://user-images.githubusercontent.com/58506115/194022536-4651e044-5edd-401b-8280-4c40abd7e6d8.png)

- [Lookbook Docs](https://lookbook.build/)
- Lookbook is a gem that provides a much nicer interface for looking at previews. It's also possible to see the HTML of a rendered component, or to pass in parameters dynamically. It can be found in development at `http://localhost:3000/lookbook/`

![image](https://user-images.githubusercontent.com/58506115/194022948-fd2fb38b-b101-46bc-8502-54de220024a3.png)

