### PR TITLE
Feature: Move Backend Section From Foundations

### DIFF
--- a/db/fixtures/lessons/shared_lessons.rb
+++ b/db/fixtures/lessons/shared_lessons.rb
@@ -1,0 +1,18 @@
+def shared_lessons
+  {
+    'Introduction to the Back End' => {
+      title: 'Introduction to the Back End',
+      description: 'A brief introduction to the wonderful world of server-side programming',
+      is_project: false,
+      github_path: '/shared/the_back_end/introduction_to_the_backend_lesson.md',
+      identifier_uuid: '9dfc032b-1919-41f8-9445-1c53d7be599b',
+    },
+    'Introduction to Frameworks' => {
+      title: 'Introduction to Frameworks',
+      description: "Let's figure out what all the hubbub is all about.",
+      is_project: false,
+      github_path: '/shared/the_back_end/introduction_to_frameworks.md',
+      identifier_uuid: '18a063b0-c22c-4415-aba4-eb2865a27fc4',
+    }
+  }
+end

--- a/db/fixtures/paths/foundations/seed.rb
+++ b/db/fixtures/paths/foundations/seed.rb
@@ -153,20 +153,6 @@ course.add_section do |section|
 end
 
 # +++++++++++++++++++++++++++++++
-# SECTION - The Back End
-# +++++++++++++++++++++++++++++++
-course.add_section do |section|
-  section.title = 'The Back End'
-  section.description = "Here you'll learn about the back end, where we'll demystify what goes on behind the scenes on a web server."
-  section.identifier_uuid = '1bda637d-2590-4e0e-b988-a74605d09a8a'
-
-  section.add_lessons(
-    foundation_lessons.fetch('Introduction to the Back End'),
-    foundation_lessons.fetch('Introduction to Frameworks'),
-  )
-end
-
-# +++++++++++++++++++++++++++++++
 # SECTION - Conclusion
 # +++++++++++++++++++++++++++++++
 course.add_section do |section|

--- a/db/fixtures/paths/full_stack_javascript/courses/node_js.rb
+++ b/db/fixtures/paths/full_stack_javascript/courses/node_js.rb
@@ -18,6 +18,8 @@ course.add_section do |section|
   section.identifier_uuid = 'f8ec5b6e-5f36-4164-add9-a6b1ff60e7a2'
 
   section.add_lessons(
+    shared_lessons.fetch('Introduction to the Back End'),
+    shared_lessons.fetch('Introduction to Frameworks'),
     node_js_lessons.fetch('Introduction: What is NodeJs'),
     node_js_lessons.fetch('Getting Started'),
     node_js_lessons.fetch('Debugging Node'),

--- a/db/fixtures/paths/full_stack_rails/courses/rails.rb
+++ b/db/fixtures/paths/full_stack_rails/courses/rails.rb
@@ -19,6 +19,8 @@ course.add_section do |section|
 
   section.add_lessons(
     ruby_on_rails_lessons.fetch('How this Course Will Work'),
+    shared_lessons.fetch('Introduction to the Back End'),
+    shared_lessons.fetch('Introduction to Frameworks'),
     ruby_on_rails_lessons.fetch('Installing Rails'),
     ruby_on_rails_lessons.fetch('A Railsy Web Refresher')
   )

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,6 +9,7 @@ load './db/fixtures/lessons/react_lessons.rb'
 load './db/fixtures/lessons/getting_hired_lessons.rb'
 load './db/fixtures/lessons/node_js_lessons.rb'
 load './db/fixtures/lessons/git_lessons.rb'
+load './db/fixtures/lessons/shared_lessons.rb'
 
 Rails::Generators.invoke('seed_uuids') if Rails.env.development?
 SeedFu.seed


### PR DESCRIPTION
Because:
* We introduce the backend at the end of foundations, well before that information will become relevant. By the time learners get to the backend courses in each path, this information will no longer be fresh in their heads. This moves those lessons closer to where they will be useful for learners.

This commit:
* Add a shared lessons seed file where we can keep lessons that have the same content but are in different courses in each path.
* Move foundation backend lessons to the introduction section of the Rails and Node courses.
