### PR TITLE
Fix: Lesson table of contents duplicating on Turbo restoration visits

### DIFF
--- a/app/javascript/controllers/lesson_toc_controller.js
+++ b/app/javascript/controllers/lesson_toc_controller.js
@@ -15,6 +15,10 @@ export default class LessonTocController extends Controller {
     });
   }
 
+  disconnect() {
+    this.tocTarget.innerHTML = '';
+  }
+
   tocItemObserver() {
     return (
       new IntersectionObserver((entries) => {


### PR DESCRIPTION
Because:
* Turbo is caching lesson tables of contents and duplicating them on return visits.
* Closes: https://github.com/TheOdinProject/theodinproject/issues/3863

This commit:
* Tear down a lessons table of contents when navigating away from the lesson and the TOC stimulus controller disconnects.