### PR TITLE
Feature: Clean Up Tailwind Config

### DIFF
--- a/app/components/notification_component.html.erb
+++ b/app/components/notification_component.html.erb
@@ -1,15 +1,33 @@
 <%= link_to notification_path(@notification), method: :patch, class: 'no-underline px-4 py-4', data: { test_id: "notification-#{@notification.id}" } do %>
-  <li class="bg-white shadow overflow-hidden p-4 sm:rounded-md">
+  <li class="bg-white dark:bg-gray-800 dark:shadow-none dark:ring-1 dark:ring-white/10 dark:ring-inset shadow overflow-hidden p-4 sm:rounded-md">
     <div class="flex">
       <div class="mr-4 flex-shrink-0">
-        <%= notification_read_status_icon %>
+        <% if @notification.read? %>
+          <%= inline_svg_tag(
+                'icons/icon-read-notification.svg',
+                class: 'h-6 w-6 text-gray-400 dark:text-gray-500',
+                aria: true,
+                title: 'read notification',
+                desc: 'an image showing that a notification has been read',
+                data: { test_id: 'notification-read-icon' }
+              ) %>
+        <% else %>
+          <%= inline_svg_tag(
+                'icons/icon-unread-notification.svg',
+                class: 'h-6 w-6 text-gold-600',
+                aria: true,
+                title: 'unread notification',
+                desc: 'an image showing that a notification has not been read',
+                data: { test_id: 'notification-unread-icon' }
+              ) %>
+        <% end %>
       </div>
       <div class="flex-col">
         <div>
-          <p class="text-base font-semibold"><%= @notification.title.titleize %></p>
+          <p class="font-medium text-gray-700 dark:text-gray-300"><%= @notification.title.titleize %></p>
         </div>
         <div>
-          <p class="mt-1 text-base">
+          <p class="mt-1 !text-sm text-gray-500 dark:text-gray-400">
             <%= @notification.message %>
           </p>
         </div>

--- a/app/components/notification_component.rb
+++ b/app/components/notification_component.rb
@@ -2,27 +2,4 @@ class NotificationComponent < ApplicationComponent
   def initialize(notification:)
     @notification = notification
   end
-
-  # rubocop:disable Metrics/MethodLength
-  def notification_read_status_icon
-    if @notification.read?
-      inline_svg_tag(
-        'icons/icon-read-notification.svg',
-        class: 'h-6 w-6 text-nav-link-read',
-        aria: true,
-        title: 'read notification',
-        desc: 'an image showing that a notification has been read'
-      )
-    else
-      inline_svg_tag(
-        'icons/icon-unread-notification.svg',
-        class: 'h-6 w-6 text-nav-link-unread',
-        aria: true,
-        title: 'unread notification',
-        desc: 'an image showing that a notification has not been read'
-      )
-
-    end
-  end
-  # rubocop:enable Metrics/MethodLength
 end

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,13 +1,13 @@
 <div class="bg-blue-400 dark:bg-gray-900 h-screen">
   <div class="grid grid-cols-12">
     <div class="col-span-12 lg:col-span-10 lg:col-start-2">
-      <div class="text-center pt-16 -mt-25px">
+      <div class="text-center pt-12">
         <h1 class="text-white text-3xl lg:text-4xl font-semibold pb-6 dark:text-gray-200">Looks like you're lost, Odinite!</h1>
         <p class="text-gray-100 dark:text-gray-400">While you're here, maybe take a second to learn about <%= link_to 'HTTP status codes', 'https://en.wikipedia.org/wiki/List_of_HTTP_status_codes', class: 'text-white font-bold underline' %></p>
         <p class="text-gray-100 dark:text-gray-400">Or just head back to <%= link_to 'theodinproject.com', home_path, class: 'text-gold-800 dark:text-gold-600 font-bold underline' %></p>
       </div>
 
-      <div class="h-60v">
+      <div class="h-[60vh]">
         <%= inline_svg_tag '404-island.svg', class: 'text-blue-400 dark:text-gray-900 w-full' %>
       </div>
     </div>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="page-container h-screen">
   <h1 class="page-heading-title">Notifications</h1>
-  <ul class="space-y-3">
+  <ul class="space-y-3 max-w-3xl mx-auto">
     <% unless @notifications.empty? %>
       <%= render NotificationComponent.with_collection(@notifications) %>
     <% else %>

--- a/spec/components/notification_component_spec.rb
+++ b/spec/components/notification_component_spec.rb
@@ -9,23 +9,23 @@ RSpec.describe NotificationComponent, type: :component do
     render_inline(described_class.new(notification:))
   end
 
-  it 'renders the component with a link to the notification\'s url' do
+  it "renders the component with a link to the notification's url" do
     expect(page).to have_link(nil, href: '/notifications/1')
   end
 
