### PR TITLE
Fix: Remove hardcoded id from course_builder_spec.rb

### DIFF
--- a/spec/lib/seeds/course_builder_spec.rb
+++ b/spec/lib/seeds/course_builder_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Seeds::CourseBuilder do
     end
   end
 
-  let(:path) { create(:path, id: 100) }
+  let(:path) { create(:path) }
   let(:position) { 1 }
 
   describe '.build' do


### PR DESCRIPTION
Because:
- It causes intermittent `ActiveRecord::RecordNotUnique` errors

[Example failure](https://app.circleci.com/pipelines/github/TheOdinProject/theodinproject/5376/workflows/d570a01e-3cc4-4505-a545-224c60b4e409/jobs/15167/tests#failed-test-0)