### PR TITLE
Fix: Heroku Review App's

### DIFF
--- a/app.json
+++ b/app.json
@@ -12,7 +12,7 @@
         { "url": "https://github.com/devforce/heroku-buildpack-cleanup" }
       ],
       "addons": [
-        "heroku-postgresql:hobby-dev",
+        "heroku-postgresql:mini",
         {
           "plan": "rediscloud:30",
           "as": "REDIS"


### PR DESCRIPTION
Because
* Heroku has removed their hobby-dev Postgresql plan

This commit:
* Use Heroku's mini Postgresql plan