### PR TITLE
Fix: Long usernames overflowing in profile card

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -7,7 +7,7 @@
       <% card.body do %>
         <div class="flex items-center flex-col md:flex-row gap-4">
           <%= render User::AvatarComponent.new(current_user: current_user, classes: " w-24") %>
-          <h2 class="basis-3/5 text-2xl pl-4" data-test-id="profile_username"><%= current_user.username %></h2>
+          <h2 class="truncate w-full basis-3/5 text-2xl md:pl-4" data-test-id="profile_username"><%= current_user.username %></h2>
           <p data-test-id='learning_goal'><%= display_dashboard_learning_goal(current_user).html_safe %></p>
         </div>
       <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -7,7 +7,7 @@
       <% card.body do %>
         <div class="flex items-center flex-col md:flex-row gap-4">
           <%= render User::AvatarComponent.new(current_user: current_user, classes: " w-24") %>
-          <h2 class="truncate w-full basis-3/5 text-2xl md:pl-4" data-test-id="profile_username"><%= current_user.username %></h2>
+          <h2 class="truncate w-full basis-3/5 text-2xl text-center md:text-left md:pl-4" data-test-id="profile_username"><%= current_user.username %></h2>
           <p data-test-id='learning_goal'><%= display_dashboard_learning_goal(current_user).html_safe %></p>
         </div>
       <% end %>


### PR DESCRIPTION
Complete the following REQUIRED checkboxes:
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable

<hr>

**1. Because:**

Currently, long usernames are overflowing the profile card and student solutions.


**2. This PR:**

- Fix username overflowing in profile card by usage of truncate
- Fix username overflowing in profile card when resizing the window by setting h2 to 100% of the container's width
- Fix username padding when resizing the window so the text is centered

**3. Additional Information:**

I was assigned to fix #3362 but I noticed that the profile card also ran into the same issue, so I decided to fix this one first.
This is my first contribution towards the main TOP repository, I was not familiar with the code base at all, so I may have made some mistakes, excuse me if so. Please if possible give me some feedback! Below I attached images of both before and after of each commit :+1: 

First commit (9d3e5f8) : [Before](https://user-images.githubusercontent.com/112586034/194523363-4a6de58c-61f1-445e-afaa-eaa199f1600c.png) | [After](https://user-images.githubusercontent.com/112586034/194523407-290a8db4-f403-4c3a-810b-c1c44d148e38.png)

Second commit (55495eb) : [Before](https://user-images.githubusercontent.com/112586034/194524677-41da9be1-49b9-4e6e-9de7-b0a5a9549fd4.png) | [After](https://user-images.githubusercontent.com/112586034/194524687-3e0985be-3977-4bee-a332-543be2deca5d.png)

Third commit (12eccad) : [Before](https://user-images.githubusercontent.com/112586034/194524277-a96a95a6-9fb0-459c-9a3c-27deeea40620.png) | [After](https://user-images.githubusercontent.com/112586034/194524289-3aed5244-0cdf-4735-bb48-6d103c8b7879.png)



