### PR TITLE
Chore: Remove Tmp Containers

### DIFF
--- a/app/javascript/stylesheets/layout.css
+++ b/app/javascript/stylesheets/layout.css
@@ -1,17 +1,5 @@
 @layer components {
-  .tmp-container-spacer {
-    @apply py-16 sm:pt-24 sm:pb-32;
-  }
-
   .page-container {
     @apply max-w-7xl mx-auto py-10 px-4 sm:py-14 sm:px-6 lg:px-8;
-  }
-
-  .content-container {
-    @apply max-w-screen-md mx-auto py-16 px-4 sm:pt-24 sm:pb-32 sm:px-6 lg:px-8;
-  }
-
-  .content-container-lg {
-    @apply max-w-screen-lg mx-auto py-16 px-4 sm:pt-24 sm:pb-32 sm:px-6 lg:px-8;
   }
 }

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -1,14 +1,16 @@
 <%= title(@course.title) %>
 
 <div class="gradient odin-dark-bg">
-  <div class="content-container">
-    <%= render 'courses/course/banner', course: @course %>
+  <div class="page-container">
+    <div class="max-w-3xl mx-auto">
+      <%= render 'courses/course/banner', course: @course %>
 
-    <div class="mb-6">
-      <h2 class="text-xl font-semibold text-gray-500">Overview</h2>
-      <p class="text-gray-500"><%= @course.description %></p>
+      <div class="mb-6">
+        <h2 class="text-xl font-semibold text-gray-500">Overview</h2>
+        <p class="text-gray-500"><%= @course.description %></p>
+      </div>
+
+      <%= render @sections, locals: { course: @course } %>
     </div>
-
-    <%= render @sections, locals: { course: @course } %>
   </div>
 </div>

--- a/app/views/lessons/installation_lessons/index.html.erb
+++ b/app/views/lessons/installation_lessons/index.html.erb
@@ -1,6 +1,6 @@
 <%= title('Installation Lessons Appendix') %>
 
-<div class="h-full tmp-container-spacer">
+<div class="page-container h-full">
   <h1 class="page-heading-title text-center">Installation Lessons Appendix</h1>
   <ul>
     <% @lessons.each do |lesson|%>

--- a/app/views/lessons/project_submissions/index.html.erb
+++ b/app/views/lessons/project_submissions/index.html.erb
@@ -1,20 +1,17 @@
 <%= title(@lesson.title) %>
 
-<div class="tmp-container-spacer">
-  <div class="grid grid-cols-12">
-    <div class="col-span-12 md:col-start-3 md:col-span-8">
-      <%= react_component(
-          "project-submissions/index",
-          {
-            userId: current_user&.id,
-            course: @lesson.course.as_json,
-            lesson: @lesson.as_json,
-            submissions: @project_submissions.map { |submission| ProjectSubmissionSerializer.as_json(submission, current_user) },
-            userSubmission: @user_submission
-          }
-        ) %>
-
-      <%== pagy_nav(@pagy) %>
-    </div>
+<div class="page-container">
+  <%= react_component(
+      "project-submissions/index",
+      {
+        userId: current_user&.id,
+        course: @lesson.course.as_json,
+        lesson: @lesson.as_json,
+        submissions: @project_submissions.map { |submission| ProjectSubmissionSerializer.as_json(submission, current_user) },
+        userSubmission: @user_submission
+      }
+    ) %>
+  <div class="text-center">
+    <%== pagy_nav(@pagy) %>
   </div>
 </div>

--- a/app/views/paths/index.html.erb
+++ b/app/views/paths/index.html.erb
@@ -1,83 +1,84 @@
 <%= title("All Paths") %>
 
-<div class="content-container-lg">
-  <h1 class="page-heading-title">All Paths</h1>
+<div class="page-container">
+  <div class="max-w-4xl mx-auto">
+    <h1 class="page-heading-title">All Paths</h1>
 
-  <%= render CardComponent.new(classes: 'odin-dark-bg-accent') do |card| %>
-    <% card.header(classes: 'flex justify-between items-center flex-col sm:flex-row space-y-4 sm:space-y-0') do %>
-      <div class="flex flex-col space-y-5 sm:space-x-6 sm:space-y-0 sm:flex-row items-center">
-        <%= link_to path_path(@foundations) do %>
-          <%= image_tag @foundations.badge_uri, alt: "#{@foundations.title} badge", class: 'w-24 h-24' %>
-        <% end %>
-        <div class="flex items-center flex-col sm:block">
-          <h3 class="text-1xl mb-1 text-gold-600">START HERE</h3>
-          <%= link_to path_path(@foundations), class: "no-underline" do %>
-            <h2 class="text-3xl font-semibold">Foundations</h2>
+    <%= render CardComponent.new(classes: 'odin-dark-bg-accent') do |card| %>
+      <% card.header(classes: 'flex justify-between items-center flex-col sm:flex-row space-y-4 sm:space-y-0') do %>
+        <div class="flex flex-col space-y-5 sm:space-x-6 sm:space-y-0 sm:flex-row items-center">
+          <%= link_to path_path(@foundations) do %>
+            <%= image_tag @foundations.badge_uri, alt: "#{@foundations.title} badge", class: 'w-24 h-24' %>
           <% end %>
