### PR TITLE
Chore: Move Introduction to HTML & CSS Lesson

### DIFF
--- a/db/fixtures/lessons/foundation_lessons.rb
+++ b/db/fixtures/lessons/foundation_lessons.rb
@@ -197,7 +197,7 @@ def foundation_lessons
       title: 'Introduction to HTML and CSS',
       description: 'Get started by learning about HTML and CSS, the building blocks of everything on the web.',
       is_project: false,
-      github_path: '/foundations/html_css/intro-to-html-css.md',
+      github_path: '/foundations/html_css/html-foundations/intro-to-html-css.md',
       identifier_uuid: '1e460bf6-5a8c-481f-a3f7-04e0dd938fac',
     },
     'HTML Boilerplate' => {


### PR DESCRIPTION
Because:
* This lesson was in an incorrect folder in the curriculum repo.
* Related curriculum PR: https://github.com/TheOdinProject/curriculum/pull/25474

This commit:
* Move it into the html_foundations folder which represents its section on the site.