### PR TITLE
Fix: Update links to #suggestions-bugs discord channel in Contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ The labels that get applied to issues and PRs in our repos have specific meaning
 * Clarifying questions - "This lesson says to use this syntax, but in a previous lesson we were told to use a different syntax. Which is correct?"
 * Other small-scale changes - "I think including an instruction about X could help minimize confusion at this step."
 
-**Significant Issues and Changes**: These will have a more significant impact on our repos, or require more work to be done in order to resolve the issue or implement the change. You should never submit a PR for a significant issue or change without first getting approval from maintainers, as we don't want your time and work to go to waste if your proposal isn't accepted. You can either go to our [suggestions-bugs Discord channel](https://discordapp.com/channels/505093832157691914/540903304046182425) to mention an issue or a proposed change, or you can simply open an issue in the appropriate repo and wait to receive a response. This channel can also be used to share a link to an issue or PR you have created if you haven't seen any activity on the actual issue/PR for a while, or to have a more real-time discussion. Just keep in mind that maintainers have busy lives - many with day jobs - and may not get to items on our repos immediately. 
+**Significant Issues and Changes**: These will have a more significant impact on our repos, or require more work to be done in order to resolve the issue or implement the change. You should never submit a PR for a significant issue or change without first getting approval from maintainers, as we don't want your time and work to go to waste if your proposal isn't accepted. You can either go to our [suggestions-bugs Discord channel](https://discord.com/channels/505093832157691914/1010231881033330819) to mention an issue or a proposed change, or you can simply open an issue in the appropriate repo and wait to receive a response. This channel can also be used to share a link to an issue or PR you have created if you haven't seen any activity on the actual issue/PR for a while, or to have a more real-time discussion. Just keep in mind that maintainers have busy lives - many with day jobs - and may not get to items on our repos immediately. 
 
 Significant issues and changes can include:
 
@@ -237,4 +237,4 @@ Once you have the repo forked and cloned, and the upstream remote has been set, 
       ![Reviewers section of GitHub's sidebar](https://user-images.githubusercontent.com/70952936/150647064-4fdd59d1-82a4-4f18-894d-0e43a5ee0ffb.jpg)
 
 ## Further Help
-Please let us know if you require any further help with any of the steps in this guide in our [suggestions-bugs Discord channel](https://discordapp.com/channels/505093832157691914/540903304046182425).
+Please let us know if you require any further help with any of the steps in this guide in our [suggestions-bugs Discord channel](https://discord.com/channels/505093832157691914/1010231881033330819).


### PR DESCRIPTION
## Because
The links to the suggestions-bugs channel in the Discord were out of date. They linked to an old channel that was not able to be used anymore.


## This PR

- Changed two links from the [old channel](https://discord.com/channels/505093832157691914/540903304046182425) to the [new channel](https://discord.com/channels/505093832157691914/1010231881033330819)


## Issue

Closes #3556 

## Additional Information
N/a


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behavior
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If applicable, this PR includes new or updated automated tests
