### PR TITLE
Chore: Rename Seeder's to Builders

### DIFF
--- a/db/fixtures/paths/foundations/seed.rb
+++ b/db/fixtures/paths/foundations/seed.rb
@@ -1,7 +1,7 @@
 # ************************
 # Path - Foundations
 # ************************
-path = Seeds::PathSeeder.create do |path|
+path = Seeds::PathBuilder.build do |path|
   path.title = 'Foundations'
   path.short_title = 'Foundations Path'
   path.description = "This is where it all begins! A hands-on introduction to all of the essential tools you'll need to build real, working websites. You'll learn what web developers actually do and the foundations you'll need for later courses."

--- a/db/fixtures/paths/full_stack_javascript/seed.rb
+++ b/db/fixtures/paths/full_stack_javascript/seed.rb
@@ -1,7 +1,7 @@
 # *****************************
 # Path - Full Stack JavaScript
 # *****************************
-@path = Seeds::PathSeeder.create do |path|
+@path = Seeds::PathBuilder.build do |path|
   path.title = 'Full Stack JavaScript'
   path.short_title = 'Node Path'
   path.description = "This path takes you through our entire JavaScript curriculum. The courses should be taken in the order that they are displayed. You'll learn everything you need to know to create beautiful responsive websites from scratch using JavaScript and NodeJs."

--- a/db/fixtures/paths/full_stack_rails/seed.rb
+++ b/db/fixtures/paths/full_stack_rails/seed.rb
@@ -1,7 +1,7 @@
 # ***************************
 # Path - Full Stack Rails
 # ***************************
-@path = Seeds::PathSeeder.create do |path|
+@path = Seeds::PathBuilder.build do |path|
   path.title = 'Full Stack Ruby on Rails'
   path.short_title = 'Rails Path'
   path.description = "This path takes you through our entire Ruby on Rails curriculum. The courses should be taken in the order that they are displayed. You'll learn everything you need to know to create beautiful responsive websites from scratch using Ruby on Rails."

--- a/db/fixtures/seed.rb
+++ b/db/fixtures/seed.rb
@@ -1,4 +1,4 @@
-require './lib/seeds/path_seeder'
+require './lib/seeds/path_builder'
 
 # load paths
 load './db/fixtures/paths/foundations/seed.rb'

--- a/lib/seeds/course_builder.rb
+++ b/lib/seeds/course_builder.rb
@@ -1,8 +1,8 @@
 require './lib/seeds/helpers'
-require './lib/seeds/section_seeder'
+require './lib/seeds/section_builder'
 
 module Seeds
-  class CourseSeeder
+  class CourseBuilder
     include Seeds::Helpers
 
     attr_accessor :identifier_uuid, :title, :description, :position, :show_on_homepage, :badge_uri
@@ -16,12 +16,12 @@ module Seeds
       @course = course
     end
 
-    def self.create(path, position, &)
+    def self.build(path, position, &)
       new(path, position, &)
     end
 
     def add_section(&)
-      Seeds::SectionSeeder.create(course, section_position, &).tap do |section|
+      Seeds::SectionBuilder.build(course, section_position, &).tap do |section|
         seeded_sections.push(section)
       end
     end

--- a/lib/seeds/lesson_builder.rb
+++ b/lib/seeds/lesson_builder.rb
@@ -1,12 +1,12 @@
 module Seeds
-  class LessonSeeder
+  class LessonBuilder
     def initialize(section, position, attributes)
       @section = section
       @position = position
       @attributes = attributes
     end
 
-    def self.create(section, position, attributes)
+    def self.build(section, position, attributes)
       new(section, position, attributes).lesson
     end
 

--- a/lib/seeds/path_builder.rb
+++ b/lib/seeds/path_builder.rb
@@ -1,8 +1,8 @@
 require './lib/seeds/helpers'
-require './lib/seeds/course_seeder'
+require './lib/seeds/course_builder'
 
 module Seeds
