### PR TITLE
Improved code on line 102

### DIFF
--- a/app/javascript/components/project-submissions/components/__tests__/submissions-list.test.jsx
+++ b/app/javascript/components/project-submissions/components/__tests__/submissions-list.test.jsx
@@ -99,7 +99,7 @@ describe('submissions list', () => {
       expect(screen.queryByText('foobar')).not.toBeInTheDocument();
     });
 
-    it('does not render no submissions message when array is empty but user submission is provided', () => {
+    it('does not render \'no submissions\' message when array is empty but user submission is provided', () => {
       render(
         <ProjectSubmissionContext.Provider value={{ allSubmissionsPath: '#' }}>
           <SubmissionsList


### PR DESCRIPTION
I changed the test description to make it easier to be read, since the context of 'no submissions' wasn't very clear.

Another alternative would be using double quotation marks, but it would not fit the other descriptions in the code.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
The context of 'no submissions' wasn't clear enough in the code.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->


## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behavior
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
