### PR TITLE
Chore: Refactor path index view by extracting components

### DIFF
--- a/app/components/card_component.html.erb
+++ b/app/components/card_component.html.erb
@@ -1,4 +1,12 @@
-<div class="bg-white shadow rounded-lg dark:bg-gray-800 dark:ring-1 dark:ring-white/10 dark:ring-inset <%= classes %>" <%= html_data_attributes_for(data_attributes) %>>
+<div class="bg-white
+              shadow rounded-lg
+            dark:bg-gray-800
+              dark:ring-1
+            dark:ring-white/10
+              dark:ring-inset
+              <%= classes %>"
+     <%= html_data_attributes_for(data_attributes) %>
+>
   <%= header %>
   <%= body %>
   <%= footer %>

--- a/app/components/content_container_component.html.erb
+++ b/app/components/content_container_component.html.erb
@@ -1,3 +1,22 @@
- <div class="lesson-content max-w-prose mx-auto prose md:prose-lg prose-gray prose-a:text-gold-600 prose-code:bg-gray-100 prose-code:p-1 prose-code:font-normal dark:prose-code:bg-gray-700/40 prose-code:rounded-md break-words line-numbers dark:prose-invert dark:antialiased prose-pre:rounded-xl prose-pre:bg-slate-800 prose-pre:shadow-lg dark:prose-pre:bg-slate-800/70 dark:prose-pre:shadow-none dark:prose-pre:ring-1 dark:prose-pre:ring-slate-300/10 <%= classes %>" data-controller="syntax-highlighting" <%= html_data_attributes_for(data_attributes) %>>
+ <div class="lesson-content
+             max-w-prose
+             mx-auto prose
+             md:prose-lg
+             prose-gray
+             prose-a:text-gold-600
+             prose-code:bg-gray-100
+             prose-code:p-1
+             prose-code:font-normal
+             dark:prose-code:bg-gray-700/40
+             prose-code:rounded-md break-words
+             line-numbers dark:prose-invert
+             dark:antialiased prose-pre:rounded-xl
+             prose-pre:bg-slate-800 prose-pre:shadow-lg
+             dark:prose-pre:bg-slate-800/70 dark:prose-pre:shadow-none dark:prose-pre:ring-1
+             dark:prose-pre:ring-slate-300/10
+             <%= classes %>"
+      data-controller="syntax-highlighting"
+      <%= html_data_attributes_for(data_attributes) %>
+ >
   <%= content %>
  </div>

--- a/app/components/divider_component.html.erb
+++ b/app/components/divider_component.html.erb
@@ -1,0 +1,12 @@
+<div class="relative my-12">
+  <div class="absolute inset-0 flex items-center" aria-hidden="true">
+    <div class="w-full border-t border-gray-300"></div>
+  </div>
+  <div class="relative flex justify-center">
+    <span data-test-id='divider-message'
+          class="px-3 bg-gray-50 dark:bg-gray-900 text-2xl font-medium text-gray-800 dark:text-gray-300"
+    >
+      <%= message %>
+    </span>
+  </div>
+</div>

--- a/app/components/divider_component.rb
+++ b/app/components/divider_component.rb
@@ -1,0 +1,9 @@
+class DividerComponent < ApplicationComponent
+  def initialize(message: nil)
+    @message = message
+  end
+
+  private
+
+  attr_reader :message
+end

