### PR TITLE
Feature: Increase light mode background color

### DIFF
--- a/app/javascript/stylesheets/lesson-content.css
+++ b/app/javascript/stylesheets/lesson-content.css
@@ -24,7 +24,7 @@
   }
 
   .lesson-note {
-    @apply bg-gray-50 p-4 border-l-4 border-gold dark:bg-gray-700/40 dark:border-gold-700 rounded;
+    @apply bg-gray-200 p-4 border-l-4 border-gold dark:bg-gray-700/40 dark:border-gold-700 rounded;
   }
 
   .lesson-note > h4::before {


### PR DESCRIPTION
## Because
- Currently the various note stylings have a background color which is easily distinguishable on dark mode, but basically invisible on light mode, as the contrast between the note background and the page background is basically zero (1.04:1).


## This PR
- Increase the color to `bg-gray-200`, which produces a much clearer background that better distinguishes the note


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behavior
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.


