### PR TITLE
Fix: Add links to open issues and PRs in CONTRIBUTING doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ Before attempting to make any changes, be sure to read the following Wiki pages:
 
 ### Check Before Doing Anything
 
-It's important that you look through any open issues or PRs in a repo before attempting to submit a new issue or work on a change, regardless of the complexity. This will help avoid any duplicates from being made, as well as prevent more than one person working on the same thing at the same time.
+It's important that you look through any open [issues](https://github.com/TheOdinProject/theodinproject/issues?page=1&q=is%3Aissue+is%3Aopen) or [PRs](https://github.com/TheOdinProject/theodinproject/pulls) in a repo before attempting to submit a new issue or work on a change, regardless of the complexity. This will help avoid any duplicates from being made, as well as prevent more than one person working on the same thing at the same time.
 
 If your proposal already exists in an open issue or PR, but you feel there are details missing, comment on the issue/PR to let those involved know of those missing details.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ Before attempting to make any changes, be sure to read the following Wiki pages:
 
 ### Check Before Doing Anything
 
-It's important that you look through any open [issues](https://github.com/TheOdinProject/theodinproject/issues?page=1&q=is%3Aissue+is%3Aopen) or [PRs](https://github.com/TheOdinProject/theodinproject/pulls) in a repo before attempting to submit a new issue or work on a change, regardless of the complexity. This will help avoid any duplicates from being made, as well as prevent more than one person working on the same thing at the same time.
+It's important that you look through any open [issues](https://github.com/TheOdinProject/theodinproject/issues) or [pull requests](https://github.com/TheOdinProject/theodinproject/pulls) in a repo before attempting to submit a new issue or work on a change, regardless of the complexity. This will help avoid any duplicates from being made, as well as prevent more than one person working on the same thing at the same time.
 
 If your proposal already exists in an open issue or PR, but you feel there are details missing, comment on the issue/PR to let those involved know of those missing details.
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
The background here is that I have a different minor change to propose (to one of the lessons), and I was about to bring it up on Discord in [#suggestions-bugs](https://discord.com/channels/505093832157691914/1010231881033330819), but then I was wondering if maybe it's a small enough change that it would be better to just make it in a fork and open a PR. So then I went to the [#faq](https://discord.com/channels/505093832157691914/823266307293839401), and while it's not directly addressed there, there is a link to GitHub, to follow the [contributing guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md). So I read through that, and found the ["Check Before Doing Anything"](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md#check-before-doing-anything) section, which mentioned checking open issues and PRs. But it takes a little more work to figure out how to do that, and someone without experience with GitHub might have trouble with that, so I think adding these links would improve clarity. Even for someone who's not new to GitHub, it would improve productivity.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
* Add links to open issues and PRs in the "Check Before Doing Anything" section of the CONTRIBUTING doc.
* The only change is adding the links to the appropriate GitHub pages. The actual text content is unchanged.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
This PR is **not** associated with any issue. This document itself indicates that simple changes can directly open a PR.

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
*none*

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behavior
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] I have verified all tests and linters pass after making these changes.
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If applicable, this PR includes new or updated automated tests
