### PR TITLE
Feature: add link to go back to a lesson from project submissions page

### DIFF
--- a/app/assets/images/icons/arrow-left-circle.svg
+++ b/app/assets/images/icons/arrow-left-circle.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M11.25 9l-3 3m0 0l3 3m-3-3h7.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+</svg>

--- a/app/javascript/components/project-submissions/containers/project-submissions-container.jsx
+++ b/app/javascript/components/project-submissions/containers/project-submissions-container.jsx
@@ -117,7 +117,7 @@ const ProjectSubmissions = ({ submissions, userSubmission }) => {
     <div className="mb-8 text-left">
       <div className="flex flex-col space-y-6 justify-between items-center pb-8 text-center md:space-y-0 md:text-left md:flex-row">
         <div className="flex md:flex-start flex-col space-y-1">
-          <h3 className="text-4xl font-medium">Solutions:</h3>
+          <h3 className="text-4xl font-medium" id="solutions">Solutions:</h3>
           <h4 data-test-id="course-lesson-title" className="text-xl text-gray-500 dark:text-gray-400">
             {course.title}
             : (

--- a/app/views/lessons/project_submissions/index.html.erb
+++ b/app/views/lessons/project_submissions/index.html.erb
@@ -15,6 +15,6 @@
     <%== pagy_nav(@pagy) %>
   </div>
   <div class="text-center">
-    <%= link_to 'Go back to lesson', @lesson %>
+    <nav><%= link_to 'Go back to lesson', @lesson, class: 'text-xl font-medium' %></nav>
   </div>
 </div>

--- a/app/views/lessons/project_submissions/index.html.erb
+++ b/app/views/lessons/project_submissions/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="page-container">
  <div>
-    <%= link_to lesson_path(@lesson, anchor: "solutions"), class: "inline-flex items-center pb-10 text-gray-600 text-base hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200 gap-2" do %>
+    <%= link_to lesson_path(@lesson, anchor: 'solutions'), class: 'inline-flex items-center pb-10 text-gray-600 text-base hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200 gap-2' do %>
       <%= inline_svg_tag 'icons/arrow-left-circle.svg', class: '', aria: true, title: 'Back to lesson icon' %>
       Back to lesson
     <% end %>

--- a/app/views/lessons/project_submissions/index.html.erb
+++ b/app/views/lessons/project_submissions/index.html.erb
@@ -14,4 +14,7 @@
   <div class="text-center">
     <%== pagy_nav(@pagy) %>
   </div>
+  <div class="text-center">
+    <%= link_to 'Go back to lesson', @lesson %>
+  </div>
 </div>

--- a/app/views/lessons/project_submissions/index.html.erb
+++ b/app/views/lessons/project_submissions/index.html.erb
@@ -1,6 +1,12 @@
 <%= title(@lesson.title) %>
 
 <div class="page-container">
+ <div>
+    <%= link_to lesson_path(@lesson, anchor: "solutions"), class: "inline-flex items-center pb-10 text-gray-600 text-base hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200 gap-2" do %>
+      <%= inline_svg_tag 'icons/arrow-left-circle.svg', class: '', aria: true, title: 'Back to lesson icon' %>
+      Back to lesson
+    <% end %>
+  </div>
   <%= react_component(
         'project-submissions/index',
         {
@@ -13,8 +19,5 @@
       ) %>
   <div class="text-center">
     <%== pagy_nav(@pagy) %>
-  </div>
-  <div class="text-center">
-    <nav><%= link_to 'Go back to lesson', @lesson, class: 'text-xl font-medium' %></nav>
   </div>
 </div>


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
There's no easy way to navigate back to the lesson one is currently on when browsing its submissions page.


## This PR
- Adds a link to go back to lesson while browsing project submissions.

![image](https://user-images.githubusercontent.com/95084627/211673623-7b9de470-be10-4d21-832b-6e8513dbf764.png)

## Issue

Closes #3518 

## Additional Information

The way this is implemented it probably will get user to land on the very top of the page as if they were there first time. Possibly for best UX, we should get them back to the `Solutions` component but that'd require having an anchor in there. Not sure if that anchor would render in the `Lesson contents` and if that'd be something we want to happen. We possibly might make the link anchor onto `Additional Resources` - somewhat close and we have that already.

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behavior
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If applicable, this PR includes new or updated automated tests
