### PR TITLE
Fix: JS error with toc item on page navigation.

### DIFF
--- a/app/javascript/controllers/lesson_toc_controller.js
+++ b/app/javascript/controllers/lesson_toc_controller.js
@@ -16,6 +16,10 @@ export default class LessonTocController extends Controller {
   }
 
   disconnect() {
+    this.lessonContentTarget.querySelectorAll('section[id]').forEach((section) => {
+      this.tocItemObserver().unobserve(section);
+    });
+
     this.tocTarget.innerHTML = '';
   }
 


### PR DESCRIPTION
Because:
* We are removing the toc items so they won't be cached, but we are still observing them with an intersection observer.

This commit:
* Unobserve all headings before destroying them on page navigation.
