### PR TITLE
fix: revert linter changes

### DIFF
--- a/app/views/courses/_course.html.erb
+++ b/app/views/courses/_course.html.erb
@@ -17,10 +17,10 @@
             ) %>
 
         <%= link_to path_course_url(course.path, course), class: 'flex flex-col md:items-start' do %>
-          <h2 id=<%= course.title.parameterize %> ">
+          <h2 id=<%= course.title.parameterize %> class="font-medium text-lg uppercase md:text-left text-gray-600 dark:text-gray-200">
             <%= course.title %>
           </h2>
-          <span class=" uppercase text-sm text-gray-400 70 "><%= course.lessons.size %> lessons</span>
+          <span class="uppercase text-sm text-gray-400/70 "><%= course.lessons.size %> lessons</span>
         <% end %>
       </div>
 
@@ -29,6 +29,6 @@
   <% end %>
 
   <% card.body do %>
-     <p class=" dark:text-gray-300 90 "><%= course.description %></p>
+     <p class="dark:text-gray-300/90 "><%= course.description %></p>
   <% end %>
 <% end %>


### PR DESCRIPTION
Complete the following REQUIRED checkboxes:
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behaviour
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [x] I have verified all tests and linters pass against my changes, and/or I have included automated tests where applicable

<hr>

**1. Because:**
Recent erb-linter changes caused some styles to be removed/changed.

**2. This PR:**
* Restores missing styles
* Restores styles changed erroneously


**3. Additional Information:**
Linter errors related to these three lines are being thrown, but I believe it is a linter configuration error.

Below was the output from the linter on my local lint run, which relate one to one to the lines that are being restored in this PR:
```bash
(19:06) crespire@dev-vm:~/repos/the_odin_project/theodinproject (fix/revert_styles) $ bundle exec erblint --lint-all
Linting 77 files with 13 linters...

expected whitespace, '>' or '=' after attribute name (at ")
In file: app/views/courses/_course.html.erb:20

expected space after attribute value (at u)
In file: app/views/courses/_course.html.erb:23

expected '>' after '/' (at 7)
In file: app/views/courses/_course.html.erb:23

expected space after attribute value (at d)
In file: app/views/courses/_course.html.erb:32

expected '>' after '/' (at 9)
In file: app/views/courses/_course.html.erb:32

Non-whitespace character(s) detected: "c".
In file: app/views/courses/_course.html.erb:20

No space detected where there should be a single space.
In file: app/views/courses/_course.html.erb:20

No space detected where there should be a single space.
In file: app/views/courses/_course.html.erb:23

Non-whitespace character(s) detected: "/".
In file: app/views/courses/_course.html.erb:23

No space detected where there should be a single space.
In file: app/views/courses/_course.html.erb:32

Non-whitespace character(s) detected: "/".
In file: app/views/courses/_course.html.erb:32

11 error(s) were found in ERB files
```

