### PR TITLE
Feature: Convert project submission flagging feature from React to Hotwire

### DIFF
--- a/app/assets/images/icons/ellipsis-vertical.svg
+++ b/app/assets/images/icons/ellipsis-vertical.svg
@@ -1,0 +1,3 @@
+<svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+  <path d="M10 3a1.5 1.5 0 110 3 1.5 1.5 0 010-3zM10 8.5a1.5 1.5 0 110 3 1.5 1.5 0 010-3zM11.5 15.5a1.5 1.5 0 10-3 0 1.5 1.5 0 003 0z" />
+</svg>

--- a/app/assets/images/icons/trash.svg
+++ b/app/assets/images/icons/trash.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
   <path stroke-linecap="round" stroke-linejoin="round" d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0" />
 </svg>

--- a/app/components/modal_component.html.erb
+++ b/app/components/modal_component.html.erb
@@ -39,7 +39,7 @@
             </button>
           </div>
 
-          <div class="border-b border-gray-200 dark:border-gray-600 pb-5">
+          <div class="pb-5">
             <h3 class="text-lg font-semibold leading-6 text-gray-900 dark:text-gray-300"><%= title %></h3>
           </div>
 

--- a/app/components/project_submissions/item_component.html.erb
+++ b/app/components/project_submissions/item_component.html.erb
@@ -16,11 +16,9 @@
       <%= link_to 'Live preview', project_submission.live_preview_url, target: '_blank', rel: 'noreferrer', class: 'button button--gray font-semibold mt-5 md:mt-0 md:mr-4', data: { test_id: 'live-preview-btn' } %>
 
       <div class="relative flex-none" data-controller="visibility" data-action="visibility:click:outside->visibility#off" data-visibility-visible-value="false">
-        <button type="button" data-action="click->visibility#toggle" data-test-id="submission-action-menu-btn" class="-m-2.5 block p-2.5 text-gray-500 hover:text-gray-900" id="options-menu-0-button" aria-expanded="false" aria-haspopup="true">
+        <button type="button" data-action="click->visibility#toggle" data-test-id="submission-action-menu-btn" class="-m-2.5 block p-2.5 text-gray-500 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100" id="options-menu-0-button" aria-expanded="false" aria-haspopup="true">
           <span class="sr-only">Open options</span>
-          <svg class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-            <path d="M10 3a1.5 1.5 0 110 3 1.5 1.5 0 010-3zM10 8.5a1.5 1.5 0 110 3 1.5 1.5 0 010-3zM11.5 15.5a1.5 1.5 0 10-3 0 1.5 1.5 0 003 0z" />
-          </svg>
+          <%= inline_svg_tag 'icons/ellipsis-vertical.svg', aria: true, title: 'open menu', desc: 'open menu icon' %>
         </button>
 
         <div
@@ -31,17 +29,22 @@
           data-transition-leave="transition ease-in duration-75"
           data-transition-leave-start="transform opacity-100 scale-100"
           data-transition-leave-end="transform opacity-10 scale-95"
-          class="absolute right-0 z-10 mt-2 w-32 origin-top-right rounded-md bg-white py-2 shadow-lg ring-1 ring-gray-900/5 focus:outline-none" role="menu" aria-orientation="vertical" aria-labelledby="options-menu-0-button" tabindex="-1">
+          class="absolute right-0 z-10 mt-2 w-32 origin-top-right rounded-md bg-white dark:bg-gray-700 py-2 shadow-lg ring-1 ring-gray-900/5 dark:ring-gray-300/5 focus:outline-none" role="menu" aria-orientation="vertical" aria-labelledby="options-menu-0-button" tabindex="-1">
 
           <% if project_submission.user == current_user %>
