### PR TITLE
Fix: Inline code blocks not using correct colour

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -23,7 +23,7 @@ module.exports = {
         DEFAULT: {
           css: {
             code: {
-              color: theme('colors.pink'),
+              color: theme('colors.pink.500'),
               backgroundColor: theme('colors.slate.100'),
               padding: '3px',
               'font-weight': 'normal',


### PR DESCRIPTION
**Because:**
* They should be pink

**This Commit:**
* Adds the correct colour to the Tailwind config file, which was missing a weight
* Closes #3397

**Additional Information:**

Seems to be a rule in `app/javascript/stylesheets/lesson-content.css`, but it's only targeting children of `a` elements. Unsure where the pink was coming from before :shrug: 

```css
  .lesson-content a > code {
    @apply text-pink-500;
  }
  ```