### PR TITLE
Feature: Admin menu link for Sidekiq Dashboard

### DIFF
--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -232,6 +232,7 @@ ActiveAdmin.setup do |config|
 
   config.namespace :admin do |admin|
     admin.build_menu :utility_navigation do |menu|
+      menu.add label: 'Sidekiq', url: '/sidekiq'
       menu.add label: 'Feature Flags', url: '/admin/feature_flags'
       admin.add_logout_button_to_menu menu
     end


### PR DESCRIPTION
Because:
* Save admins from needing to remember the url path for the sidekiq dashboard.

<img width="363" alt="Screenshot 2023-06-01 at 17 35 37" src="https://github.com/TheOdinProject/theodinproject/assets/7963776/81f0510a-7921-4446-a9b0-43f685b2c2bc">