-  class PathSeeder
+  class PathBuilder
     include Helpers
 
     attr_accessor :identifier_uuid, :title, :description, :position, :default_path, :short_title, :badge_uri
@@ -14,7 +14,7 @@ module Seeds
       @path = path
     end
 
-    def self.create(&)
+    def self.build(&)
       new(&)
     end
 
@@ -31,7 +31,7 @@ module Seeds
     end
 
     def add_course(&)
-      Seeds::CourseSeeder.create(path, course_position, &).tap do |seeded_course|
+      Seeds::CourseBuilder.build(path, course_position, &).tap do |seeded_course|
         seeded_courses.push(seeded_course)
       end
     end

--- a/lib/seeds/section_builder.rb
+++ b/lib/seeds/section_builder.rb
@@ -1,8 +1,8 @@
 # rubocop: disable Style/ClassVars
-require './lib/seeds/lesson_seeder'
+require './lib/seeds/lesson_builder'
 
 module Seeds
-  class SectionSeeder
+  class SectionBuilder
     @@total_seeded_lessons = Hash.new(0)
 
     attr_accessor :identifier_uuid, :title, :description, :position
@@ -17,7 +17,7 @@ module Seeds
       @section = section
     end
 
-    def self.create(course, position, &)
+    def self.build(course, position, &)
       new(course, position, &)
     end
 
@@ -32,7 +32,7 @@ module Seeds
 
     def add_lessons(*lessons)
       @add_lessons ||= lessons.map do |lesson|
-        LessonSeeder.create(section, lesson_position, lesson).tap do |seeded_lesson|
+        LessonBuilder.build(section, lesson_position, lesson).tap do |seeded_lesson|
           seeded_lessons.push(seeded_lesson)
         end
       end

--- a/spec/lib/seeds/course_builder_spec.rb
+++ b/spec/lib/seeds/course_builder_spec.rb
@@ -1,9 +1,9 @@
-require './lib/seeds/course_seeder'
+require './lib/seeds/course_builder'
 require 'rails_helper'
 
-RSpec.describe Seeds::CourseSeeder do
-  subject(:course_seeder) do
-    described_class.create(path, position) do |course|
+RSpec.describe Seeds::CourseBuilder do
+  subject(:course_builder) do
+    described_class.build(path, position) do |course|
       course.identifier_uuid = 'course_uuid'
       course.title = 'Foundations'
       course.description = 'a foundation course'
@@ -14,27 +14,27 @@ RSpec.describe Seeds::CourseSeeder do
   let(:path) { create(:path, id: 100) }
   let(:position) { 1 }
 
-  describe '.create' do
-    it 'creates a new course' do
-      expect { course_seeder }.to change { Course.count }.from(0).to(1)
+  describe '.build' do
+    it 'builds a new course' do
+      expect { course_builder }.to change { Course.count }.from(0).to(1)
     end
 
-    it 'create a course with the given title' do
-      course_seeder
+    it 'builds a course with the given title' do
+      course_builder
 
       course = Course.find_by(identifier_uuid: 'course_uuid')
       expect(course.title).to eq('Foundations')
     end
 
-    it 'create a course with the given description' do
-      course_seeder
+    it 'builds a course with the given description' do
+      course_builder
 
       course = Course.find_by(identifier_uuid: 'course_uuid')
       expect(course.description).to eq('a foundation course')
     end
 
-    it 'create a course with the given position' do
-      course_seeder
+    it 'builds a course with the given position' do
+      course_builder
 
       course = Course.find_by(identifier_uuid: 'course_uuid')
       expect(course.position).to eq(1)
@@ -44,7 +44,7 @@ RSpec.describe Seeds::CourseSeeder do
       it 'updates the attributes that are different' do
         existing_course = create(:course, identifier_uuid: 'course_uuid', title: 'Development 101', position: 2)
 
-        expect { course_seeder }
+        expect { course_builder }
           .to change { existing_course.reload.title }.from('Development 101').to('Foundations')
                                                      .and change { existing_course.position }.from(2).to(1)
       end