+          <div class="flex items-center flex-col sm:block">
+            <h3 class="text-1xl mb-1 text-gold-600">START HERE</h3>
+            <%= link_to path_path(@foundations), class: "no-underline" do %>
+              <h2 class="text-3xl font-semibold">Foundations</h2>
+            <% end %>
+          </div>
         </div>
-      </div>
 
-      <div class="space-x-6 justify-center hidden md:flex">
-        <%= render Paths::SelectButtonComponent.new(current_user: current_user, path: @foundations, classes: 'px-12')%>
-        <%= render Paths::ViewButtonComponent.new(current_user: current_user, path: @foundations, classes: 'px-12') %>
-      </div>
-    <% end %>
-
-    <% card.body do %>
-      <p class="text-gray-700 leading-normal text-base"><%= @foundations.description %></p>
-    <% end %>
-
-    <% card.footer do |card| %>
-      <div class="flex space-x-6 justify-center sm:items-center sm:justify-start md:hidden">
-        <%= render Paths::SelectButtonComponent.new(current_user: current_user, path: @foundations, classes: 'px-10')%>
-        <%= render Paths::ViewButtonComponent.new(current_user: current_user, path: @foundations, classes: 'px-10') %>
-      </div>
-    <% end %>
-  <% end %>
-
-  <div class="relative mb-10 mt-10">
-    <div class="absolute inset-0 flex items-center" aria-hidden="true">
-      <div class="w-full border-t border-gray-300"></div>
-    </div>
-    <div class="relative flex justify-center">
-      <span class="px-3 bg-white text-2xl font-semibold text-gray-900 odin-dark-bg odin-dark-text"> Then choose a learning path:</span>
-    </div>
-  </div>
-
-  <div class="flex gap-x-10 gap-y-6 flex-col md:flex-row">
-    <% @fullstack_paths.each do |path| %>
-
-      <%= render CardComponent.new(classes: 'flex flex-col odin-dark-bg-accent') do |card| %>
-        <% card.header(classes: 'flex flex-col justify-between items-center') do %>
-          <%= link_to path_path(path) do %>
-            <%= image_tag path.badge_uri, alt: "#{path.title} badge", class: 'w-28 h-28' %>
-          <% end %>
-
-          <div class="w-full flex justify-between pt-6">
-            <p class="text-lg text-gold-600">PATH</p>
-            <p class="text-lg text-gray-500"><%= path.courses.size %> Courses</p>
-          </div>
-        <% end %>
-
-        <% card.body(classes: "flex-grow") do %>
-          <%= link_to path_path(path), class: "no-underline" do %>
-            <h2 class="text-2xl font-semibold pb-4">
-              <%= path.title %>
-            </h2>
-          <% end %>
-
-          <p class="text-gray-700 leading-normal text-base">
-            <%= path.description %>
-          </p>
-        <% end %>
-
-        <% card.footer do %>
-          <div class="flex space-x-6 items-center justify-center sm:justify-start">
-            <%= render Paths::SelectButtonComponent.new(current_user: current_user, path: path, classes: 'px-10 lg:px-12') %>
-            <%= render Paths::ViewButtonComponent.new(current_user: current_user, path: path, classes: 'px-10 lg:px-12') %>
-          </div>
-        <% end %>
+        <div class="space-x-6 justify-center hidden md:flex">
+          <%= render Paths::SelectButtonComponent.new(current_user: current_user, path: @foundations, classes: 'px-12')%>
+          <%= render Paths::ViewButtonComponent.new(current_user: current_user, path: @foundations, classes: 'px-12') %>
+        </div>
       <% end %>
-    <% end%>
-  </div>
+
+      <% card.body do %>
+        <p class="text-gray-700 leading-normal text-base"><%= @foundations.description %></p>
+      <% end %>
+
+      <% card.footer do |card| %>
+        <div class="flex space-x-6 justify-center sm:items-center sm:justify-start md:hidden">
+          <%= render Paths::SelectButtonComponent.new(current_user: current_user, path: @foundations, classes: 'px-10')%>
+          <%= render Paths::ViewButtonComponent.new(current_user: current_user, path: @foundations, classes: 'px-10') %>
+        </div>
+      <% end %>
+    <% end %>
+
+    <div class="relative mb-10 mt-10">
+      <div class="absolute inset-0 flex items-center" aria-hidden="true">
+        <div class="w-full border-t border-gray-300"></div>
+      </div>
+      <div class="relative flex justify-center">
+        <span class="px-3 bg-white text-2xl font-semibold text-gray-900 odin-dark-bg odin-dark-text"> Then choose a learning path:</span>
+      </div>
+    </div>
+
+    <div class="flex gap-x-10 gap-y-6 flex-col md:flex-row">
+      <% @fullstack_paths.each do |path| %>
+
+        <%= render CardComponent.new(classes: 'flex flex-col odin-dark-bg-accent') do |card| %>
+          <% card.header(classes: 'flex flex-col justify-between items-center') do %>
+            <%= link_to path_path(path) do %>
+              <%= image_tag path.badge_uri, alt: "#{path.title} badge", class: 'w-28 h-28' %>
+            <% end %>
+
+            <div class="w-full flex justify-between pt-6">
+              <p class="text-lg text-gold-600">PATH</p>
+              <p class="text-lg text-gray-500"><%= path.courses.size %> Courses</p>
+            </div>
+          <% end %>
+
+          <% card.body(classes: "flex-grow") do %>
+            <%= link_to path_path(path), class: "no-underline" do %>
+              <h2 class="text-2xl font-semibold pb-4">
+                <%= path.title %>
+              </h2>
+            <% end %>
+
+            <p class="text-gray-700 leading-normal text-base">
+              <%= path.description %>
+            </p>
+          <% end %>
+
+          <% card.footer do %>
+            <div class="flex space-x-6 items-center justify-center sm:justify-start">
+              <%= render Paths::SelectButtonComponent.new(current_user: current_user, path: path, classes: 'px-10 lg:px-12') %>
+              <%= render Paths::ViewButtonComponent.new(current_user: current_user, path: path, classes: 'px-10 lg:px-12') %>
+            </div>
+          <% end %>
+        <% end %>
+      <% end%>
+    </div>
 </div>

