### PR TITLE
Fix: Course Lesson Count Contrast

### DIFF
--- a/app/views/courses/_course.html.erb
+++ b/app/views/courses/_course.html.erb
@@ -20,7 +20,7 @@
           <h2 id="<%= course.title.parameterize %>" class="font-medium text-lg uppercase md:text-left text-gray-600 dark:text-gray-200">
             <%= course.title %>
           </h2>
-          <span class="uppercase text-sm text-gray-400/70 "><%= course.lessons.size %> lessons</span>
+          <span class="uppercase text-sm text-gray-400"><%= course.lessons.size %> lessons</span>
         <% end %>
       </div>
 
@@ -29,6 +29,6 @@
   <% end %>
 
   <% card.body do %>
-     <p class="dark:text-gray-300/90 "><%= course.description %></p>
+     <p class="dark:text-gray-300"><%= course.description %></p>
   <% end %>
 <% end %>


### PR DESCRIPTION
Because:
* The lesson count on course cards was hard to see on light mode.

Before:
<img width="921" alt="Screenshot 2022-10-19 at 17 57 52" src="https://user-images.githubusercontent.com/7963776/196756182-5897ad36-7fad-4321-8c02-82787efa695f.png">

After:
<img width="927" alt="Screenshot 2022-10-19 at 17 57 42" src="https://user-images.githubusercontent.com/7963776/196756190-44327cc1-079d-497c-89d2-78760202bb67.png">

