### PR TITLE
Fix: fix project submissions' page overflow bug.

### DIFF
--- a/app/javascript/components/project-submissions/components/submission.jsx
+++ b/app/javascript/components/project-submissions/components/submission.jsx
@@ -84,7 +84,7 @@ const Submission = forwardRef(({
           )
           : (
             <button
-              className="submissions-flag text-gray-300 hover:text-gray-500 dark:text-gray-400 dark:hover:text-gray-300 hint--top"
+              className="submissions-flag text-gray-300 hover:text-gray-500 dark:text-gray-400 dark:hover:text-gray-300 hint--top-left"
               aria-label="Report submission"
               type="button"
               data-test-id="flag-btn"

--- a/app/javascript/stylesheets/pagy.css
+++ b/app/javascript/stylesheets/pagy.css
@@ -1,5 +1,5 @@
 .pagy-nav {
-  @apply flex space-x-2 my-8 justify-center;
+  @apply flex space-x-2 my-8 mx-auto w-fit;
 }
 
 .pagy-nav .page a,

--- a/app/views/lessons/project_submissions/index.html.erb
+++ b/app/views/lessons/project_submissions/index.html.erb
@@ -17,7 +17,7 @@
           userSubmission: @user_submission
         }
       ) %>
-  <div class="text-center" style="overflow-x: auto;">
+  <div class="text-center overflow-x-auto">
     <%== pagy_nav(@pagy) %>
   </div>
 </div>

--- a/app/views/lessons/project_submissions/index.html.erb
+++ b/app/views/lessons/project_submissions/index.html.erb
@@ -17,7 +17,7 @@
           userSubmission: @user_submission
         }
       ) %>
-  <div class="text-center">
+  <div class="text-center" style="overflow-x: auto;">
     <%== pagy_nav(@pagy) %>
   </div>
 </div>


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
This pull request fixes the page overflow issue on The Odin Project's project_submissions page. Currently, when users click on the "View full list of solutions" link on any project page ( eg. [View full list of solutions](https://www.theodinproject.com/lessons/596/project_submissions) ), the resulting page layout is broken on mobile devices and smaller screen sizes. The issue is caused by two main problems: the hint--top class from the Hint.css library and the pagination's fixed width as shown below with some screenshots.

1.  The hint--top class from Hint.css library was contributing to the page overflow. Below is a screenshot to demostrate my claim. 



#### Bug: Overflow due to hint--top class from Hint.css library - Screenshot
![bug-caused-by-hint-css-library](https://user-images.githubusercontent.com/99342564/234033020-ba436ffc-126c-4466-ba53-4cbc2f0e1150.png)



2. The pagination is not responsive and also results to page overflow. Below is the screenshot.

#### Bug: Overflow due to fixed with on pagination - Screenshot
![bug-page-overflow](https://user-images.githubusercontent.com/99342564/234034239-8cc0a65f-6f83-42c9-9601-90ae69abca04.png)



After fixing the above below are the screenshot of the results;

1. Change hint--top class to hint--top-left.

#### Fix - Screenshot
![fix-page-overflow3](https://user-images.githubusercontent.com/99342564/234036608-0a6679a2-f88f-4c32-af9e-b241ad31585e.png)



2. Add overflow-x: auto; rule to nav pagination container. This makes pagination nav links scrollable on smaller devices.

#### Fix - Screenshot
![fix-page-overflow2](https://user-images.githubusercontent.com/99342564/234037284-3718077b-b509-4806-9606-8093ece2ec12.png)



## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- [Replaced the justify-center utility class with the mx-auto and w-fit classes to ensure the container is centered and the width adjusts to the content](https://github.com/TheOdinProject/theodinproject/commit/0b22f899de27dec30f75bf06c41ba2c49d413f02)

- [Added the overflow-x: auto rule to the pagy_nav container div element to make the pagination nav links scrollable on smaller devices.](https://github.com/TheOdinProject/theodinproject/commit/dbef0c9d41eaf93823959ce9d60a3dc0ece036a9)

- [Changed the hint.css library class from hint--top to hint--top-left to prevent the hint from overflowing the container.](https://github.com/TheOdinProject/theodinproject/commit/7ea1a443d9c1c2aeff3deafc949163ffd033174d)

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
After the fixes the project_submissions' pages becomes fully responsive on smaller screen devices as well as bigger screen devices.

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behavior
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
