### PR TITLE
Chore: Replace OpenStruct with Data class

### DIFF
--- a/app/controllers/guides/community_controller.rb
+++ b/app/controllers/guides/community_controller.rb
@@ -1,7 +1,9 @@
 module Guides
   class CommunityController < ApplicationController
+    Guide = Data.define(:title, :path)
+
     def show
-      @guides = guides.map { |title, path| OpenStruct.new(title:, path:) } # rubocop:disable Style/OpenStructUse
+      @guides = guides.map { |title, path| Guide.new(title:, path:) }
     end
 
     private


### PR DESCRIPTION
Because:
* Now that we're on Ruby 3.2, we can use the built-in Data class in place of structs :tada:

This commit:
* Use Data class instead of  OpenStuct when creating guide page objects.

