### PR TITLE
Chore: Ensure Shakapacker package and gem versions are the same

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -7,6 +7,7 @@ default: &default
   public_output_path: packs
   cache_path: tmp/webpacker
   webpack_compile_output: true
+  ensure_consistent_versioning: true
 
   # Additional paths webpack should look up modules
   # ['app/assets', 'engine/foo/app/assets']

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "regenerator-runtime": "^0.13.10",
     "sass": "^1.57.1",
     "sass-loader": "^13.2.0",
-    "shakapacker": "6.5.5",
+    "shakapacker": "6.6",
     "stickyfilljs": "^2.1.0",
     "stimulus-use": "^0.51.3",
     "stimulus-validation": "^1.0.1-beta.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7509,10 +7509,10 @@ setprototypeof@1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-shakapacker@6.5.5:
-  version "6.5.5"
-  resolved "https://registry.yarnpkg.com/shakapacker/-/shakapacker-6.5.5.tgz#34c027b3d3b34b8241a946d4af256df81c0c04f7"
-  integrity sha512-KsDhjihjmkJVpdnuDvHj70RzRjreXcnMQtePp+TkHzi4sXO8gwt0btoTNrwuLrgxOfac7UQadDFYFGzJwoPz5w==
+shakapacker@6.6:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/shakapacker/-/shakapacker-6.6.0.tgz#1e372a7ce6fa93f1a7bd1820737b8168679eb220"
+  integrity sha512-7sNnv8PXMlgm2Ob7vZOayLKu0+PPMN3q0HEyAlkFIJtHJt7wA3p1rObhlk0/OrNeBa4dio/9HiBUeEU7bZsHvw==
   dependencies:
     glob "^7.2.0"
     js-yaml "^4.1.0"


### PR DESCRIPTION
Because:
* Resolve warning: Webpacker::VersionChecker - Version mismatch detected

This commit:
* Enable ensure_consistent_versioning option in Webpack config
* Bump Shakapacker package to 6.6 to match the gem version.