@@ -55,10 +55,10 @@ RSpec.describe Seeds::CourseSeeder do
     let(:course) { Course.find_by(identifier_uuid: 'course_uuid') }
 
     it 'adds a section to the course' do
-      course_seeder
+      course_builder
 
       expect do
-        course_seeder.add_section do |section|
+        course_builder.add_section do |section|
           section.identifier_uuid = 'section_uuid'
           section.title = 'Basics'
           section.description = 'A Basics section'
@@ -68,19 +68,19 @@ RSpec.describe Seeds::CourseSeeder do
 
     context 'when adding multiple sections' do
       it 'applies to correct position to each section' do
-        section_one = course_seeder.add_section do |section|
+        section_one = course_builder.add_section do |section|
           section.identifier_uuid = 'section_uuid_1'
           section.title = 'Basics'
           section.description = 'A Basics section'
         end
 
-        section_two = course_seeder.add_section do |section|
+        section_two = course_builder.add_section do |section|
           section.identifier_uuid = 'section_uuid_2'
           section.title = 'Intermediate'
           section.description = 'A Intermediate section'
         end
 
-        section_three = course_seeder.add_section do |section|
+        section_three = course_builder.add_section do |section|
           section.identifier_uuid = 'section_uuid_3'
           section.title = 'Advanced'
           section.description = 'A Advanced section'
@@ -99,12 +99,12 @@ RSpec.describe Seeds::CourseSeeder do
       create(:section, identifier_uuid: 'section_uuid_1', course_id: course.id)
       seeded_section = create(:section, identifier_uuid: 'section_uuid_2', course_id: course.id)
 
-      course_seeder.add_section do |section|
+      course_builder.add_section do |section|
         section.identifier_uuid = 'section_uuid_2'
       end
 
-      course_seeder.delete_removed_seeds
-      expect(course_seeder.course.sections.reload).to contain_exactly(seeded_section)
+      course_builder.delete_removed_seeds
+      expect(course_builder.course.sections.reload).to contain_exactly(seeded_section)
     end
 
     it 'deletes lessons that are in the db but removed from the seeds file' do
@@ -116,7 +116,7 @@ RSpec.describe Seeds::CourseSeeder do
       lesson_two = create(:lesson, section: section_two, course_id: course.id, identifier_uuid: 'lesson_uuid_2')
       create(:lesson, section: section_one, course_id: course.id, identifier_uuid: 'lesson_uuid_3')
 
-      course_seeder.add_section do |section|
+      course_builder.add_section do |section|
         section.identifier_uuid = 'section_uuid_2'
 
         section.add_lessons(
@@ -129,8 +129,8 @@ RSpec.describe Seeds::CourseSeeder do
         )
       end
 
-      course_seeder.delete_removed_seeds
-      expect(course_seeder.course.lessons.reload).to contain_exactly(lesson_two)
+      course_builder.delete_removed_seeds
+      expect(course_builder.course.lessons.reload).to contain_exactly(lesson_two)
     end
   end
 end

--- a/spec/lib/seeds/lesson_builder_spec.rb
+++ b/spec/lib/seeds/lesson_builder_spec.rb
@@ -1,8 +1,8 @@
-require './lib/seeds/lesson_seeder'
+require './lib/seeds/lesson_builder'
 require 'rails_helper'
 
-RSpec.describe Seeds::LessonSeeder do
-  subject(:lesson_seeder) { described_class.create(section, position, attributes) }
+RSpec.describe Seeds::LessonBuilder do
+  subject(:lesson_builder) { described_class.build(section, position, attributes) }
 
   let(:section) { create(:section, course:) }
   let(:course) { create(:course) }
@@ -19,48 +19,48 @@ RSpec.describe Seeds::LessonSeeder do
     }
   end
 
