### PR TITLE
Feature: Add GitHub action to automate project board (#3092)

### DIFF
--- a/.github/workflows/add_to_project.yml
+++ b/.github/workflows/add_to_project.yml
@@ -1,0 +1,20 @@
+name: Add issues and PRs to project
+
+on:
+  issues:
+    types:
+      - opened
+      - transferred
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issues and PRs to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.3.0
+        with:
+          project-url: https://github.com/orgs/TheOdinProject/projects/12
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
## Because
* It's a common task that's useful and easy to automate

## This PR
* Adds a Github action to workflows

## Issue
Closes #3092

## Additional Information

- [Action docs](https://github.com/actions/add-to-project)
- This is will require an admin [setting up a PAT](https://github.com/actions/add-to-project#creating-a-pat-and-adding-it-to-your-repository) before it works - current name `ADD_TO_PROJECT_PAT`
- Probably wortwhile giving a PAT organisation level access to repos, so that it can be re-used to automate other projects if it works as intended
- Current settings are very broad and will add all issues and PRs, but it is possible to make it more fine grained (ie issues only, based on certain labels or tags etc)
- This will eventually be a native feature to projects, so it should be removed when that becomes reality