### PR TITLE
Fix: Disable Turbo when using omniauth to sign in

### DIFF
--- a/app/components/oauth/connect_button_component.html.erb
+++ b/app/components/oauth/connect_button_component.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <%= button_to omniauth_authorize_path(resource_name, provider), class: 'button button--clear w-full py-2 px-4 text-sm font-medium text-gray-500 focus:ring-0 dark:focus:ring-offset-gray-800', title: provider, data: { test_id: "#{provider}-btn" } do %>
+  <%= button_to omniauth_authorize_path(resource_name, provider), class: 'button button--clear w-full py-2 px-4 text-sm font-medium text-gray-500 focus:ring-0 dark:focus:ring-offset-gray-800', title: provider, data: { test_id: "#{provider}-btn", turbo: false } do %>
     <span class="sr-only">Sign in with <%= provider.capitalize %></span>
     <%= inline_svg_tag "icons/#{provider}.svg", class: 'h-5 w-5', aria: true, title: "#{provider} icon" %>
   <% end %>


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Turbo was re-enabled, breaking the logging in functionality through Github & Google. This PR resolves that issue.


## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Adds `data-turbo: false` to the Github & Google login buttons, and any future provider that is added using the Omniauth button component
- Resolves CORS error caused by Turbo

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #3853

Related #3806

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
Various users reported this in Discord, and I confirmed that I could not log in using Github or Google on my end as well, before the fix.

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behavior
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If applicable, this PR includes new or updated automated tests