-  describe '.create' do
-    it 'creates a new lesson' do
-      expect { lesson_seeder }.to change { Lesson.count }.from(0).to(1)
+  describe '.build' do
+    it 'builds a new lesson' do
+      expect { lesson_builder }.to change { Lesson.count }.from(0).to(1)
     end
 
-    it 'creates a lesson with the given title' do
-      lesson_seeder
+    it 'builds a lesson with the given title' do
+      lesson_builder
 
       lesson = Lesson.find_by(identifier_uuid: 'lesson_uuid')
       expect(lesson.title).to eq('Ruby Lesson')
     end
 
-    it 'creates a lesson with the given description' do
-      lesson_seeder
+    it 'builds a lesson with the given description' do
+      lesson_builder
 
       lesson = Lesson.find_by(identifier_uuid: 'lesson_uuid')
       expect(lesson.description).to eq('lesson description')
     end
 
-    it 'creates a lesson with the given position' do
-      lesson_seeder
+    it 'builds a lesson with the given position' do
+      lesson_builder
 
       lesson = Lesson.find_by(identifier_uuid: 'lesson_uuid')
       expect(lesson.position).to eq(1)
     end
 
-    it 'creates a lesson with a true is_project attribute' do
-      lesson_seeder
+    it 'builds a lesson with a true is_project attribute' do
+      lesson_builder
 
       lesson = Lesson.find_by(identifier_uuid: 'lesson_uuid')
       expect(lesson.is_project).to be(true)
     end
 
-    it 'creates a lesson with a true accepts_submission attribute' do
-      lesson_seeder
+    it 'builds a lesson with a true accepts_submission attribute' do
+      lesson_builder
 
       lesson = Lesson.find_by(identifier_uuid: 'lesson_uuid')
       expect(lesson.accepts_submission).to be(true)
     end
 
-    it 'creates a lesson with a true has_live_preview attribute' do
-      lesson_seeder
+    it 'builds a lesson with a true has_live_preview attribute' do
+      lesson_builder
 
       lesson = Lesson.find_by(identifier_uuid: 'lesson_uuid')
       expect(lesson.has_live_preview).to be(true)
@@ -76,30 +76,30 @@ RSpec.describe Seeds::LessonSeeder do
         }
       end
 
-      it 'creates a lesson with a false is_project attribute' do
-        lesson_seeder
+      it 'builds a lesson with a false is_project attribute' do
+        lesson_builder
 
         lesson = Lesson.find_by(identifier_uuid: 'lesson_uuid')
         expect(lesson.is_project).to be(false)
       end
 
-      it 'creates a lesson with a false accepts_submission attribute' do
-        lesson_seeder
+      it 'builds a lesson with a false accepts_submission attribute' do
+        lesson_builder
 
         lesson = Lesson.find_by(identifier_uuid: 'lesson_uuid')
         expect(lesson.accepts_submission).to be(false)
       end
 
-      it 'creates a lesson with a false has_live_preview attribute' do
-        lesson_seeder
+      it 'builds a lesson with a false has_live_preview attribute' do
+        lesson_builder
 
         lesson = Lesson.find_by(identifier_uuid: 'lesson_uuid')
         expect(lesson.has_live_preview).to be(false)
       end
     end
 
-    it 'creates a lesson with the given url' do
-      lesson_seeder
+    it 'builds a lesson with the given url' do
+      lesson_builder
 
       lesson = Lesson.find_by(identifier_uuid: 'lesson_uuid')
       expect(lesson.github_path).to eq('/github/lesson_path')
@@ -116,7 +116,7 @@ RSpec.describe Seeds::LessonSeeder do
           course_id: course.id,
         )
 
-        expect { lesson_seeder }.to change { existing_lesson.reload.title }
+        expect { lesson_builder }.to change { existing_lesson.reload.title }
           .from('JS Lesson').to('Ruby Lesson')
           .and change { existing_lesson.position }.from(2).to(1)
       end

