### PR TITLE
fix: remove strange behavior on anchor for lesson nested content

### DIFF
--- a/app/javascript/controllers/lesson_toc_controller.js
+++ b/app/javascript/controllers/lesson_toc_controller.js
@@ -41,7 +41,7 @@ export default class LessonTocController extends Controller {
   headings() {
     return (
       Array
-        .from(this.lessonContentTarget.querySelectorAll('h3'))
+        .from(this.lessonContentTarget.querySelectorAll('section > h3'))
         .map((heading) => heading)
         .filter((heading) => heading.innerText)
     );


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because

Firefox on `/lessons/foundations-installations` page is showing some non-functional anchor links.

<details>
  <summary>Before screenshot (and as is in GoogleChrome)</summary>
  <img width="313" alt="image" src="https://user-images.githubusercontent.com/7772012/197355282-ae732082-22e0-46d9-9cf9-98e2ef33234f.png">
</details>

<details>
  <summary>After screenshot</summary>
  <img width="269" alt="image" src="https://user-images.githubusercontent.com/7772012/197355270-81e25b3c-a733-4b51-85f1-f5ddc54b3041.png">
</details>

## This PR
- To a quick fix, I added a new condition (by section) to display the anchor links on lesson contents, making firefox have the same behavior as Google Chrome.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #3444 

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behavior
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If applicable, this PR includes new or updated automated tests