-  it 'renders the component with the notification\'s title titleized' do
+  it "renders the component with the notification's title titleized" do
     expect(page).to have_text 'Test Title'
   end
 
-  it 'renders the component with the notification\'s message' do
-    expect(page).to have_text 'test message'
+  it "renders the component with the notification's message" do
+    expect(page).to have_text('test message')
   end
 
   context 'when the notification is read' do
     let(:notification) { create(:notification, read_at: Time.zone.now) }
 
     it 'renders the read notification icon inside the component' do
-      expect(page).to have_css 'svg.text-nav-link-read'
+      expect(page).to have_content('read notification')
     end
   end
 
@@ -33,7 +33,7 @@ RSpec.describe NotificationComponent, type: :component do
     let(:notification) { create(:notification, read_at: nil) }
 
     it 'renders the unread notification icon inside the component' do
-      expect(page).to have_css 'svg.text-nav-link-unread'
+      expect(page).to have_content('unread notification')
     end
   end
 end

--- a/spec/system/user_notification_spec.rb
+++ b/spec/system/user_notification_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe 'User Notifications', type: :system do
     end
 
     sign_out(admin)
-
     sign_in(submission_owner)
   end
 
@@ -29,7 +28,7 @@ RSpec.describe 'User Notifications', type: :system do
       visit root_path
 
       within(find(:test_id, 'navbar-notification-icon')) do
-        expect(page).to have_selector "span[data-test-id='unread-notifications']"
+        expect(page).to have_selector("span[data-test-id='unread-notifications']")
       end
     end
 
@@ -39,7 +38,7 @@ RSpec.describe 'User Notifications', type: :system do
       find(:test_id, 'navbar-notification-icon').click
 
       within(find(:test_id, "notification-#{submission_owner.notifications.first.id}")) do
-        expect(page).to have_css '.text-nav-link-unread'
+        expect(page).to have_selector('[data-test-id="notification-unread-icon"]')
       end
     end
   end
@@ -49,10 +48,9 @@ RSpec.describe 'User Notifications', type: :system do
       visit root_path
 
       find(:test_id, 'navbar-notification-icon').click
-
       find(:test_id, "notification-#{submission_owner.notifications.first.id}").click
 
-      expect(page).to have_current_path lesson_path(lesson)
+      expect(page).to have_current_path(lesson_path(lesson))
     end
   end
 
@@ -61,7 +59,6 @@ RSpec.describe 'User Notifications', type: :system do
       visit root_path
 
       find(:test_id, 'navbar-notification-icon').click
-
       find(:test_id, "notification-#{submission_owner.notifications.first.id}").click
     end
 
@@ -69,7 +66,7 @@ RSpec.describe 'User Notifications', type: :system do
       visit root_path
 
       within(find(:test_id, 'navbar-notification-icon')) do
-        expect(page).not_to have_selector "span[data-test-id='unread-notifications']"
+        expect(page).not_to have_selector("span[data-test-id='unread-notifications']")
       end
     end
 
@@ -79,7 +76,7 @@ RSpec.describe 'User Notifications', type: :system do
       find(:test_id, 'navbar-notification-icon').click
 
       within(find(:test_id, "notification-#{submission_owner.notifications.first.id}")) do
-        expect(page).to have_css '.text-nav-link-read'
+        expect(page).to have_selector('[data-test-id="notification-read-icon"]')
       end
     end
   end

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,3 @@
-const colors = require('tailwindcss/colors');
-
 module.exports = {
   content: [
     './app/**/*.html.erb',
@@ -77,23 +75,6 @@ module.exports = {
           '800': '#503914',
           '900': '#231909'
         },
-        'nav-link-read': 'rgba(74, 74, 74, 0.7)',
-        'nav-link-unread': 'rgba(206, 151, 62, 0.7)',
-        'notification': 'rgba(74, 74, 74, 0.7)',
-        'notification-hover': 'rgba(0, 0, 0, 1)',
-        'new-notification': 'rgba(206, 151, 62, 1)',
-      },
-      height: {
-        '60v': '60vh',
-      },
-      margin: {
-        '-25px': '-25px',
-      },
-      textColor: {
-        primary: '#4a4a4a',
-      },
-      padding: {
-        '2px': '2px',
       },
     },
   },


### PR DESCRIPTION
Because:
* Since moving to Tailwind 3, we can use arbitrary values in place for custom config.
* We had custom colors for notifications which are no longer needed.

Closes: https://github.com/TheOdinProject/theodinproject/issues/3486

This commit:
* Remove custom height, margin and padding config only used on our not found page.
* Remove custom colors for notifications and replace them with default Tailwind colors.