--- a/spec/lib/seeds/path_builder_spec.rb
+++ b/spec/lib/seeds/path_builder_spec.rb
@@ -1,9 +1,9 @@
-require './lib/seeds/path_seeder'
+require './lib/seeds/path_builder'
 require 'rails_helper'
 
-RSpec.describe Seeds::PathSeeder do
-  subject(:path_seeder) do
-    described_class.create do |path|
+RSpec.describe Seeds::PathBuilder do
+  subject(:path_builder) do
+    described_class.build do |path|
       path.identifier_uuid = 'path_uuid'
       path.title = 'Foundations'
       path.description = 'a foundation path'
@@ -13,34 +13,34 @@ RSpec.describe Seeds::PathSeeder do
     end
   end
 
-  describe '.create' do
-    it 'creates a new path' do
-      expect { path_seeder }.to change { Path.count }.from(0).to(1)
+  describe '.build' do
+    it 'builds a new path' do
+      expect { path_builder }.to change { Path.count }.from(0).to(1)
     end
 
-    it 'creates a path with the given title' do
-      path_seeder
+    it 'builds a path with the given title' do
+      path_builder
 
       path = Path.find_by(identifier_uuid: 'path_uuid')
       expect(path.title).to eq('Foundations')
     end
 
-    it 'creates a path with the given description' do
-      path_seeder
+    it 'builds a path with the given description' do
+      path_builder
 
       path = Path.find_by(identifier_uuid: 'path_uuid')
       expect(path.description).to eq('a foundation path')
     end
 
-    it 'creates a path with the given position' do
-      path_seeder
+    it 'builds a path with the given position' do
+      path_builder
 
       path = Path.find_by(identifier_uuid: 'path_uuid')
       expect(path.position).to eq(1)
     end
 
-    it 'creates a path with the given default path attribute' do
-      path_seeder
+    it 'builds a path with the given default path attribute' do
+      path_builder
 
       path = Path.find_by(identifier_uuid: 'path_uuid')
       expect(path.default_path).to be(true)
@@ -50,7 +50,7 @@ RSpec.describe Seeds::PathSeeder do
       it 'updates the attributes that are different' do
         existing_path = create(:path, identifier_uuid: 'path_uuid', title: 'Development 101', position: 2)
 
-        expect { path_seeder }.to change { existing_path.reload.title }
+        expect { path_builder }.to change { existing_path.reload.title }
           .from('Development 101').to('Foundations')
           .and change { existing_path.position }.from(2).to(1)
       end
@@ -61,10 +61,10 @@ RSpec.describe Seeds::PathSeeder do
     let(:path) { Path.find_by(identifier_uuid: 'path_uuid') }
 
     it 'adds a course to the path' do
-      path_seeder
+      path_builder
 
       expect do
-        path_seeder.add_course do |course|
+        path_builder.add_course do |course|
           course.identifier_uuid = 'course_uuid'
           course.title = 'Ruby'
           course.description = 'A Ruby course'
@@ -75,21 +75,21 @@ RSpec.describe Seeds::PathSeeder do
 
     context 'when adding multiple courses' do
       it 'applies to correct position to each course' do
-        course_one = path_seeder.add_course do |course|
+        course_one = path_builder.add_course do |course|
           course.identifier_uuid = 'course_uuid_1'
           course.title = 'Ruby'
           course.description = 'A Ruby course'
           course.badge_uri = 'ruby-soho.jpeg'
         end
 
-        course_two = path_seeder.add_course do |course|
+        course_two = path_builder.add_course do |course|
           course.identifier_uuid = 'course_uuid_2'
           course.title = 'Rails'
           course.description = 'A Rails course'
           course.badge_uri = 'choo-choo-choose-you.bmp'
         end
 
-        course_three = path_seeder.add_course do |course|
+        course_three = path_builder.add_course do |course|
           course.identifier_uuid = 'course_uuid_3'
           course.title = 'JS'
           course.description = 'A JS course'