-            <%= link_to edit_lesson_v2_project_submission_path(project_submission.lesson, project_submission), class: 'text-gray-700 group flex items-center px-4 py-2 text-sm', role: 'menuitem', tabindex: '-1', data: { turbo_frame: 'modal', test_id: 'edit-submission'} do %>
-              <%= inline_svg_tag 'icons/pencil-square.svg', class: 'mr-3 h-5 w-5 text-gray-400 group-hover:text-gray-500', aria: true, title: 'edit', desc: 'edit icon' %>
+            <%= link_to edit_lesson_v2_project_submission_path(project_submission.lesson, project_submission), class: 'text-gray-700 dark:text-gray-300 group flex items-center px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-600 hover:text-gray-900 dark:hover:text-gray-200', role: 'menuitem', tabindex: '-1', data: { turbo_frame: 'modal', test_id: 'edit-submission', action: 'click->visibility#off'} do %>
+              <%= inline_svg_tag 'icons/pencil-square.svg', class: 'mr-3 h-4 w-4 text-gray-400 group-hover:text-gray-500 dark:group-hover:text-gray-300', aria: true, title: 'edit', desc: 'edit icon' %>
               Edit
             <% end %>
 
-            <%= link_to lesson_v2_project_submission_path(project_submission.lesson, project_submission), class: 'text-gray-700 group flex items-center px-4 py-2 text-sm', role: 'menuitem', tabindex: '-1', data: { turbo_method: :delete, turbo_confirm: 'Are you sure? this cannot be undone.', test_id: 'delete-submission' } do %>
-              <%= inline_svg_tag 'icons/trash.svg', class: 'mr-3 h-5 w-5 text-gray-400 group-hover:text-gray-500', aria: true, title: 'edit', desc: 'edit icon' %>
+            <%= link_to lesson_v2_project_submission_path(project_submission.lesson, project_submission), class: 'text-gray-700 dark:text-gray-300 group flex items-center px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-600 hover:text-gray-900 dark:hover:text-gray-200', role: 'menuitem', tabindex: '-1', data: { turbo_method: :delete, turbo_confirm: 'Are you sure? this cannot be undone.', test_id: 'delete-submission' } do %>
+              <%= inline_svg_tag 'icons/trash.svg', class: 'mr-3 h-4 w-4 text-gray-400 group-hover:text-gray-500 dark:group-hover:text-gray-300', aria: true, title: 'edit', desc: 'edit icon' %>
               Delete
+            <% end %>
+          <% else %>
+            <%= link_to new_project_submission_flag_path(project_submission), class: 'text-gray-700 dark:text-gray-300 group flex items-center px-4 py-2 text-sm hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-gray-600 dark:hover:text-gray-200', role: 'menuitem', tabindex: '-1', data: { turbo_frame: 'modal', test_id: 'report-submission', action: 'click->visibility#off' } do %>
+              <%= inline_svg_tag 'icons/flag.svg', class: 'mr-3 h-4 w-4 text-gray-400 group-hover:text-gray-500 dark:group-hover:text-gray-300', aria: true, title: 'edit', desc: 'edit icon' %>
+              Report
             <% end %>
           <% end %>
         </div>

--- a/app/controllers/lessons/v2_project_submissions_controller.rb
+++ b/app/controllers/lessons/v2_project_submissions_controller.rb
@@ -33,7 +33,7 @@ module Lessons
       @project_submission = current_user.project_submissions.find(params[:id])
 
       respond_to do |format|
-        if @project_submission.update!(project_submission_params)
+        if @project_submission.update(project_submission_params)
           format.html { redirect_to lesson_path(@lesson), notice: 'Project updated' }
           format.turbo_stream
         else

--- a/app/controllers/project_submissions/flags_controller.rb
+++ b/app/controllers/project_submissions/flags_controller.rb
@@ -1,23 +1,40 @@
 class ProjectSubmissions::FlagsController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_project_submission
 
-  def create
-    if flag.save
-      notify_discord_admins
-      render json: flag, status: :ok
-    else
-      render json: { error: 'Unable to flag project submission' }, status: :unprocessable_entity
+  def new
+    @flag = @project_submission.flags.new
+  end
+
+  def create # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    @flag = @project_submission.flags.new(flag_params)
+
+    respond_to do |format|
+      if @flag.save
+        notify_discord_admins
+
+        format.html { redirect_to lesson_path(@project_submission.lesson) }
+        format.json { render json: @flag, status: :created }
+        format.turbo_stream { flash.now[:notice] = 'Thank you! your report has been submitted.' }
+      else
+        format.json { render json: { error: 'Unable to flag project submission' }, status: :unprocessable_entity }
+        format.html { render :new, status: :unprocessable_entity }
+      end
     end
   end
 
   private
 
