### PR TITLE
Fix: Long username overflowing the submission panel.

### DIFF
--- a/app/javascript/components/project-submissions/components/submission.jsx
+++ b/app/javascript/components/project-submissions/components/submission.jsx
@@ -37,7 +37,7 @@ const Submission = forwardRef(({
     <div className={submissionItemClassnames} ref={ref} data-test-id="submission-item">
       <div className="flex items-center mb-4 md:mb-0">
         <Like submission={submission} handleLikeToggle={handleLikeToggle} />
-        <p className="font-medium text-lg break-words">
+        <p className="truncate max-w-xs lg:max-w-lg font-medium text-lg break-words">
           <SubmissionTitle
             submission={submission}
             isCurrentUsersSubmission={isCurrentUsersSubmission}


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
Currently, long usernames are overflowing student solutions.

## This PR
- Fix username overflowing solutions by usage of `truncate`
- Add responsive `max-width` in `p` element, so overflowing doesn't occur when resizing the window.

## Issue
I was supposed to fix this a while ago but I ended up fixing the overflow in the profile card first. I decided to make a new PR because the initial issue is no longer open.

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
Below are the before and afters of two different cases.

Case 1: Longest personal name ever used || [Before](https://user-images.githubusercontent.com/112586034/204267397-580c451d-b37e-435e-b1a8-fcb9ad38b103.png) | [After](https://user-images.githubusercontent.com/112586034/204267425-f29867af-8dc4-4057-b7a5-694f234961c4.png)
Case 2: A really long username (no spaces) || [Before](https://user-images.githubusercontent.com/112586034/204267419-13c7931e-5cc3-456a-954a-36c0010fb66e.png) | [After](https://user-images.githubusercontent.com/112586034/204267429-16a004d3-186c-4501-bba1-87738e50f4f3.png)


Let me know if I missed the mark of if there is any suggestion regarding the widths when you resize the window. I feel like it could be a little bit better but I'll wait for your input. Cheers!

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behavior
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests