### PR TITLE
Fix: Flaky add submission test (round 2)

### DIFF
--- a/spec/system/v2_lesson_project_submissions/add_submission_spec.rb
+++ b/spec/system/v2_lesson_project_submissions/add_submission_spec.rb
@@ -32,10 +32,11 @@ RSpec.describe 'Add a Project Submission' do
 
     context 'when setting a submission as private' do
       it 'will display the submission for the submission owner but not for other users' do
-        form = Pages::ProjectSubmissions::Form.new.open.fill_in
-
-        form.v2_make_private
-        form.submit
+        wait_for_turbo_frame("project-submissions_lesson_#{lesson.id}") do
+          form = Pages::ProjectSubmissions::Form.new.open.fill_in
+          form.v2_make_private
+          form.submit
+        end
 
         within(:test_id, 'submissions-list') do
           page.driver.refresh


### PR DESCRIPTION
Because:
* It has appeared again: https://app.circleci.com/pipelines/github/TheOdinProject/theodinproject/5600/workflows/5c7ebb19-cdbc-4c1f-822d-25b3e547137a/jobs/15911/tests#failed-test-0
* Capybara is trying to open the form before the project submissions turbo frame is finished loading.

This commit:
* Wait until the turbo frame is finished loading and then open the submission modal.