-  def flag
-    @flag ||= Flag.new(flag_params)
+  def set_project_submission
+    @project_submission = ProjectSubmission.find(params[:project_submission_id])
   end
 
   def flag_params
-    params.permit(:project_submission_id, :reason).merge(flagger: current_user)
+    if Feature.enabled?(:v2_project_submissions, current_user)
+      params.require(:flag).permit(:reason).merge(flagger: current_user)
+    else
+      params.permit(:reason).merge(flagger: current_user)
+    end
   end
 
   def notify_discord_admins

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -12,7 +12,6 @@ export default class ModalController extends Controller {
 
   close() {
     Promise.all(this.transitionableTargets.map((element) => leave(element))).then(() => {
-      this.element.parentElement.removeAttribute('src');
       this.element.remove();
       this.unlockScroll();
     });

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,7 +34,9 @@
   <body class="h-full bg-gray-50 text-gray-600 dark:bg-gray-900 dark:text-gray-300">
     <%= render AnnouncementComponent.new(announcement: Announcement.showable_messages(disabled_announcement_ids).first) %>
     <%= render 'shared/navbar' %>
-    <%= render 'shared/flash', flash: flash if flash.any? %>
+    <div id="flash-messages">
+      <%= render 'shared/flash', flash: flash if flash.any? %>
+    </div>
 
     <%= turbo_frame_tag 'modal' %>
     <%= yield %>

--- a/app/views/project_submissions/flags/create.turbo_stream.erb
+++ b/app/views/project_submissions/flags/create.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.update 'flash-messages', partial: 'shared/flash' %>

--- a/app/views/project_submissions/flags/new.html.erb
+++ b/app/views/project_submissions/flags/new.html.erb
@@ -1,0 +1,19 @@
+<%= render ModalComponent.new(title: 'Report submission')  do %>
+  <%= turbo_frame_tag 'flag_form', class: 'w-full' do %>
+    <%= form_with model: [@project_submission, @flag], builder: TailwindFormBuilder do |form| %>
+      <div class=''>
+        <div class="space-y-6 pt-4">
+          <div>
+            <%= form.text_area :reason, placeholder: 'Please explain why you are reporting this submission...', rows: 6, data: { test_id: 'flag-description-field' }, autofocus: true %>
+            <p class="mt-3 text-sm leading-6 text-gray-600 dark:text-gray-400"> Please include as much detail as possible to help us assess and action your report.</p>
+          </div>
+        </div>
+
+        <div class="mt-5 sm:flex sm:flex-row-reverse pt-4">
+          <%= form.submit 'Save', class: 'cursor-pointer inline-flex w-full justify-center rounded-md button--primary px-5 py-2 text-sm font-semibold text-white shadow-sm sm:ml-3 sm:w-auto', data: { test_id: 'submit-btn' } %>
+          <button type="button" data-action="click->modal#close" class="button--white mt-3 inline-flex w-full justify-center sm:mt-0 sm:w-auto">Cancel</button>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,7 +99,7 @@ Rails.application.routes.draw do
   end
 
   resources :project_submissions do
-    resources :flags, only: %i[create], controller: 'project_submissions/flags'
+    resources :flags, only: %i[new create], controller: 'project_submissions/flags'
     resources :likes, controller: 'project_submissions/likes'
   end
 

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,7 +1,5 @@
-Capybara.default_max_wait_time = 2
-
+Capybara.default_max_wait_time = 5
 Capybara.default_normalize_ws = true
-
 Capybara.save_path = File.expand_path(ENV.fetch('CAPYBARA_ARTIFACTS', './tmp/capybara'))
 
 Capybara.configure do |config|
@@ -28,4 +26,12 @@ Capybara.add_selector(:test_project_submission) do
   xpath do |num|
     ".//div[@data-test-id='submission-item'][#{num}]"
   end
+end
+
+def wait_for_turbo_frame(selector = 'turbo-frame', timeout = nil)
+  if has_selector?("#{selector}[busy]", visible: true, wait: 0.25.seconds)
+    has_no_selector?("#{selector}[busy]", wait: timeout.presence || 5.seconds)
+  end
+
+  yield if block_given?
 end

--- a/spec/support/cuprite.rb
+++ b/spec/support/cuprite.rb
@@ -1,6 +1,16 @@
 require 'capybara/cuprite'
 
-Capybara.register_driver(:cuprite) do |app|
+module CupriteHelpers
+  def pause
+    page.driver.pause
+  end
+
+  def debug(*args)
+    page.driver.debug(*args)
+  end
+end
+
+Capybara.register_driver(:odin_cuprite) do |app|
   Capybara::Cuprite::Driver.new(
     app,
     window_size: [1200, 1200],
@@ -13,22 +23,12 @@ Capybara.register_driver(:cuprite) do |app|
   )
 end
 
-Capybara.default_driver = :cuprite
-Capybara.javascript_driver = :cuprite
-
-module CupriteHelpers
-  def pause
-    page.driver.pause
-  end
-
-  def debug(*args)
-    page.driver.debug(*args)
-  end
-end
+Capybara.default_driver = :odin_cuprite
+Capybara.javascript_driver = :odin_cuprite
 
 RSpec.configure do |config|
   config.prepend_before(:each, type: :system) do
-    driven_by :cuprite
+    driven_by :odin_cuprite
   end
 
   config.include CupriteHelpers, type: :system

--- a/spec/system/v2_lesson_project_submissions/add_submission_spec.rb
+++ b/spec/system/v2_lesson_project_submissions/add_submission_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Add a Project Submission' do
         form = Pages::ProjectSubmissions::Form.new.open.fill_in
 
         form.v2_make_private
-        click_on 'Save'
+        form.submit
 
         within(:test_id, 'submissions-list') do
           page.driver.refresh

--- a/spec/system/v2_lesson_project_submissions/flag_submission_spec.rb
+++ b/spec/system/v2_lesson_project_submissions/flag_submission_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe 'Flagging a Project Submission' do
+  let(:user) { create(:user) }
+  let(:lesson) { create(:lesson, :project) }
+  let!(:project_submission) { create(:project_submission, lesson:) }
+
+  before do
+    Flipper.enable(:v2_project_submissions)
+
+    sign_in(user)
+    visit lesson_path(lesson)
+  end
+
+  after do
+    Flipper.disable(:v2_project_submissions)
+  end
+
+  it 'successfully flags a submission' do
+    submission = first(:test_id, 'submission-item')
+
+    wait_for_turbo_frame("project-submissions_lesson_#{lesson.id}") do
+      within(submission) do
+        find(:test_id, 'submission-action-menu-btn').click
+        find(:test_id, 'report-submission').click
+      end
+    end
+
+    find(:test_id, 'flag-description-field').fill_in(with: 'It contains offensive material')
+    find(:test_id, 'submit-btn').click
+
+    expect(page).to have_content('Thank you! your report has been submitted.')
+    expect(project_submission.reload.flags.count).to eq(1)
+  end
+end


### PR DESCRIPTION
Because:
* We are moving our React components to Hotwire.

This commit:
* Renders Flag form within a Hotwire modal
* Amends flags controller to work with both the Hotwire and React versions of the flag form.
* Improves dark mode style of the submission action menu dropdown.
* Add `wait_for_turbo` system test helper - lazily loaded turbo frames may not be available when Capybara tries to interact with its content. This helper ensures it ready to be interacted with.

Cuprite config changes:
When working with the tests I couldn't run in non-headless mode. After some investigating, Cuprite was not being passed our custom config options set when registering the driver with Capybara. 

Changing the name we use to the register the driver from "cuprite" to "odin_cuprite" fixed it. I haven't been able to find any changes documented anywhere about why this needs to be done. But it seems like using "cuprite" for the driver name will just use the out of the box options Cuprite has. This may also be the cause of at least some of the weird test behaviour we've been seeing on CI lately. 


<img width="887" alt="Screenshot 2023-07-07 at 15 57 59" src="https://github.com/TheOdinProject/theodinproject/assets/7963776/06936ebe-9c3e-4282-a076-45f9fbbdb75a">

