### PR TITLE
Chore: Add Capybara and Factorybot to Rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,8 @@ require:
   - rubocop-performance
   - rubocop-rails
   - rubocop-rspec
+  - rubocop-capybara
+  - rubocop-factory_bot
 
 AllCops:
   Include:


### PR DESCRIPTION
Because:
* They're already loaded as part of Rubocop-rspec. Silences recommendation to add when linting