### PR TITLE
Chore: Move Allowed Theme Behaviour into Theme Value Object

### DIFF
--- a/app/controllers/themes_controller.rb
+++ b/app/controllers/themes_controller.rb
@@ -1,10 +1,8 @@
 class ThemesController < ApplicationController
-  ALLOWED_THEMES = %w[light dark].freeze
-
   def update
     theme = params[:theme]
 
-    if ALLOWED_THEMES.include?(theme)
+    if Users::Theme.exists?(theme)
       change_current_theme(theme)
 
       respond_to do |format|
@@ -12,7 +10,7 @@ class ThemesController < ApplicationController
         format.turbo_stream
       end
     else
-      redirect_back(fallback_location: root_path, alert: 'Sorry, that theme is not allowed.', status: :see_other)
+      redirect_back(fallback_location: root_path, alert: "Sorry, we can't find that theme.", status: :see_other)
     end
   end
 end

--- a/app/models/users/theme.rb
+++ b/app/models/users/theme.rb
@@ -11,6 +11,10 @@ module Users
       DEFAULT_THEMES.map { |name, icon| new(name:, icon:) }
     end
 
+    def self.exists?(theme)
+      all.map(&:name).include?(theme)
+    end
+
     def self.for(value)
       all.find { |theme| theme.name == value }
     end

--- a/spec/models/users/theme_spec.rb
+++ b/spec/models/users/theme_spec.rb
@@ -10,6 +10,20 @@ RSpec.describe Users::Theme do
     end
   end
 
+  describe '.exists?' do
+    context 'when the theme exists' do
+      it 'returns true' do
+        expect(described_class.exists?('light')).to be true
+      end
+    end
+
+    context 'when the theme does not exist' do
+      it 'returns false' do
+        expect(described_class.exists?('foo')).to be false
+      end
+    end
+  end
+
   describe '.for' do
     it 'returns the theme for the given name' do
       expect(described_class.for('dark')).to have_attributes(name: 'dark', icon: 'moon')


### PR DESCRIPTION
Because:
* We had the theme names duplicated in the themes controller.

This commit:
* Adds an exists? method to the theme value object
* Refactor the themes controller to check if the theme exists or return an appropriate alert if it does not.
