### PR TITLE
Feature: Reinstate underlines for links

### DIFF
--- a/app/javascript/stylesheets/lesson-content.css
+++ b/app/javascript/stylesheets/lesson-content.css
@@ -79,7 +79,7 @@
   }
 
   .lesson-content a[href^="http"] {
-    @apply no-underline hover:underline;
+    @apply hover:no-underline;
   }
 
   .lesson-content h3 > a {


### PR DESCRIPTION
Because:
* It will improve contrast between default and link text.
