### PR TITLE
Fix: Flip order of PR checklist and details

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,33 +1,36 @@
-<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->
+<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->
 
-Complete the following REQUIRED checkboxes:
-<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
--   [ ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
--   [ ] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
-  - `Feature` - adds new or amends existing user-facing behaviour
-  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
-  - `Fix` - bug fixes
+## Because
+<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
 
-Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
--   [ ] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable
 
-<hr>
+## This PR
+<!-- A bullet point list of one or more items describing the specific changes. -->
 
-**1. Because:**
+
+## Issue
 <!--
-If this PR closes an open issue, replace the XXXXX below with the issue number, e.g. Closes #2013. Or if the issue is in another TOP repo replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX
+If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.
 
-Otherwise, provide a clear and concise reason for your pull request, e.g. what problem it solves or what benefit it provides. If this PR is related to, but does not close, another issue or PR, you can also link it as above without the 'Closes' keyword, e.g. "Related to #2013".
- -->
+If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX
+
+If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
+-->
 Closes #XXXXX
 
-
-**2. This PR:**
-<!--
-A bullet point list of one or more items outlining what was done in this PR to solve the problem(s) or implement the feature/enhancement.
- -->
+## Additional Information
+<!-- Any other information about this PR, such as a link to a Discord discussion. -->
 
 
-**3. Additional Information:**
-<!-- Any additional information about the PR, such as a link to a Discord discussion, etc. -->
-
+## Pull Request Requirements
+<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. Or after you create the PR, they will become checkboxes that you can click on. -->
+-   [ ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
+-   [ ] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
+  - `Feature` - adds new or amends existing user-facing behavior
+  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
+  - `Fix` - bug fixes
+-   [ ] The `Because` section summarizes the reason for this PR
+-   [ ] The `This PR` section has a bullet point list describing the changes in this PR
+-   [ ] I have verified all tests and linters pass after making these changes.
+-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
+-   [ ] If applicable, this PR includes new or updated automated tests

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,7 @@ Closes #XXXXX
 
 
 ## Pull Request Requirements
-<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. Or after you create the PR, they will become checkboxes that you can click on. -->
+<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
 -   [ ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
 -   [ ] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
   - `Feature` - adds new or amends existing user-facing behavior


### PR DESCRIPTION
Because
If the details are first, they are viewable in Discord's webhook

This PR
* Moves the detail sections to the beginning of the template
* Moves the checklist section to the end of the template
* Adds an issue section to link the issue
* Adds the Because, This PR, and Issue sections to checklist
* Reduce wording that is not essential

Additional Information:
Related to https://github.com/TheOdinProject/curriculum/pull/24779

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [ ] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable
