### PR TITLE
Fix: Modal closing on any key press in test env

### DIFF
--- a/app/components/modal_component.html.erb
+++ b/app/components/modal_component.html.erb
@@ -6,7 +6,7 @@
     data-visibility-visible-value="true"
     aria-modal="true"
     data-controller="modal"
-    data-action="turbo:submit-end->modal#submitEnd keydown.esc->modal#close">
+    data-action="turbo:submit-end->modal#submitEnd keydown->modal#onKeydown">
 
     <div
       class="fixed inset-0 bg-gray-500/75 dark:bg-black/70 transition-opacity"

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -23,6 +23,12 @@ export default class ModalController extends Controller {
     }
   }
 
+  onKeydown(event) {
+    if (event.key === 'Escape') {
+      this.close();
+    }
+  }
+
   lockScroll() {
     document.body.classList.add('overflow-hidden', 'pr-4');
   }

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,6 +1,7 @@
 Capybara.default_max_wait_time = 5
 Capybara.default_normalize_ws = true
 Capybara.save_path = File.expand_path(ENV.fetch('CAPYBARA_ARTIFACTS', './tmp/capybara'))
+Capybara.disable_animation = true
 
 Capybara.configure do |config|
   config.test_id = 'data-test'

--- a/spec/system/v2_lesson_project_submissions/add_submission_spec.rb
+++ b/spec/system/v2_lesson_project_submissions/add_submission_spec.rb
@@ -32,11 +32,9 @@ RSpec.describe 'Add a Project Submission' do
 
     context 'when setting a submission as private' do
       it 'will display the submission for the submission owner but not for other users' do
-        wait_for_turbo_frame("project-submissions_lesson_#{lesson.id}") do
-          form = Pages::ProjectSubmissions::Form.new.open.fill_in
-          form.v2_make_private
-          form.submit
-        end
+        form = Pages::ProjectSubmissions::Form.new.open.fill_in
+        form.v2_make_private
+        form.submit
 
         within(:test_id, 'submissions-list') do
           page.driver.refresh


### PR DESCRIPTION
Because:
* We listen for esc keydown events when the submission modal is open to close it. But this is being ignored in the test env and firing on any keydown event.

Running the test in non-headless with slow mo and stimulus debug enabled shows whats happening (notice all the modal close events being fired after the first field is filled in lol)
https://drive.google.com/file/d/1oR29fmg0gboZT-Sm57hc9nb-u4dsprv8/view?usp=drive_link



This commit:
* Filters the keydown event manually with a new function on the modal controller instead of using a [Stimulus JS keyboard event filter action](https://stimulus.hotwired.dev/reference/actions#keyboardevent-filter).
* Disables animations in system tests - it's generally recommended.


