### PR TITLE
Feature: Change lesson buttons to clear style

### DIFF
--- a/app/views/lessons/_lesson_buttons.html.erb
+++ b/app/views/lessons/_lesson_buttons.html.erb
@@ -1,5 +1,5 @@
 <div class="flex flex-col justify-center max-w-sm mx-auto space-y-6 md:max-w-full md:space-y-0 md:flex-row md:space-x-7">
-  <%= link_to path_course_path(course.path, course), class: 'button button--clear font-medium', data: { test_id: 'view-course-btn' } do %>
+  <%= link_to path_course_path(course.path, course), class: 'button button--clear px-4 font-medium', data: { test_id: 'view-course-btn' } do %>
     <i class="pr-2 text-lg far fa-map"></i>View Course
   <% end %>
 
@@ -15,7 +15,7 @@
   <% end %>
 
   <% if course.next_lesson(lesson).present? %>
-    <%= link_to lesson_path(course.next_lesson(lesson)), class: 'button button--clear font-medium', data: { test_id: 'next-lesson-btn' } do %>
+    <%= link_to lesson_path(course.next_lesson(lesson)), class: 'button button--clear px-4 font-medium', data: { test_id: 'next-lesson-btn' } do %>
       <i class="pr-2 text-lg far fa-arrow-alt-circle-right" aria-hidden="true"></i>Next Lesson
     <% end %>
   <% elsif lesson.choose_path_lesson? %>

--- a/app/views/lessons/_lesson_buttons.html.erb
+++ b/app/views/lessons/_lesson_buttons.html.erb
@@ -1,5 +1,5 @@
 <div class="flex flex-col justify-center max-w-sm mx-auto space-y-6 md:max-w-full md:space-y-0 md:flex-row md:space-x-7">
-  <%= link_to path_course_path(course.path, course), class: 'button button--secondary font-medium', data: { test_id: 'view-course-btn' } do %>
+  <%= link_to path_course_path(course.path, course), class: 'button button--clear font-medium', data: { test_id: 'view-course-btn' } do %>
     <i class="pr-2 text-lg far fa-map"></i>View Course
   <% end %>
 
@@ -15,7 +15,7 @@
   <% end %>
 
   <% if course.next_lesson(lesson).present? %>
-    <%= link_to lesson_path(course.next_lesson(lesson)), class: 'button button--secondary font-medium', data: { test_id: 'next-lesson-btn' } do %>
+    <%= link_to lesson_path(course.next_lesson(lesson)), class: 'button button--clear font-medium', data: { test_id: 'next-lesson-btn' } do %>
       <i class="pr-2 text-lg far fa-arrow-alt-circle-right" aria-hidden="true"></i>Next Lesson
     <% end %>
   <% elsif lesson.choose_path_lesson? %>

--- a/app/views/lessons/_lesson_buttons.html.erb
+++ b/app/views/lessons/_lesson_buttons.html.erb
@@ -19,7 +19,7 @@
       <i class="pr-2 text-lg far fa-arrow-alt-circle-right" aria-hidden="true"></i>Next Lesson
     <% end %>
   <% elsif lesson.choose_path_lesson? %>
-    <%= link_to paths_url, class: 'button button--secondary font-medium', data: { test_id: 'choose-path-lesson-btn' } do %>
+    <%= link_to paths_url, class: 'button button--clear px-4 font-medium', data: { test_id: 'choose-path-lesson-btn' } do %>
       <i class="pr-2 text-lg fas fa-road" aria-hidden="true"></i>Choose Path
     <% end %>
   <% end %>


### PR DESCRIPTION
## Because
- the current secondary buttons at the bottom of each lessons are both inaccessible and also distracting when placed directly next to a primary button ("Mark complete") in this case.


## This PR
- Changes the button style to `button--clear`


## Issue
Part of #3923 

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behavior
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section