### PR TITLE
Chore: Display project submissions list using Hotwire

### DIFF
--- a/app/assets/images/icons/flag.svg
+++ b/app/assets/images/icons/flag.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M3 3v1.5M3 21v-6m0 0l2.77-.693a9 9 0 016.208.682l.108.054a9 9 0 006.086.71l3.114-.732a48.524 48.524 0 01-.005-10.499l-3.11.732a9 9 0 01-6.085-.711l-.108-.054a9 9 0 00-6.208-.682L3 4.5M3 15V4.5" />
+</svg>

--- a/app/assets/images/icons/heart.svg
+++ b/app/assets/images/icons/heart.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z" />
+</svg>

--- a/app/components/project_submissions/item_component.html.erb
+++ b/app/components/project_submissions/item_component.html.erb
@@ -1,0 +1,21 @@
+<div data-test-id="submission-item" class="relative py-6 border-solid border-t border-gray-300 flex flex-col md:flex-row justify-between items-center">
+
+  <div class="flex items-center mb-4 md:mb-0">
+
+    <button class="text-gray-300 mr-4 flex items-center hint--top" data-test-id="like-btn" aria-label="Like submission">
+      <span class="mr-1" data-test-id="number-of-likes"><%= item.votes_for.size %></span>
+      <%= inline_svg_tag 'icons/heart.svg', class: 'h-5 w-5', aria: true, title: 'heart', desc: 'heart icon' %>
+    </button>
+
+    <p class="truncate max-w-xs lg:max-w-lg font-medium text-lg break-words"><%= item.user.username %></p>
+  </div>
+
+  <div class="flex flex-col md:flex-row md:items-center">
+    <%= link_to 'View code', item.repo_url, target: '_blank', rel: 'noreferrer', class: 'button button--gray font-semibold md:mr-4', data: { test_id: 'view-code-btn' } %>
+    <%= link_to 'Live preview', item.live_preview_url, target: '_blank', rel: 'noreferrer', class: 'button button--gray font-semibold mt-5 md:mt-0 md:mr-4', data: { test_id: 'live-preview-btn' } %>
+
+    <button aria-label="Report submission" data-test-id="flag-btn" class="submissions-flag text-gray-300 hover:text-gray-500 dark:text-gray-400 dark:hover:text-gray-300 hint--top-left">
+      <%= inline_svg_tag 'icons/flag.svg', class: 'h-4 w-4', aria: true, title: 'flag', desc: 'flag icon' %>
+    </button>
+  </div>
+</div>

--- a/app/components/project_submissions/item_component.rb
+++ b/app/components/project_submissions/item_component.rb
@@ -1,0 +1,11 @@
+module ProjectSubmissions
+  class ItemComponent < ApplicationComponent
+    def initialize(item:)
+      @item = item
+    end
+
+    private
+
+    attr_reader :item
+  end
+end

--- a/app/controllers/lessons/v2_project_submissions_controller.rb
+++ b/app/controllers/lessons/v2_project_submissions_controller.rb
@@ -1,0 +1,27 @@
+module Lessons
+  class V2ProjectSubmissionsController < ApplicationController
+    before_action :authenticate_user!
+    before_action :set_lesson
+
+    def index
+      @pagy, @project_submissions = pagy(public_project_submissions, items: params.fetch(:limit, 15))
+    end
+
+    private
+
+    def public_project_submissions
+      project_submissions_query.public_submissions
+    end
+
+    def project_submissions_query
+      @project_submissions_query ||= ::LessonProjectSubmissionsQuery.new(
+        lesson: @lesson,
+        current_user:
+      )
+    end
+
+    def set_lesson
+      @lesson = Lesson.find(params[:lesson_id])
+    end
+  end
+end

