### PR TITLE
Fix: Hotwire submissions add and delete flow

### DIFF
--- a/app/controllers/lessons/v2_project_submissions_controller.rb
+++ b/app/controllers/lessons/v2_project_submissions_controller.rb
@@ -46,7 +46,9 @@ module Lessons
       @project_submission = current_user.project_submissions.find(params[:id])
       @project_submission.destroy
 
-      render turbo_stream: turbo_stream.remove(@project_submission)
+      respond_to do |format|
+        format.turbo_stream
+      end
     end
 
     private

--- a/app/views/lessons/v2_project_submissions/_add_button.html.erb
+++ b/app/views/lessons/v2_project_submissions/_add_button.html.erb
@@ -1,0 +1,3 @@
+<%= link_to new_lesson_v2_project_submission_path(@lesson), class: 'button button--primary', data: { turbo_frame: 'modal', test_id: 'add_submission_btn' }  do %>
+  Add submission
+<% end %>

--- a/app/views/lessons/v2_project_submissions/create.turbo_stream.erb
+++ b/app/views/lessons/v2_project_submissions/create.turbo_stream.erb
@@ -2,4 +2,4 @@
   <%= render ProjectSubmissions::ItemComponent.new(project_submission: @project_submission, current_user: current_user) %>
 <% end %>
 
-<%= turbo_stream.remove "add-submission-button" %>
+<%= turbo_stream.update "add-submission-button", "" %>

--- a/app/views/lessons/v2_project_submissions/destroy.turbo_stream.erb
+++ b/app/views/lessons/v2_project_submissions/destroy.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%= turbo_stream.remove @project_submission %>
+
+<%= turbo_stream.update "add-submission-button" do %>
+  <%= render "lessons/v2_project_submissions/add_button", lesson: @lesson %>
+<% end %>

--- a/app/views/lessons/v2_project_submissions/index.html.erb
+++ b/app/views/lessons/v2_project_submissions/index.html.erb
@@ -19,7 +19,9 @@
         </h4>
       </div>
       <% if @current_user_submission.nil? %>
-        <%= link_to 'Add solution', new_lesson_v2_project_submission_path(@lesson), id: 'add-submission-button', class: 'button button--primary', data: { turbo_frame: 'modal', test_id: 'add_submission_btn' } %>
+        <div id="add-submission-button">
+          <%= render 'lessons/v2_project_submissions/add_button', lesson: @lesson %>
+        </div>
       <% end %>
     </header>
 

--- a/spec/system/v2_lesson_project_submissions/add_submission_spec.rb
+++ b/spec/system/v2_lesson_project_submissions/add_submission_spec.rb
@@ -42,6 +42,8 @@ RSpec.describe 'Add a Project Submission' do
           expect(page).to have_content(user.username)
         end
 
+        expect(page).not_to have_content('Add submission')
+
         using_session('another_user') do
           sign_in(another_user)
           visit lesson_path(lesson)

--- a/spec/system/v2_lesson_project_submissions/delete_submission_spec.rb
+++ b/spec/system/v2_lesson_project_submissions/delete_submission_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe 'Deleting a Project Submission' do
       end
     end
 
+    expect(page).to have_content('Add submission')
+
     within(:test_id, 'submissions-list') do
       expect(page).not_to have_content(user.username)
     end


### PR DESCRIPTION
Because:
* The add button was not displaying again after deleting your submission.

This commit:
* Breaks the add submission button out into its own partial so it can be rendered within turbo streams.
* Adds a destroy turbo stream response to remove the submissions and display the add button.
* Add a couple of expectations to ensure this cannot regress in the future.