### PR TITLE
Chore: Update Devise Config for Turbo

### DIFF
--- a/app/views/users/profiles/edit.html.erb
+++ b/app/views/users/profiles/edit.html.erb
@@ -61,11 +61,11 @@
         <% end %>
         <% card.with_body do %>
           <div class="inline-flex flex-col space-y-5">
-            <%= link_to users_progress_path(current_user), class: 'button button--clear px-3 py-2 text-sm', data: { confirm: 'Are you sure?', test_id: 'user-reset-progress-link' }, method: :delete do %>
+            <%= link_to users_progress_path(current_user), class: 'button button--clear px-3 py-2 text-sm', data: { turbo_method: :delete, turbo_confirm: 'Are you sure?', test_id: 'user-reset-progress-link' } do %>
               <%= inline_svg_tag 'icons/refresh.svg', class: '-ml-0.5 mr-2 h-4 w-4 text-red-700 dark:text-red-500', aria: true, title: 'Reset icon' %>
               Reset progress
             <% end %>
-            <%= link_to registration_path(current_user), class: 'button button--clear px-3 py-2 text-sm', data: { confirm: 'Are you sure?', test_id: 'user-account-delete-link' }, method: :delete do %>
+            <%= link_to registration_path(current_user), class: 'button button--clear px-3 py-2 text-sm', data: { turbo_method: :delete, turbo_confirm: 'Are you sure?', test_id: 'user-account-delete-link' } do %>
               <%= inline_svg_tag 'icons/trash.svg', class: '-ml-0.5 mr-2 h-4 w-4 text-red-700 dark:text-red-500', aria: true, title: 'Trash can icon' %>
               Delete account
             <% end %>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -40,7 +40,7 @@
               </div>
             <% end %>
             <% card.with_footer(classes: 'px-4 py-3 pt-3 bg-gray-50 text-right sm:px-6 dark:bg-gray-700/40') do %>
-              <%= form.submit 'Save', class: 'button button--primary py-2 px-4', data: { disable_with: false, turbo: false } %>
+              <%= form.submit 'Save', class: 'button button--primary py-2 px-4', data: { disable_with: false } %>
             <% end %>
           <% end %>
         <% end %>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -40,7 +40,7 @@
             </div>
 
             <div>
-              <%= form.submit 'Sign up', class: 'button button--primary w-full py-2 px-4 text-sm', data: {test_id: 'submit_btn', disable_with: false, turbo: false } %>
+              <%= form.submit 'Sign up', class: 'button button--primary w-full py-2 px-4 text-sm', data: {test_id: 'submit_btn', disable_with: false } %>
             </div>
           </div>
         <% end %>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -38,7 +38,7 @@
               </div>
 
               <div>
-                <%= form.submit 'Sign in', class: 'button button--primary w-full py-2 px-4 text-sm', data: { test_id: 'submit-btn', disable_with: false, turbo: false } %>
+                <%= form.submit 'Sign in', class: 'button button--primary w-full py-2 px-4 text-sm', data: { test_id: 'submit-btn', disable_with: false } %>
               </div>
             </div>
           <% end %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -239,4 +239,13 @@ Devise.setup do |config|
   # When using omniauth, Devise cannot automatically set Omniauth path,
   # so you need to do it manually. For the users scope, it would be:
   # config.omniauth_path_prefix = "/my_engine/users/auth"
+
+  # ==> Hotwire/Turbo configuration
+  # When using Devise with Hotwire/Turbo, the http status for error responses
+  # and some redirects must match the following. The default in Devise for existing
+  # apps is `200 OK` and `302 Found respectively`, but new apps are generated with
+  # these new defaults that match Hotwire/Turbo behavior.
+  # Note: These might become the new default in future versions of Devise.
+  config.responder.error_status = :unprocessable_entity
+  config.responder.redirect_status = :see_other
 end


### PR DESCRIPTION
Because:
* Devise needs a couple of config changes to work properly with Turbo. Otherwise unsuccessful sign-ins will return JS errors.

This commit:
* Update Devise error responses to return a 422(unprocessable_entity) status
* Update Devise redirects to return a 303(see_other) status
* Change reset progress and cancel account links to use the turbo http delete method instead of ujs http delete method