### PR TITLE
Chore: Run Heroku Release Task Automatically

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
+release: bin/rails heroku:release
 web: bundle exec puma -C config/puma.rb
 worker: bundle exec sidekiq -c 2


### PR DESCRIPTION
Because:
* We need to reference the release task in our Procfile so it can run after deploy.