--- a/app/components/path_component.html.erb
+++ b/app/components/path_component.html.erb
@@ -1,0 +1,72 @@
+<% if wide? %>
+  <%# Designed primarily for a single column layout %>
+  <%= render CardComponent.new do |card| %>
+    <% card.header(classes: 'md:pb-6 md:border-b border-gray-200 dark:border-gray-600') do %>
+      <div class=" flex justify-between items-center flex-col sm:flex-row space-y-4 sm:space-y-0">
+        <div class="flex flex-col space-y-5 sm:space-x-6 sm:space-y-0 sm:flex-row items-center">
+          <%= link_to path_path(path), class: 'p-2 dark:bg-gray-700/50 rounded-full' do %>
+            <%= image_tag path.badge_uri, alt: "#{path.title} badge", class: 'w-24 h-24' %>
+          <% end %>
+
+          <div class="flex items-center flex-col sm:block">
+            <h3 class="text-sm text-gold-600"><%= tagline %></h3>
+            <%= link_to path_path(path), class: 'no-underline' do %>
+              <h2 class="text-3xl font-medium text-gray-800 dark:text-gray-300"><%= path.title %></h2>
+            <% end %>
+          </div>
+        </div>
+
+        <div class="space-x-6 justify-center hidden md:flex">
+          <%= render Paths::SelectButtonComponent.new(current_user: user, path: path, classes: 'px-12') %>
+          <%= render Paths::ViewButtonComponent.new(current_user: user, path: path, classes: 'px-12') %>
+        </div>
+      </div>
+    <% end %>
+
+    <% card.body(classes: 'pt-6 md:pb-0') do %>
+      <p class="prose prose-gray max-w-none text-gray-500 dark:text-gray-400"><%= path.description %></p>
+    <% end %>
+
+    <% card.footer do |card| %>
+      <div class="flex space-x-6 justify-center sm:items-center sm:justify-start md:hidden">
+        <%= render Paths::SelectButtonComponent.new(current_user: user, path: path, classes: 'px-10') %>
+        <%= render Paths::ViewButtonComponent.new(current_user: user, path: path, classes: 'px-10') %>
+      </div>
+    <% end %>
+  <% end %>
+<% elsif column? %>
+  <%# Designed primarily for a 2 column layout %>
+  <div class="flex gap-x-10 gap-y-6 flex-col md:flex-row">
+    <%= render CardComponent.new(classes: 'flex flex-col') do |card| %>
+      <% card.header(classes: 'flex flex-col justify-between items-center') do %>
+        <%= link_to path_path(path), class: 'p-2 dark:bg-gray-700/50 rounded-full' do %>
+          <%= image_tag path.badge_uri, alt: "#{path.title} badge", class: 'w-24 h-24' %>
+        <% end %>
+
+        <div class="w-full flex justify-between pt-6">
+          <p class=" text-gold-600">PATH</p>
+          <p class=" text-gray-500 dark:text-gray-400"><%= path.courses.size %> Courses</p>
+        </div>
+      <% end %>
+
+      <% card.body(classes: 'flex-grow') do %>
+        <%= link_to path_path(path), class: 'no-underline' do %>
+          <h2 class="text-xl font-medium pb-4 text-gray-800 dark:text-gray-200">
+            <%= path.title %>
+          </h2>
+        <% end %>
+
+        <p class="prose prose-gray max-w-none text-gray-500 dark:text-gray-400">
+          <%= path.description %>
+        </p>
+      <% end %>
+
+      <% card.footer do %>
+        <div class="flex space-x-6 items-center justify-center sm:justify-start">
+          <%= render Paths::SelectButtonComponent.new(current_user: user, path:, classes: 'px-10 lg:px-12') %>
+          <%= render Paths::ViewButtonComponent.new(current_user: user, path:, classes: 'px-10 lg:px-12') %>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/components/path_component.rb
+++ b/app/components/path_component.rb
@@ -1,0 +1,24 @@
+class PathComponent < ApplicationComponent
+  def initialize(path:, style: :wide, tagline: nil, classes: nil)
+    @path = path
+    @style = style
+    @tagline = tagline
+    @classes = classes
+  end
+
+  private
+
+  attr_reader :path, :user, :style, :tagline, :classes
+
+  def before_render
+    @user = helpers.current_user
+  end
+
+  def wide?
+    style == :wide
+  end
+
+  def column?
+    style == :column
+  end
+end

