### PR TITLE
Fix: Component Preview Layout

### DIFF
--- a/app/views/layouts/component_preview.html.erb
+++ b/app/views/layouts/component_preview.html.erb
@@ -16,6 +16,6 @@
     max-width: <%= params.dig(:lookbook, :display, :max_width) || '100%' %>
   ">
       <%= yield %>
-      <%= render 'shared/ga' %>
     </div>
+  </body>
 </html>


### PR DESCRIPTION
This commit:
* Remove shared/ga partial call - it no longer exists.
* Add missing closing body tag
