### PR TITLE
Chore: Move lesson contents to new table (#3423)

### DIFF
--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -1,0 +1,5 @@
+class Content < ApplicationRecord
+  belongs_to :lesson
+
+  validates :body, presence: true
+end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -6,6 +6,7 @@ class Lesson < ApplicationRecord
   belongs_to :section
   has_one :course, through: :section
   has_one :path, through: :course
+  has_one :content, dependent: :destroy
   has_many :project_submissions, dependent: :destroy
   has_many :lesson_completions, dependent: :destroy
   has_many :completing_users, through: :lesson_completions, source: :user
@@ -14,6 +15,8 @@ class Lesson < ApplicationRecord
   scope :installation_lessons, -> { where(installation_lesson: true) }
 
   validates :position, presence: true
+
+  delegate :body, to: :content
 
   def position_in_section
     section_lessons.where('position <= ?', position).count

--- a/app/services/lesson_content_importer.rb
+++ b/app/services/lesson_content_importer.rb
@@ -1,9 +1,10 @@
 class LessonContentImporter
-  attr_reader :lesson
-  private :lesson
+  attr_reader :lesson, :content
+  private :lesson, :content
 
   def initialize(lesson)
     @lesson = lesson
+    @content = lesson.content || lesson.build_content
   end
 
   def self.for(lesson)
@@ -24,7 +25,7 @@ class LessonContentImporter
   end
 
   def import
-    lesson.update!(content: content_converted_to_html) if content_needs_updated?
+    content.update!(body: content_converted_to_html) if content_needs_updated?
   rescue Octokit::Error => e
     log_error(e.message)
   end
@@ -32,7 +33,7 @@ class LessonContentImporter
   private
 
   def content_needs_updated?
-    lesson.content != content_converted_to_html
+    content.body != content_converted_to_html
   end
 
   def content_converted_to_html

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -8,7 +8,7 @@
     <main class="grid grid-cols-12 gap-x-6" data-controller="lesson-toc" data-lesson-toc-item-classes-value="no-underline hover:text-gray-800 text-sm dark:hover:text-gray-300">
       <article class="col-span-full xl:col-span-7 xl:col-start-2">
         <%= render ContentContainerComponent.new(classes: 'xl:mx-0', data_attributes: { lesson_toc_target: 'lessonContent' }) do %>
-          <%= @lesson.content.html_safe %>
+          <%= @lesson.body.html_safe %>
         <% end %>
       </article>
 

--- a/db/migrate/20221014124812_create_contents.rb
+++ b/db/migrate/20221014124812_create_contents.rb
@@ -1,0 +1,9 @@
+class CreateContents < ActiveRecord::Migration[6.1]
+  def change
+    create_table :contents do |t|
+      t.text :body, null: false
+      t.belongs_to :lesson, foreign_key: true, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20221014130631_remove_content_from_lessons.rb
+++ b/db/migrate/20221014130631_remove_content_from_lessons.rb
@@ -1,0 +1,5 @@
+class RemoveContentFromLessons < ActiveRecord::Migration[6.1]
+  def change
+    remove_columns :lessons, :content, type: :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -40,6 +40,14 @@ ActiveRecord::Schema.define(version: 2022_10_21_183414) do
     t.index ["user_id"], name: "index_announcements_on_user_id"
   end
 
+  create_table "contents", force: :cascade do |t|
+    t.text "body", null: false
+    t.bigint "lesson_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["lesson_id"], name: "index_contents_on_lesson_id"
+  end
+
   create_table "courses", id: :serial, force: :cascade do |t|
     t.string "title", limit: 255
     t.text "description"
@@ -111,7 +119,6 @@ ActiveRecord::Schema.define(version: 2022_10_21_183414) do
     t.integer "section_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "content"
     t.string "slug"
     t.boolean "accepts_submission", default: false, null: false
     t.boolean "has_live_preview", default: false, null: false
@@ -262,6 +269,7 @@ ActiveRecord::Schema.define(version: 2022_10_21_183414) do
   end
 
   add_foreign_key "announcements", "users"
+  add_foreign_key "contents", "lessons"
   add_foreign_key "flags", "project_submissions"
   add_foreign_key "flags", "users", column: "flagger_id"
   add_foreign_key "lesson_completions", "lessons", on_delete: :cascade

--- a/spec/factories/contents.rb
+++ b/spec/factories/contents.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :content do
+    lesson
+    body { 'content' }
+  end
+end

--- a/spec/factories/lessons.rb
+++ b/spec/factories/lessons.rb
@@ -4,13 +4,19 @@ FactoryBot.define do
     sequence(:title) { |n| "test lesson#{n}" }
     sequence(:position) { |n| n }
     github_path { '/lesson_course/lesson_title.md' }
-    content { 'content' }
     identifier_uuid { SecureRandom.uuid }
 
     trait :project do
       is_project { true }
       accepts_submission { true }
       has_live_preview { true }
+    end
+
+    after(:create) do |lesson|
+      if lesson.content.blank?
+        create(:content, lesson:)
+        lesson.reload
+      end
     end
   end
 end

--- a/spec/models/content_spec.rb
+++ b/spec/models/content_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe Content do
+  it { is_expected.to belong_to(:lesson) }
+  it { is_expected.to validate_presence_of(:body) }
+end

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Lesson do
 
   it { is_expected.to belong_to(:section) }
   it { is_expected.to have_one(:course).through(:section) }
+  it { is_expected.to have_one(:content) }
   it { is_expected.to have_many(:project_submissions) }
   it { is_expected.to have_many(:lesson_completions) }
   it { is_expected.to have_many(:completing_users).through(:lesson_completions) }

--- a/spec/services/lesson_content_importer_spec.rb
+++ b/spec/services/lesson_content_importer_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe LessonContentImporter do
   subject(:importer) { described_class.new(lesson) }
 
   let(:lesson) do
-    create(:lesson, content: lesson_content, title: 'Ruby Basics', github_path: '/ruby_basics/variables')
+    create(:lesson, title: 'Ruby Basics', github_path: '/ruby_basics/variables',
+                    content: create(:content, body: lesson_content))
   end
 
   let(:lesson_content) { "<p>Hello World</p>\n" }
@@ -33,14 +34,14 @@ RSpec.describe LessonContentImporter do
 
   describe '#import' do
     it 'updates the lesson content' do
-      expect { importer.import }.to change { lesson.reload.content }.to("<p>Hello World!</p>\n")
+      expect { importer.import }.to change { lesson.content.reload.body }.to("<p>Hello World!</p>\n")
     end
 
     context 'when lesson content is the same as the github content' do
       let(:decoded_lesson_content) { 'Hello World' }
 
       it 'does not update the lesson content' do
-        expect { importer.import }.not_to change { lesson.reload.content }
+        expect { importer.import }.not_to change { lesson.content.reload.body }
       end
     end
 


### PR DESCRIPTION
**Because:**
* It avoids an expensive operation when it is not needed
* Spike for / closes #3423

**This commit:**
* Remove content column from lesson
* Create new content table
* Update lesson importer to point to new table
* Beat Factory Bot into submission
