### PR TITLE
Fix: Flaky project submissions test

### DIFF
--- a/spec/system/v2_lesson_project_submissions/add_submission_spec.rb
+++ b/spec/system/v2_lesson_project_submissions/add_submission_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Add a Project Submission' do
         form = Pages::ProjectSubmissions::Form.new.open.fill_in
 
         form.v2_make_private
-        click_on 'Save'
+        form.submit
 
         within(:test_id, 'submissions-list') do
           page.driver.refresh


### PR DESCRIPTION
Because:
* On some test runs, it is not waiting long enough to find the submit button.

This commit:
* Use the project submission form page object submit button finder.
