### PR TITLE
Chore: Generate unique UUID's for matches in the same seed file

### DIFF
--- a/lib/generators/rails/seed_uuids/seed_uuids_generator.rb
+++ b/lib/generators/rails/seed_uuids/seed_uuids_generator.rb
@@ -3,7 +3,9 @@ class Rails::SeedUuidsGenerator < Rails::Generators::Base
     seed_files = Dir.glob('db/fixtures/**/*').reject { |f| File.directory?(f) }
 
     seed_files.each do |file_name|
-      gsub_file(file_name, 'create_uuid', SecureRandom.uuid)
+      gsub_file file_name, 'create_uuid' do
+        SecureRandom.uuid
+      end
     end
   end
 end


### PR DESCRIPTION
Because:
* It was finding all matches in a file and replacing them all with the same UUID.

This commit:
* Use a block with `gsub_file` as it will generate a new uuid for each match.