### PR TITLE
Fix: change not_found links to a more accessible color

### DIFF
--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -5,8 +5,8 @@
     <div class="col-span-12 lg:col-span-10 lg:col-start-2">
       <div class="text-center pt-12">
         <h1 class="text-white text-3xl lg:text-4xl font-semibold pb-6 dark:text-gray-200">Looks like you're lost, Odinite!</h1>
-        <p class="text-gray-100 dark:text-gray-400">While you're here, maybe take a second to learn about <%= link_to 'HTTP status codes', 'https://en.wikipedia.org/wiki/List_of_HTTP_status_codes', class: 'text-slate-800 hover:text-slate-700 font-bold underline' %></p>
-        <p class="text-gray-100 dark:text-gray-400">Or just <%= link_to 'head back home', root_path, class: 'text-slate-800 hover:text-slate-700 font-bold underline' %></p>
+        <p class="text-gray-100 dark:text-gray-400">While you're here, maybe take a second to learn about <%= link_to 'HTTP status codes', 'https://en.wikipedia.org/wiki/List_of_HTTP_status_codes', class: 'text-gray-800 hover:text-gray-700 dark:text-gray-300 dark:hover:text-gray-200 font-bold underline hover:no-underline' %></p>
+        <p class="text-gray-100 dark:text-gray-400">Or just <%= link_to 'head back home', root_path, class: 'text-gray-800 hover:text-gray-700 dark:text-gray-300 dark:hover:text-gray-200 font-bold underline hover:no-underline' %></p>
       </div>
 
       <div class="h-[60vh]">


### PR DESCRIPTION
## Because
- Currently when loading the 404 page in dark mode the links are inaccessible


## This PR
- Changes them to a more visible color, and also makes the underline go away on hover


## Issue
Closes #3932 

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behavior
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section