@@ -109,13 +109,13 @@ RSpec.describe Seeds::PathSeeder do
       create(:course, identifier_uuid: 'course_uuid_1', path_id: path.id)
       seeded_course = create(:course, identifier_uuid: 'course_uuid_2', path_id: path.id)
 
-      path_seeder.add_course do |course|
+      path_builder.add_course do |course|
         course.identifier_uuid = 'course_uuid_2'
         course.badge_uri = 'nothing-to-see-here.svg'
       end
 
-      path_seeder.delete_removed_courses
-      expect(path_seeder.path.courses.reload).to contain_exactly(seeded_course)
+      path_builder.delete_removed_courses
+      expect(path_builder.path.courses.reload).to contain_exactly(seeded_course)
     end
   end
 end

--- a/spec/lib/seeds/section_builder_spec.rb
+++ b/spec/lib/seeds/section_builder_spec.rb
@@ -1,9 +1,9 @@
-require './lib/seeds/section_seeder'
+require './lib/seeds/section_builder'
 require 'rails_helper'
 
-RSpec.describe Seeds::SectionSeeder do
-  subject(:section_seeder) do
-    described_class.create(course, position) do |section|
+RSpec.describe Seeds::SectionBuilder do
+  subject(:section_builder) do
+    described_class.build(course, position) do |section|
       section.identifier_uuid = 'section_uuid'
       section.title = 'Basics Section'
       section.description = 'a basics section'
@@ -13,27 +13,27 @@ RSpec.describe Seeds::SectionSeeder do
   let(:course) { create(:course) }
   let(:position) { 1 }
 
-  describe '.create' do
-    it 'creates a new section' do
-      expect { section_seeder }.to change { Section.count }.from(0).to(1)
+  describe '.build' do
+    it 'builds a new section' do
+      expect { section_builder }.to change { Section.count }.from(0).to(1)
     end
 
-    it 'creates a section with the given title' do
-      section_seeder
+    it 'builds a section with the given title' do
+      section_builder
 
       section = Section.find_by(identifier_uuid: 'section_uuid')
       expect(section.title).to eq('Basics Section')
     end
 
-    it 'creates a section with the given description' do
-      section_seeder
+    it 'builds a section with the given description' do
+      section_builder
 
       section = Section.find_by(identifier_uuid: 'section_uuid')
       expect(section.description).to eq('a basics section')
     end
 
-    it 'creates a section with the given position' do
-      section_seeder
+    it 'builds a section with the given position' do
+      section_builder
 
       section = Section.find_by(identifier_uuid: 'section_uuid')
       expect(section.position).to eq(1)
@@ -49,7 +49,7 @@ RSpec.describe Seeds::SectionSeeder do
           course:
         )
 
-        expect { section_seeder }.to change { existing_section.reload.title }
+        expect { section_builder }.to change { existing_section.reload.title }
           .from('Intermediate Section').to('Basics Section')
           .and change { existing_section.position }.from(2).to(1)
       end
@@ -60,10 +60,10 @@ RSpec.describe Seeds::SectionSeeder do
     let(:section) { Section.find_by(identifier_uuid: 'section_uuid') }
 
     it 'adds lessons to the section' do
-      section_seeder
+      section_builder
 
       expect do
-        section_seeder.add_lessons(
+        section_builder.add_lessons(
           {
             title: 'Ruby Lesson',
             description: 'A Ruby Lesson',
@@ -82,7 +82,7 @@ RSpec.describe Seeds::SectionSeeder do
 
     context 'when adding multiple lessons' do
       it 'applies to correct position to each lesson' do
-        lessons = section_seeder.add_lessons(
+        lessons = section_builder.add_lessons(
           {
             title: 'Ruby Lesson',
             description: 'A Ruby Lesson',


### PR DESCRIPTION
Because:
* The seeder classes were named incorrectly. They are instead builders which _build_ the curriculum up bit by bit by adding courses, sections and lessons to a path. We should reveal this in the code with the appropriate naming.


