### PR TITLE
Chore: Rename and Move Landing Page Project Folder Location.

### DIFF
--- a/db/fixtures/lessons/foundation_lessons.rb
+++ b/db/fixtures/lessons/foundation_lessons.rb
@@ -309,7 +309,7 @@ def foundation_lessons
       title: 'Landing Page',
       description: 'Build a complete landing page from a given web design.',
       is_project: true,
-      github_path: '/foundations/html_css/project/html-css-foundations-project.md',
+      github_path: '/foundations/html_css/flexbox/project-landing-page.md',
       accepts_submission: true,
       has_live_preview: true,
       identifier_uuid: '22e0c585-c146-4dab-9dc0-17a20f0ecbc5',


### PR DESCRIPTION
Because:
* Renaming it "project-landing-page" to make the file easier to find and moving it to the flexbox folder which is the section where the project is displayed on the site.
* Related curriculum PR: https://github.com/TheOdinProject/curriculum/pull/25509