--- a/app/views/paths/index.html.erb
+++ b/app/views/paths/index.html.erb
@@ -4,83 +4,13 @@
   <div class="max-w-4xl mx-auto">
     <h1 class="page-heading-title">All Paths</h1>
 
-    <%= render CardComponent.new do |card| %>
-      <% card.header(classes: 'md:pb-6 md:border-b border-gray-200 dark:border-gray-600') do %>
-        <div class=" flex justify-between items-center flex-col sm:flex-row space-y-4 sm:space-y-0">
-          <div class="flex flex-col space-y-5 sm:space-x-6 sm:space-y-0 sm:flex-row items-center">
-            <%= link_to path_path(@foundations), class: 'p-2 dark:bg-gray-700/50 rounded-full' do %>
-              <%= image_tag @foundations.badge_uri, alt: "#{@foundations.title} badge", class: 'w-24 h-24' %>
-            <% end %>
-            <div class="flex items-center flex-col sm:block">
-              <h3 class="text-sm text-gold-600">Start here</h3>
-              <%= link_to path_path(@foundations), class: 'no-underline' do %>
-                <h2 class="text-3xl font-medium text-gray-800 dark:text-gray-300">Foundations</h2>
-              <% end %>
-            </div>
-          </div>
+    <%= render PathComponent.new(path: @foundations, style: :wide, tagline: 'Start here') %>
 
-          <div class="space-x-6 justify-center hidden md:flex">
-            <%= render Paths::SelectButtonComponent.new(current_user:, path: @foundations, classes: 'px-12') %>
-            <%= render Paths::ViewButtonComponent.new(current_user:, path: @foundations, classes: 'px-12') %>
-          </div>
-        </div>
-      <% end %>
-
-      <% card.body(classes: 'pt-6 md:pb-0') do %>
-        <p class="prose prose-gray max-w-none text-gray-500 dark:text-gray-400"><%= @foundations.description %></p>
-      <% end %>
-
-      <% card.footer do |card| %>
-        <div class="flex space-x-6 justify-center sm:items-center sm:justify-start md:hidden">
-          <%= render Paths::SelectButtonComponent.new(current_user:, path: @foundations, classes: 'px-10') %>
-          <%= render Paths::ViewButtonComponent.new(current_user:, path: @foundations, classes: 'px-10') %>
-        </div>
-      <% end %>
-    <% end %>
-
-    <div class="relative my-12">
-      <div class="absolute inset-0 flex items-center" aria-hidden="true">
-        <div class="w-full border-t border-gray-300"></div>
-      </div>
-      <div class="relative flex justify-center">
-        <span class="px-3 bg-gray-50 dark:bg-gray-900 text-2xl font-medium text-gray-800 dark:text-gray-300"> Then choose a learning path:</span>
-      </div>
-    </div>
+    <%= render DividerComponent.new(message: 'Then choose a learning path') %>
 
     <div class="flex gap-x-10 gap-y-6 flex-col md:flex-row">
       <% @fullstack_paths.each do |path| %>
-
-        <%= render CardComponent.new(classes: 'flex flex-col') do |card| %>
-          <% card.header(classes: 'flex flex-col justify-between items-center') do %>
-            <%= link_to path_path(path), class: 'p-2 dark:bg-gray-700/50 rounded-full' do %>
-              <%= image_tag path.badge_uri, alt: "#{path.title} badge", class: 'w-24 h-24' %>
-            <% end %>
-
-            <div class="w-full flex justify-between pt-6">
-              <p class=" text-gold-600">PATH</p>
-              <p class=" text-gray-500 dark:text-gray-400"><%= path.courses.size %> Courses</p>
-            </div>
-          <% end %>
-
-          <% card.body(classes: 'flex-grow') do %>
-            <%= link_to path_path(path), class: 'no-underline' do %>
-              <h2 class="text-xl font-medium pb-4 text-gray-800 dark:text-gray-200">
-                <%= path.title %>
-              </h2>
-            <% end %>
-
-            <p class="prose prose-gray max-w-none text-gray-500 dark:text-gray-400">
-              <%= path.description %>
-            </p>
-          <% end %>
-
-          <% card.footer do %>
-            <div class="flex space-x-6 items-center justify-center sm:justify-start">
-              <%= render Paths::SelectButtonComponent.new(current_user:, path:, classes: 'px-10 lg:px-12') %>
-              <%= render Paths::ViewButtonComponent.new(current_user:, path:, classes: 'px-10 lg:px-12') %>
-            </div>
-          <% end %>
-        <% end %>
+        <%= render PathComponent.new(path: path, style: :column) %>
       <% end %>
     </div>
   </div>

