### PR TITLE
Fix: Flaky add submission test round 3

### DIFF
--- a/app/components/modal_component.html.erb
+++ b/app/components/modal_component.html.erb
@@ -6,7 +6,8 @@
     data-visibility-visible-value="true"
     aria-modal="true"
     data-controller="modal"
-    data-action="turbo:submit-end->modal#submitEnd keydown.esc->modal#close">
+    data-action="turbo:submit-end->modal#submitEnd keydown->modal#onKeydown"
+    tabindex="0">
 
     <div
       class="fixed inset-0 bg-gray-500/75 dark:bg-black/70 transition-opacity"

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -23,6 +23,12 @@ export default class ModalController extends Controller {
     }
   }
 
+  onKeydown(event) {
+    if (event.key === 'Escape') {
+      this.close();
+    }
+  }
+
   lockScroll() {
     document.body.classList.add('overflow-hidden', 'pr-4');
   }

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,6 +1,7 @@
 Capybara.default_max_wait_time = 5
 Capybara.default_normalize_ws = true
 Capybara.save_path = File.expand_path(ENV.fetch('CAPYBARA_ARTIFACTS', './tmp/capybara'))
+Capybara.disable_animation = true
 
 Capybara.configure do |config|
   config.test_id = 'data-test'

--- a/spec/support/pages/project_submissions/form.rb
+++ b/spec/support/pages/project_submissions/form.rb
@@ -6,6 +6,7 @@ module Pages
 
       option :repo_url, default: -> { 'https://github.com/myname/my-project' }
       option :live_preview_url, default: -> { 'https://myprojectlivepreview.com' }
+      option :is_public, default: -> { true }
 
       def self.fill_in_and_submit(**args)
         new(**args)
@@ -23,6 +24,13 @@ module Pages
       def fill_in
         find(:test_id, 'repo-url-field').fill_in(with: @repo_url)
         find(:test_id, 'live-preview-url-field').fill_in(with: @live_preview_url)
+        self
+      end
+
+      def v2_fill_in
+        find(:test_id, 'repo-url-field').fill_in(with: @repo_url)
+        find(:test_id, 'live-preview-url-field').fill_in(with: @live_preview_url)
+        choose("project_submission_is_public_#{@is_public}")
         self
       end
 

--- a/spec/support/pages/project_submissions/form.rb
+++ b/spec/support/pages/project_submissions/form.rb
@@ -45,6 +45,7 @@ module Pages
       end
 
       def submit
+        expect(page).to have_content("Submit your project")
         find(:test_id, 'submit-btn').click
         self
       end

--- a/spec/support/pages/project_submissions/form.rb
+++ b/spec/support/pages/project_submissions/form.rb
@@ -45,7 +45,6 @@ module Pages
       end
 
       def submit
-        expect(page).to have_content("Submit your project")
         find(:test_id, 'submit-btn').click
         self
       end

--- a/spec/support/retry.rb
+++ b/spec/support/retry.rb
@@ -1,12 +1,12 @@
 require 'rspec/retry'
 
-if ENV['CI'].present?
-  RSpec.configure do |config|
-    config.verbose_retry = true
-    config.display_try_failure_messages = true
+# if ENV['CI'].present?
+#   RSpec.configure do |config|
+#     config.verbose_retry = true
+#     config.display_try_failure_messages = true
 
-    config.around :each, type: :system do |ex|
-      ex.run_with_retry retry: 3
-    end
-  end
-end
+#     config.around :each, type: :system do |ex|
+#       ex.run_with_retry retry: 3
+#     end
+#   end
+# end

--- a/spec/system/v2_lesson_project_submissions/add_submission_spec.rb
+++ b/spec/system/v2_lesson_project_submissions/add_submission_spec.rb
@@ -31,26 +31,24 @@ RSpec.describe 'Add a Project Submission' do
     end
 
     context 'when setting a submission as private' do
-      it 'will display the submission for the submission owner but not for other users' do
-        wait_for_turbo_frame("project-submissions_lesson_#{lesson.id}") do
-          form = Pages::ProjectSubmissions::Form.new.open.fill_in
-          form.v2_make_private
-          form.submit
-        end
-
-        within(:test_id, 'submissions-list') do
-          page.driver.refresh
-          expect(page).to have_content(user.username)
-        end
-
-        expect(page).not_to have_content('Add submission')
-
-        using_session('another_user') do
-          sign_in(another_user)
-          visit lesson_path(lesson)
+      30.times do
+        it 'will display the submission for the submission owner but not for other users' do
+          wait_for_turbo_frame("project-submissions_lesson_#{lesson.id}") do
+            Pages::ProjectSubmissions::Form.new(is_public: false).open.v2_fill_in.submit
+          end
 
           within(:test_id, 'submissions-list') do
-            expect(page).not_to have_content(user.username)
+            expect(page).not_to have_content('Add submission')
+            expect(page).to have_content(user.username)
+          end
+
+          using_session('another_user') do
+            sign_in(another_user)
+            visit lesson_path(lesson)
+
+            within(:test_id, 'submissions-list') do
+              expect(page).not_to have_content(user.username)
+            end
           end
         end
       end

--- a/spec/system/v2_lesson_project_submissions/add_submission_spec.rb
+++ b/spec/system/v2_lesson_project_submissions/add_submission_spec.rb
@@ -33,9 +33,7 @@ RSpec.describe 'Add a Project Submission' do
     context 'when setting a submission as private' do
       30.times do
         it 'will display the submission for the submission owner but not for other users' do
-          wait_for_turbo_frame("project-submissions_lesson_#{lesson.id}") do
-            Pages::ProjectSubmissions::Form.new(is_public: false).open.v2_fill_in.submit
-          end
+          Pages::ProjectSubmissions::Form.new(is_public: false).open.v2_fill_in.submit
 
           within(:test_id, 'submissions-list') do
             expect(page).not_to have_content('Add submission')


### PR DESCRIPTION
Because:
* It appears a race condition is happening in the test. When it tries to submit the project solution form, the submit button cannot be found. In the failure screenshots the modal is not there and right after

This commit:
* Fill in the url fields and select the privacy option in one method.
* Verify the submission has been added without refreshing.
