### PR TITLE
Chore: Automate Setting New UUID's When Running the Seeds Task

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,6 +10,7 @@ load './db/fixtures/lessons/getting_hired_lessons.rb'
 load './db/fixtures/lessons/node_js_lessons.rb'
 load './db/fixtures/lessons/git_lessons.rb'
 
+Rails::Generators.invoke('seed_uuids') if Rails.env.development?
 SeedFu.seed
 
 # GENERATE SUCCESS STORY Content

--- a/lib/generators/rails/seed_uuids/USAGE
+++ b/lib/generators/rails/seed_uuids/USAGE
@@ -1,0 +1,5 @@
+Description:
+bin/rails generate seed_uuids
+
+This will replace "create_uuid" in the seeds file with a real uuid
+

--- a/lib/generators/rails/seed_uuids/seed_uuids_generator.rb
+++ b/lib/generators/rails/seed_uuids/seed_uuids_generator.rb
@@ -1,0 +1,9 @@
+class Rails::SeedUuidsGenerator < Rails::Generators::Base
+  def generate_uuids
+    seed_files = Dir.glob('db/fixtures/**/*').reject { |f| File.directory?(f) }
+
+    seed_files.each do |file_name|
+      gsub_file(file_name, 'create_uuid', SecureRandom.uuid)
+    end
+  end
+end


### PR DESCRIPTION
Because:
* It is frustrating and time consuming having to manually generate uuids and then copy and paste them into the seed files.
* To get a random uuid automatically created for you, you just need to give any identifier_uuid attribute the value of `"create_uuid"` and then run the seeds as normal.

This commit.
* Adds a seed_uuids generator which will look for any "create_uuid" strings within the fixtures files and replace any instances with a new random uuid.
* New generator can be invoked form the command line manually with `bin/rails g seed_uuids`.
* Generator is invoked during the seed task everything is done with one command instead of needing to manually run the uuid generator first and then and then the seeds task.