### PR TITLE
Feature: New Rails Deployment Lesson

### DIFF
--- a/db/fixtures/lessons/ruby_on_rails_lessons.rb
+++ b/db/fixtures/lessons/ruby_on_rails_lessons.rb
@@ -7,13 +7,6 @@ def ruby_on_rails_lessons
       github_path: '/ruby_on_rails/introduction/how_this_course_will_work.md',
       identifier_uuid: '5e9d7694-e930-4090-ba4e-1ae3b19d513e',
     },
-    'Preparing for Deployment' => {
-      title: 'Preparing for Deployment',
-      description: 'Get setup to use Heroku to deploy our web applications',
-      is_project: false,
-      github_path: '/ruby_on_rails/introduction/preparing_for_deployment.md',
-      identifier_uuid: '78c530bf-f358-4e6c-924d-8767efc37533',
-    },
     'Installing Rails' => {
       title: 'Installing Rails',
       description: 'Get setup for this course by installing Rails.',
@@ -54,7 +47,7 @@ def ruby_on_rails_lessons
     },
     'Deployment' => {
       title: 'Deployment',
-      description: "There's nothing quite like seeing your application on a real website.  We'll show you how it's done.",
+      description: "There's nothing quite like seeing your application on a real website. We'll show you how it's done.",
       is_project: false,
       github_path: '/ruby_on_rails/rails_basics/deployment.md',
       identifier_uuid: '122dffc9-d98e-490e-8e58-e5f7c66909d4',

--- a/db/fixtures/paths/full_stack_rails/courses/rails.rb
+++ b/db/fixtures/paths/full_stack_rails/courses/rails.rb
@@ -19,7 +19,6 @@ course.add_section do |section|
 
   section.add_lessons(
     ruby_on_rails_lessons.fetch('How this Course Will Work'),
-    ruby_on_rails_lessons.fetch('Preparing for Deployment'),
     ruby_on_rails_lessons.fetch('Installing Rails'),
     ruby_on_rails_lessons.fetch('A Railsy Web Refresher')
   )
@@ -37,8 +36,8 @@ course.add_section do |section|
     ruby_on_rails_lessons.fetch('Routing'),
     ruby_on_rails_lessons.fetch('Controllers'),
     ruby_on_rails_lessons.fetch('Views'),
-    ruby_on_rails_lessons.fetch('Deployment'),
     ruby_on_rails_lessons.fetch('Blog App'),
+    ruby_on_rails_lessons.fetch('Deployment'),
   )
 end
 


### PR DESCRIPTION
Because:
* We need to provide more deployment options since Heroku no longer has a free tier.

This commit:
* Remove preparing for deployment lesson - it was all about setting up Heroku and no longer needed.
* Move deployment lesson after the first blog project so we can give the learner the assignment of deploying their finished blog app.

Curriculum changes: https://github.com/TheOdinProject/curriculum/pull/25042
