### PR TITLE
Fix: Remove hardcoded ids

### DIFF
--- a/spec/serializers/project_submission_serializer_spec.rb
+++ b/spec/serializers/project_submission_serializer_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe ProjectSubmissionSerializer do
   end
 
   let(:current_user) { create(:user) }
-  let(:user) { create(:user, id: 123, username: 'A USERNAME') }
-  let(:lesson) { create(:lesson, id: 12, title: 'A LESSON TITLE', has_live_preview: true) }
+  let(:user) { create(:user, username: 'A USERNAME') }
+  let(:lesson) { create(:lesson, title: 'A LESSON TITLE', has_live_preview: true) }
 
   describe '#as_json' do
     let(:serialized_project_submission) do
@@ -27,8 +27,8 @@ RSpec.describe ProjectSubmissionSerializer do
         live_preview_url: 'https://www.livepreviewurl.com/path',
         is_public: false,
         user_name: 'A USERNAME',
-        user_id: 123,
-        lesson_id: 12,
+        user_id: user.id,
+        lesson_id: lesson.id,
         lesson_title: 'A LESSON TITLE',
         lesson_path: "/lessons/#{lesson.slug}",
         lesson_has_live_preview: true,


### PR DESCRIPTION
## Because
FactoryBot increments ids each time a factory is created, there is potential for those specs to flake depending on the randomized run order


## This PR

- Removed the hardcoded ids when creating a factory
- Use the ids created by factory when creating serialized project submission


## Issue
Closes #3897 


## Additional Information


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behavior
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
