### PR TITLE
Chore: Remove PRs from add to project action (#3517)

### DIFF
--- a/.github/workflows/add_to_project.yml
+++ b/.github/workflows/add_to_project.yml
@@ -1,17 +1,14 @@
-name: Add issues and PRs to project
+name: Add issues to project
 
 on:
   issues:
     types:
       - opened
       - transferred
-  pull_request:
-    types:
-      - opened
 
 jobs:
   add-to-project:
-    name: Add issues and PRs to project
+    name: Add issues to project
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@v0.3.0


### PR DESCRIPTION
Because:
  * There are permission issues for dependabot and people outside of the organisation. Additionally dependabot PRs don't add much value to project tracking, and contributors should have a related issue.

This PR:
* Closes #3517 
