### PR TITLE
Fix: Lesson Icon Shrinking on Mobile

### DIFF
--- a/app/components/sections/lesson_component.html.erb
+++ b/app/components/sections/lesson_component.html.erb
@@ -1,7 +1,7 @@
 <div class="flex justify-between items-center flex-shrink-1 hover:bg-gray-100 dark:hover:bg-gray-700 px-2 rounded-md">
   <%= link_to lesson_url(lesson), class: 'text-lg grow py-2' do %>
     <div class="flex items-center gap-3">
-      <%= inline_svg "icons/#{icon}.svg", alt: 'lesson icon', class: 'bg-inherit w-6 dark:text-gray-500 text-gray-400', title: icon_title %>
+      <%= inline_svg "icons/#{icon}.svg", alt: 'lesson icon', class: 'bg-inherit w-6 dark:text-gray-500 text-gray-400 shrink-0', title: icon_title %>
 
       <span class="text-gray-800 dark:text-gray-300 "><%= title %></span>
     </div>


### PR DESCRIPTION
Because:
* Lesson icons can shrinks too much when paired with longer lesson names on mobile.

This commit:
* Don't allow lesson icons to shrink

Before:
<img width="463" alt="Screenshot 2022-10-25 at 21 36 34" src="https://user-images.githubusercontent.com/7963776/197877092-1ccd76f9-e53a-41ed-ad7b-46beda92c4be.png">

After:
<img width="462" alt="Screenshot 2022-10-25 at 21 38 08" src="https://user-images.githubusercontent.com/7963776/197877117-a432f43d-2d1c-43f4-b569-76ed127ea135.png">
