### PR TITLE
Feature: Improve contrast between complete and incomplete icons

### DIFF
--- a/app/components/complete/icon_component.html.erb
+++ b/app/components/complete/icon_component.html.erb
@@ -8,7 +8,7 @@
   data-complete-button-loading-class="complete-icon-button--loading"
   data-complete-button-completed-class="complete-icon-button--completed !text-teal-700 dark:!text-teal-600"
   data-test-id="complete-button"
-  class="complete-icon-button h-8 sm:h-9 text-gray-400">
+  class="complete-icon-button h-8 sm:h-9 text-gray-400 dark:text-gray-500">
   <span class="complete-icon-button__loading-icon" data-complete-button-target="loading">
     <%= inline_svg_tag 'icons/spinner.svg', class: 'animate-spin h-7 sm:h-8', aria: true, title: 'loading', desc: 'loading spinner' %>
   </span>


### PR DESCRIPTION
Because:
* We've seen some reports about it being a little hard to tell whats complete and incomplete on the course page

This commit:
* Use a darker shade of gray for the the incomplete icon

Before:
<img width="835" alt="Screenshot 2022-10-16 at 06 39 49" src="https://user-images.githubusercontent.com/7963776/196020265-d78364c2-04cc-4753-b350-02e006afe716.png">

After: 
<img width="797" alt="Screenshot 2022-10-16 at 06 39 18" src="https://user-images.githubusercontent.com/7963776/196020271-81570de2-b5c8-4e33-ab07-83c10a7044fb.png">