--- a/app/views/lessons/_project_submissions.html.erb
+++ b/app/views/lessons/_project_submissions.html.erb
@@ -1,0 +1,26 @@
+<% if Feature.enabled?(:v2_project_submissions, current_user) %>
+  <%= turbo_frame_tag 'submissions-list', src: lesson_v2_project_submissions_path(lesson, limit: 10)  do %>
+    <div class="flex justify-center h-">
+      <%= inline_svg_tag 'icons/spinner.svg', class: 'animate-spin h-12 w-12 text-gray-400 dark:text-gray-300', aria: true, title: 'dismiss', desc: 'dismiss icon' %>
+    </div>
+  <% end %>
+
+  <div>
+    <p class="text-center py-6 px-0">
+      <span> Showing <%= limit %> most liked submissions -
+      <%= link_to 'View full list of solutions', lesson_v2_project_submissions_path(lesson), class: 'text-gold', data: { test_id: 'view-all-projects-link' } %>
+    </p>
+  </div>
+<% else %>
+  <%= react_component(
+        'project-submissions/index',
+        {
+          userId: current_user.id,
+          course: lesson.course.as_json,
+          lesson: lesson.as_json,
+          submissions: project_submissions,
+          allSubmissionsPath: lesson_project_submissions_path(lesson.id),
+          userSubmission: user_submission
+        }
+      ) %>
+<% end %>

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -24,20 +24,15 @@
 
 <div class="bg-gray-100 dark:bg-gray-800/30 text-center">
   <div class="page-container">
-
     <%= render CardComponent.new do |card| %>
       <% card.with_body do %>
         <% if user_signed_in? && @lesson.accepts_submission? %>
-          <%= react_component(
-                'project-submissions/index',
-                {
-                  userId: current_user.id,
-                  course: @lesson.course.as_json,
-                  lesson: @lesson.as_json,
-                  submissions: @project_submissions,
-                  allSubmissionsPath: lesson_project_submissions_path(@lesson.id),
-                  userSubmission: @user_submission
-                }
+          <%= render(
+                'lessons/project_submissions',
+                  lesson: @lesson,
+                  project_submissions: @project_submissions,
+                  user_submission: @user_submission,
+                  limit: 10
               ) %>
         <% elsif @lesson.accepts_submission? %>
           <p class="mb-7">

--- a/app/views/lessons/v2_project_submissions/index.html.erb
+++ b/app/views/lessons/v2_project_submissions/index.html.erb
@@ -1,0 +1,32 @@
+<%= title(@lesson.display_title) %>
+
+<div class="page-container">
+   <div>
+    <%= link_to lesson_path(@lesson, anchor: 'solutions'), class: 'inline-flex items-center pb-10 text-gray-600 text-base hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200 gap-2' do %>
+      <%= inline_svg_tag 'icons/arrow-left-circle.svg', aria: true, title: 'Back to lesson icon' %>
+      Back to lesson
+    <% end %>
+  </div>
+
+<%= turbo_frame_tag 'submissions-list' do %>
+  <div class="mb-8 text-left">
+
+    <header class="flex flex-col space-y-6 justify-between items-center pb-8 text-center md:space-y-0 md:text-left md:flex-row">
+      <div class="flex md:flex-start flex-col space-y-1">
+        <h3 class="text-4xl font-medium" id="solutions">Solutions:</h3>
+        <h4 data-test-id="course-lesson-title" class="text-xl text-gray-500 dark:text-gray-400">
+          <%= @lesson.course.title %> : (<%= @lesson.title %>)
+        </h4>
+      </div>
+    </header>
+
+    <div data-test-id="submissions-list">
+      <%= render ProjectSubmissions::ItemComponent.with_collection(@project_submissions) %>
+    </div>
+  </div>
+<% end %>
+
+<div class="text-center overflow-x-auto">
+    <%== pagy_nav(@pagy) %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,7 @@ Rails.application.routes.draw do
 
   resources :lessons, only: :show do
     resources :project_submissions, only: %i[index], controller: 'lessons/project_submissions'
+    resources :v2_project_submissions, only: %i[index], controller: 'lessons/v2_project_submissions'
     resource :completion, only: %i[create destroy], controller: 'lessons/completions'
   end
 


### PR DESCRIPTION
Because
* We can simplify and make our project submissions feature more robust by using Hotwire.

This commit:
* Add v2_project submissions feature flag, controllers and routes so we can move things over gradually.
* Add project submission item component to replicate the submission item component we have in react.
* Lazily load the submission list with Hotwire - displays a loading spinner until the list response is rendered.
