### PR TITLE
Chore: Content Container Component

### DIFF
--- a/app/components/content_container_component.html.erb
+++ b/app/components/content_container_component.html.erb
@@ -1,0 +1,3 @@
+ <div class="lesson-content max-w-prose mx-auto prose prose-lg prose-gray prose-a:text-gold-600 prose-code:bg-gray-100 prose-code:p-1 prose-code:font-normal dark:prose-code:bg-gray-700/40 prose-code:rounded-md break-words line-numbers dark:prose-invert dark:antialiased prose-pre:rounded-xl prose-pre:bg-slate-800 prose-pre:shadow-lg dark:prose-pre:bg-slate-800/70 dark:prose-pre:shadow-none dark:prose-pre:ring-1 dark:prose-pre:ring-slate-300/10 <%= classes %>" data-controller="syntax-highlighting" <%= data_attributes %>>
+  <%= content %>
+ </div>

--- a/app/components/content_container_component.rb
+++ b/app/components/content_container_component.rb
@@ -1,0 +1,16 @@
+class ContentContainerComponent < ViewComponent::Base
+  def initialize(classes: '', data_attributes: {})
+    @classes = classes
+    @data_attributes = data_attributes
+  end
+
+  private
+
+  attr_reader :classes
+
+  def data_attributes
+    @data_attributes.map do |key, value|
+      "data-#{key.to_s.dasherize}=#{value.to_s.dasherize}"
+    end.join(' ')
+  end
+end

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -7,9 +7,9 @@
 
     <main class="grid grid-cols-12 gap-x-6" data-controller="lesson-toc" data-lesson-toc-item-classes-value="no-underline hover:text-gray-800 text-sm dark:hover:text-gray-300">
       <article class="col-span-full xl:col-span-7 xl:col-start-2">
-        <div class="lesson-content max-w-prose mx-auto xl:mx-0 prose prose-lg prose-gray prose-a:text-gold-600 prose-code:bg-gray-100 prose-code:p-1 prose-code:font-normal dark:prose-code:bg-gray-700/40 prose-code:rounded-md break-words line-numbers dark:prose-invert dark:antialiased prose-pre:rounded-xl prose-pre:bg-slate-800 prose-pre:shadow-lg dark:prose-pre:bg-slate-800/70 dark:prose-pre:shadow-none dark:prose-pre:ring-1 dark:prose-pre:ring-slate-300/10" data-controller="syntax-highlighting" data-lesson-toc-target="lessonContent">
+        <%= render ContentContainerComponent.new(classes: 'xl:mx-0', data_attributes: { lesson_toc_target: 'lessonContent' }) do %>
           <%= @lesson.content.html_safe %>
-        </div>
+        <% end %>
       </article>
 
       <aside class="col-span-3 col-start-10 justify-self-end hidden xl:block">

--- a/app/views/static_pages/before_asking.html.erb
+++ b/app/views/static_pages/before_asking.html.erb
@@ -1,6 +1,7 @@
 <%= title('Help Yourself Before Asking Others') %>
 <div class="page-container">
-  <div class="lesson-content prose prose-lg prose-gray prose-a:text-gold-600 max-w-prose mx-auto dark:prose-invert dark:antialiased dark:prose-code:bg-gray-700/60 dark:prose-pre:prose-code">
+
+  <%= render ContentContainerComponent.new do %>
 
     <h2>Help Yourself Before Asking Others</h2>
 
@@ -98,8 +99,7 @@
     <p>
       Going through each of these tips can take quite a bit of time, but as you get more experience many of these will become part of your development process, which will save you time in the end. If you have not found the root of the problem, after working through each of these tips, it is time to ask others. However, asking others for help is not as simple as it may sound, so please read <a href="/how_to_ask" target="_blank">How to Ask a Technical Question</a>.
     </p>
-
-  </div>
+  <% end %>
 
   <%= render 'static_pages/dashboard_steps/github_link', filename: 'app/views/static_pages/before_asking.html.erb' %>
 

--- a/app/views/static_pages/community_expectations.html.erb
+++ b/app/views/static_pages/community_expectations.html.erb
@@ -1,7 +1,7 @@
 <%= title('Community Expectations') %>
 <div class="page-container">
-  <div class="lesson-content prose prose-lg prose-gray prose-a:text-gold-600 max-w-prose mx-auto dark:prose-invert antialiased">
 
+  <%= render ContentContainerComponent.new do %>
     <h2>Community Expectations</h2>
 
     <p>