--- a/spec/components/divider_component_spec.rb
+++ b/spec/components/divider_component_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe DividerComponent, type: :component do
+  it 'renders the component with the provided message' do
+    component = described_class.new(message: 'Quite divisive')
+
+    render_inline(component)
+
+    expect(page).to have_selector("[data-test-id='divider-message']", text: 'Quite divisive')
+  end
+
+  it 'renders the component without a message' do
+    component = described_class.new
+
+    render_inline(component)
+
+    expect(page).to have_selector("[data-test-id='divider-message']", text: nil)
+  end
+end

--- a/spec/components/path_component_spec.rb
+++ b/spec/components/path_component_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe PathComponent, type: :component do
+  # Todo
+end

--- a/spec/components/previews/announcement_component_preview.rb
+++ b/spec/components/previews/announcement_component_preview.rb
@@ -1,12 +1,12 @@
 class AnnouncementComponentPreview < ViewComponent::Preview
   # @param message [String] text "The text to display in the announcement"
   def with_announcment(message: 'Hello!')
-    render(AnnouncementComponent.new(announcement: default_announcment(message:)))
+    render(AnnouncementComponent.new(announcement: default_announcement(message:)))
   end
 
   private
 
-  def default_announcment(**opts)
+  def default_announcement(**opts)
     defaults = {
       expires_at: DateTime.tomorrow,
       user_id: 1,

--- a/spec/components/previews/content_container_component_preview.rb
+++ b/spec/components/previews/content_container_component_preview.rb
@@ -1,0 +1,9 @@
+class ContentContainerComponentPreview < ViewComponent::Preview
+  # @!group
+  # @param content [String] text "The content to be contained"
+  def default(content: 'This is where the content goes')
+    render ContentContainerComponent.new do
+      content
+    end
+  end
+end

--- a/spec/components/previews/divider_component_preview.rb
+++ b/spec/components/previews/divider_component_preview.rb
@@ -1,0 +1,15 @@
+class DividerComponentPreview < ViewComponent::Preview
+  # @!group
+  def with_text
+    render DividerComponent.new(message: 'Dividing text!')
+  end
+
+  def without_text
+    render DividerComponent.new
+  end
+
+  # @param message [String] text "The text to display in the divider"
+  def with_param(message: 'Change me in params')
+    render DividerComponent.new(message:)
+  end
+end

--- a/spec/components/previews/path_component_preview.rb
+++ b/spec/components/previews/path_component_preview.rb
@@ -1,0 +1,13 @@
+class PathComponentPreview < ViewComponent::Preview
+  # @!group
+  def wide
+    render(PathComponent.new(path: Path.first, style: :wide))
+  end
+
+  def column
+    render(PathComponent.new(path: Path.first, style: :column))
+  end
+
+  # TODO: Currently will display the logged in / not logged in version based on global state.
+  # Configure the lookbook layout to more easily inject a `current_user` for state based previews
+end


### PR DESCRIPTION
Todo: Path component spec

Because:

This PR:
* Refactor path index view to use a component
* Extract divider to a component
* Add previews to new components + content container
* Several minor formatting changes

Additional Notes:
* Inspired by semi-related spike on a different feature, splitting out the component refactoring from that work