### PR TITLE
Fix: Admin Flags Button Styling

### DIFF
--- a/app/views/admin/flags/_flag_actions.html.erb
+++ b/app/views/admin/flags/_flag_actions.html.erb
@@ -1,6 +1,17 @@
-<div style="display:flex;">
-  <%= button_to 'Dismiss Flag', dismiss_admin_flag_path, data: { confirm: 'Are you sure?', test_id: 'dismiss-flag-btn' }, disabled: flag.resolved? %>
-  <%= button_to 'Remove Submission', remove_project_submission_admin_flag_path, data: { confirm: 'Are you sure?', test_id: 'remove-submission-btn' }, disabled: flag.resolved? %>
-  <%= button_to 'Ban User', ban_flagged_user_admin_flag_path, data: { confirm: 'Are you sure?', test_id: 'ban-user-btn' }, disabled: flag.resolved? %>
-  <%= button_to 'Notify Broken Link', notify_broken_link_admin_flag_path, data: { confirm: 'Are you sure?', test_id: 'notify-broken-link-btn' }, disabled: flag.resolved? %>
+<div style="display:flex;" class="buttons">
+  <%= form_with url: dismiss_admin_flag_path do |f| %>
+    <%= f.submit 'Dismiss Flag', data: { confirm: 'Are you sure?', test_id: 'dismiss-flag-btn' }, disabled: flag.resolved? %>
+  <% end %>
+
+  <%= form_with url: remove_project_submission_admin_flag_path do |f| %>
+    <%= f.submit 'Remove Submission', data: { confirm: 'Are you sure?', test_id: 'remove-submission-btn' }, disabled: flag.resolved? %>
+  <% end %>
+
+  <%= form_with url: ban_flagged_user_admin_flag_path do |f| %>
+    <%= f.submit 'Ban User', data: { confirm: 'Are you sure?', test_id: 'ban-user-btn' }, disabled: flag.resolved? %>
+  <% end %>
+
+  <%= form_with url: notify_broken_link_admin_flag_path do |f| %>
+    <%= f.submit 'Notify Broken Link', data: { confirm: 'Are you sure?', test_id: 'notify-broken-link-btn' }, disabled: flag.resolved? %>
+  <% end %>
 </div>


### PR DESCRIPTION
Because:
* Rails 7 has switched button_to helpers to use button instead input elements. But, Active admin styles buttons by targeting input elements.

This commit:
* Use form with submit button to get back input elements for the flag buttons - This is kind of a hacky work around until we can migrate from active admin or they update their CSS.