@@ -79,7 +79,7 @@
         <strong>Provide context when sharing a resource.</strong> When posting a link to an article or youtube video, include <strong>why</strong> you are sharing it. Otherwise it will be marked as spam and deleted.
       </li>
     </ul>
-  </div>
+  <% end %>
 
   <%= render 'static_pages/dashboard_steps/github_link', filename: 'app/views/static_pages/community_expectations.html.erb' %>
 

--- a/app/views/static_pages/community_rules.html.erb
+++ b/app/views/static_pages/community_rules.html.erb
@@ -1,7 +1,7 @@
 <%= title('Community Rules') %>
 <div class="page-container">
-  <div class="lesson-content prose prose-lg prose-gray prose-a:text-gold-600 max-w-prose mx-auto dark:prose-invert dark:antialiased">
 
+  <%= render ContentContainerComponent.new do %>
    <h2>Community Rules</h2>
 
     <p>
@@ -176,8 +176,7 @@
     <p>
       This is not a comprehensive list of all possible scenarios and zaps are made at the discretion of the moderation team if particular behaviors are inappropriate but not otherwise explicitly covered. Please DM @ModMail if you would like to discuss these rules or any moderation activity (whether you are on the receiving end or not).
     </p>
-
-  </div>
+  <% end %>
 
   <%= render 'static_pages/dashboard_steps/github_link', filename: 'app/views/static_pages/community_rules.html.erb' %>
 

--- a/app/views/static_pages/how_to_ask.html.erb
+++ b/app/views/static_pages/how_to_ask.html.erb
@@ -1,7 +1,7 @@
 <%= title('How to Ask Technical Questions') %>
 <div class="page-container">
-  <div class="lesson-content prose prose-lg prose-gray prose-a:text-gold-600 max-w-prose mx-auto dark:prose-invert dark:antialiased dark:prose-code:bg-gray-700/60 dark:prose-pre:prose-code">
 
+  <%= render ContentContainerComponent.new do %>
     <h2>How to Ask Technical Questions</h2>
 
     <p>
@@ -115,8 +115,7 @@
     <p>
       If you do not find your own answer, following these tips will allow others to help you as easily as possible. It is highly recommended to review these tips each time you ask a question, at least until it is second nature to always provide this level of detail.
     </p>
-
-  </div>
+  <% end %>
 
   <%= render 'static_pages/dashboard_steps/github_link', filename: 'app/views/static_pages/how_to_ask.html.erb' %>
 

--- a/app/views/static_pages/terms_of_use.html.erb
+++ b/app/views/static_pages/terms_of_use.html.erb
@@ -2,7 +2,8 @@
 
 <div class="page-container">
   <h1 class="page-heading-title">Terms of Use</h1>
-  <div class="prose prose-lg prose-gray prose-a:text-gold-600 max-w-prose mx-auto dark:prose-invert dark:antialiased">
+
+  <%= render ContentContainerComponent.new do %>
     <h3 id="introduction">Introduction</h3>
     <p>This document should be read in conjunction with Thinkful's <a href="https://www.thinkful.com/privacy-policy/">privacy policy</a> and <a href="https://www.thinkful.com/terms-of-service/">terms of service</a>.</p>
 
@@ -176,5 +177,5 @@
 
     <h3 id="headings">Headings</h3>
     <p>The headings in this User Agreement are inserted only as a matter of convenience and for reference and in no way define, limit or describe the scope or intent of this User Agreement.</p>
-  </div>
+  <% end %>
 </div>

--- a/spec/components/content_container_component_spec.rb
+++ b/spec/components/content_container_component_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe ContentContainerComponent, type: :component do
+  it 'renders content' do
+    component = described_class.new
+
+    render_inline(component) { 'Some riveting content' }
+
+    expect(page).to have_content('Some riveting content')
+  end
+
+  it 'renders content with classes' do
+    component = described_class.new(classes: 'some-class')
+
+    render_inline(component) { 'Some riveting content' }
+
+    expect(page).to have_selector('.some-class')
+  end
+
+  it 'renders content with data attributes' do
+    component = described_class.new(data_attributes: { some_attribute: 'some-value' })
+
+    render_inline(component) { 'Some riveting content' }
+
+    expect(page).to have_selector("[data-some-attribute='some-value']")
+  end
+end


### PR DESCRIPTION
Because:
* We were repeating content classes in a few different files and needed to update each one when making changes to our content styling.

This commit:
* Add content container component with configurable classes and data attributes
* Use content container with lesson content
* Use content container with community page content