### PR TITLE
Fix: Stretched TOP contributor images bug for Safari browser

### DIFF
--- a/app/views/static_pages/contributing/_hall_of_fame.html.erb
+++ b/app/views/static_pages/contributing/_hall_of_fame.html.erb
@@ -13,7 +13,7 @@
       <% members.each do |member| %>
         <div class="col-span-4 sm:col-span-3 md:col-span-2">
           <%= link_to(member[:github_url], target: '_blank', rel: 'noreferrer') do %>
-            <%= image_tag(member[:image], alt: member[:name], class: 'h-full') %>
+            <%= image_tag(member[:image], alt: member[:name]) %>
           <% end %>
         </div>
       <% end %>


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
This solves the bug on the [Contribute Page](https://www.theodinproject.com/contributing) Hall of Fame section where the images are vertically stretched using the Safari browser. 

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Removed the class `h-full` from each image. This was forcing all images to have a `height:100%`.
- When the `h-full` class is removed, the `height:auto` is set with the code below:
`img, video { 
height: auto;
max-width: 100%;
}`

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #3662

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behavior
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If applicable, this PR includes new or updated automated tests
