### PR TITLE
Fix: Lesson and Course Page Caching

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -45,6 +45,10 @@ class ApplicationController < ActionController::Base
     Sentry.set_user(id: current_user.id, email: current_user.email)
   end
 
+  def set_cache_control_header_to_no_store
+    response.cache_control.replace(no_store: true)
+  end
+
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:username])
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,4 +1,6 @@
 class CoursesController < ApplicationController
+  before_action :set_cache_control_header_to_no_store
+
   def show
     @path = Path.find(params[:path_id])
     @course = @path.courses.friendly.find(params[:id])

--- a/app/controllers/lessons/completions_controller.rb
+++ b/app/controllers/lessons/completions_controller.rb
@@ -6,14 +6,14 @@ module Lessons
     def create
       lesson = Lesson.find(params[:lesson_id])
 
-      lesson_completion = current_user.lesson_completions.new(
+      lesson_completion = current_user.lesson_completions.find_or_create_by(
         lesson:,
         lesson_identifier_uuid: lesson.identifier_uuid,
         course: lesson.course,
         path: lesson.course.path,
       )
 
-      if lesson_completion.save!
+      if lesson_completion
         render json: lesson_completion, status: :created
       else
         render json: { errors: lesson_completion.errors.full_messages }, status: :unprocessable_entity

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -1,4 +1,6 @@
 class LessonsController < ApplicationController
+  before_action :set_cache_control_header_to_no_store
+
   def show
     @lesson = Lesson.find(params[:id])
 


### PR DESCRIPTION
Because:
* Lesson completions check boxes can sometimes get into the wrong state due to http caching when using the browsers back and forward navigation buttons.
* Closes https://github.com/TheOdinProject/theodinproject/issues/3717

This commit:
* Don't use http no cache header with lesson and course pages so a fresh page is always sent in response.