### PR TITLE
Feature: Change Discord buttons to clear style

### DIFF
--- a/app/helpers/button_helper.rb
+++ b/app/helpers/button_helper.rb
@@ -20,6 +20,6 @@ module ButtonHelper
   end
 
   def chat_button
-    link_to 'Open Discord', ODIN_CHAT_URL, class: 'button button--secondary', target: '_blank', rel: 'noreferrer'
+    link_to 'Open Discord', ODIN_CHAT_URL, class: 'button button--clear px-4', target: '_blank', rel: 'noreferrer'
   end
 end

--- a/app/views/static_pages/about.html.erb
+++ b/app/views/static_pages/about.html.erb
@@ -31,7 +31,7 @@
         Connect with our friendly community on discord, a chat and networking platform or <a href="mailto:theodinprojectcontact@gmail.com" class="text-gold hover:underline">send us an email</a>.
       </p>
 
-      <%= link_to 'Chat on Discord', ODIN_CHAT_URL, class: 'button button--secondary', target: '_blank', rel: 'noreferrer' %>
+      <%= link_to 'Chat on Discord', ODIN_CHAT_URL, class: 'button button--clear px-4', target: '_blank', rel: 'noreferrer' %>
     </div>
   </div>
 </div>

--- a/spec/helpers/button_helper_spec.rb
+++ b/spec/helpers/button_helper_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe ButtonHelper do
   describe '#chat_button' do
     let(:chat_button) do
       # rubocop:disable Layout/LineLength
-      '<a class="button button--secondary" target="_blank" rel="noreferrer" href="https://discord.gg/fbFCkYabZB">Open Discord</a>'
+      '<a class="button button--clear px-4" target="_blank" rel="noreferrer" href="https://discord.gg/fbFCkYabZB">Open Discord</a>'
       # rubocop:enable Layout/LineLength
     end
 


### PR DESCRIPTION
## Because
- Our current button styling doesn't meet WCAG contrast requirements


## This PR
- Changes links to Discord to `button--clear`


## Issue
Part of #3923 

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behavior
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
