### PR TITLE
Chore: Add Erblint to Test Script

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -1,9 +1,12 @@
 #!/usr/bin/env ruby
 
-results = { 'Rubocop' => false, 'RSpec' => false, 'ESLint' => false, 'Jest' => false }
+results = { 'Rubocop' => false, 'Erblint' => false, 'RSpec' => false, 'ESLint' => false, 'Jest' => false }
 puts "\n== Running linters =="
 puts 'Rubocop:'
 results['Rubocop'] = system 'bundle exec rubocop'
+
+puts 'Erblint:'
+results['Erblint'] = system 'bundle exec erblint --lint-all'
 
 puts 'ESlint:'
 results['ESLint'] = system 'yarn eslint'


### PR DESCRIPTION
Because:
* Every linter that runs in CI should also run the test script