--- a/app/views/paths/show.html.erb
+++ b/app/views/paths/show.html.erb
@@ -1,28 +1,31 @@
 <%= title(@path.title) %>
 
-<div class="content-container-lg">
-  <section class="flex flex-col justify-between items-start space-y-8 mb-12 md:flex-row md:items-center md:space-y-0">
-    <div>
-      <h1 class="page-heading-title text-left m-0"><%= @path.title %></h1>
-      <p class="text-left max-w-lg lg:max-w-xl"><%= @path.description %></p>
-    </div>
+<div class="page-container">
+  <div class="max-w-4xl mx-auto">
 
-    <% if current_user&.path != @path %>
-      <%= button_to 'Select Path', users_paths_path(path_id: @path.id), class: 'button button--secondary', remote: false, method: :post, data: { disable_with: 'Selecting...', test_id: "#{@path.title.downcase}-select-path-btn" } %>
-    <% else %>
-      <%= button_to 'Selected Path', "", class: 'button button--disabled', disabled: true %>
+    <section class="flex flex-col justify-between items-start space-y-8 mb-12 md:flex-row md:items-center md:space-y-0">
+      <div>
+        <h1 class="page-heading-title text-left m-0"><%= @path.title %></h1>
+        <p class="text-left max-w-lg lg:max-w-xl"><%= @path.description %></p>
+      </div>
+
+      <% if current_user&.path != @path %>
+        <%= button_to 'Select Path', users_paths_path(path_id: @path.id), class: 'button button--secondary', remote: false, method: :post, data: { disable_with: 'Selecting...', test_id: "#{@path.title.downcase}-select-path-btn" } %>
+      <% else %>
+        <%= button_to 'Selected Path', "", class: 'button button--disabled', disabled: true %>
+      <% end %>
+    </section>
+
+    <%= render @path.courses %>
+
+    <% unless user_signed_in? %>
+      <p class="text-center path-description">
+        <%= render 'shared/bottom_cta',
+          button: sign_in_or_view_curriculum_button,
+          heading: 'Start learning for free now!',
+          sub_heading: ''
+        %>
+      </p>
     <% end %>
-  </section>
-
-  <%= render @path.courses %>
-
-  <% unless user_signed_in? %>
-    <p class="text-center path-description">
-      <%= render 'shared/bottom_cta',
-        button: sign_in_or_view_curriculum_button,
-        heading: 'Start learning for free now!',
-        sub_heading: ''
-      %>
-    </p>
-  <% end %>
+  </div>
 </div>

--- a/app/views/static_pages/faq.html.erb
+++ b/app/views/static_pages/faq.html.erb
@@ -1,6 +1,6 @@
 <%= title('FAQ') %>
 
-<div class="content-container-lg w-full">
+<div class="page-container">
   <h1 class="page-heading-title">Frequently Asked Questions</h1>
   <div class="max-w-7xl mx-auto py-12 px-4 sm:py-16 sm:px-6 lg:px-8">
     <div class="max-w-3xl mx-auto divide-y-2 divide-gray-200">

--- a/app/views/static_pages/terms_of_use.html.erb
+++ b/app/views/static_pages/terms_of_use.html.erb
@@ -1,6 +1,6 @@
 <%= title('Terms of Use') %>
 
-<div class="content-container">
+<div class="page-container">
   <h1 class="page-heading-title">Terms of Use</h1>
   <div class="prose prose-lg prose-slate prose-a:text-gold-600 max-w-prose mx-auto">
     <h3 id="introduction">Introduction</h3>


### PR DESCRIPTION
Because:
* Now that all pages have been switched over to Tailwind, we should use only one page-container across the site to keep all pages consistent.

Closes: https://github.com/TheOdinProject/top-meta/issues/238

This commit:
* Remove .tmp-container-spacer utility class
* Remove and replace content containers with page containers and explicit max widths
