### PR TITLE
Feature: Moving project solutions to Hotwire final tweaks

### DIFF
--- a/app/components/project_submissions/item_component.html.erb
+++ b/app/components/project_submissions/item_component.html.erb
@@ -24,7 +24,7 @@
           data-transition-leave="transition ease-in duration-75"
           data-transition-leave-start="transform opacity-100 scale-100"
           data-transition-leave-end="transform opacity-10 scale-95"
-          class="absolute right-0 z-10 mt-2 w-32 origin-top-right rounded-md bg-white dark:bg-gray-700 py-2 shadow-lg ring-1 ring-gray-900/5 dark:ring-gray-300/5 focus:outline-none" role="menu" aria-orientation="vertical" aria-labelledby="options-menu-0-button" tabindex="-1">
+          class="hidden absolute right-0 z-10 mt-2 w-32 origin-top-right rounded-md bg-white dark:bg-gray-700 py-2 shadow-lg ring-1 ring-gray-900/5 dark:ring-gray-300/5 focus:outline-none" role="menu" aria-orientation="vertical" aria-labelledby="options-menu-0-button" tabindex="-1">
 
           <% if project_submission.user == current_user %>
             <%= link_to edit_lesson_v2_project_submission_path(project_submission.lesson, project_submission), class: 'text-gray-700 dark:text-gray-300 group flex items-center px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-600 hover:text-gray-900 dark:hover:text-gray-200', role: 'menuitem', tabindex: '-1', data: { turbo_frame: 'modal', test_id: 'edit-submission', action: 'click->visibility#off'} do %>

--- a/app/views/lessons/v2_project_submissions/_add_button.html.erb
+++ b/app/views/lessons/v2_project_submissions/_add_button.html.erb
@@ -1,3 +1,3 @@
 <%= link_to new_lesson_v2_project_submission_path(@lesson), class: 'button button--primary', data: { turbo_frame: 'modal', test_id: 'add_submission_btn' }  do %>
-  Add submission
+  Add solution
 <% end %>

--- a/app/views/lessons/v2_project_submissions/_form.html.erb
+++ b/app/views/lessons/v2_project_submissions/_form.html.erb
@@ -25,7 +25,7 @@
               </div>
               <div class="pl-7 text-sm leading-6">
                 <%= form.label :is_public_true, 'Public to other learners', class: 'dark:text-gray-200' %>
-                <p class="text-gray-500 dark:text-gray-400">Anyone can see this project in the submissions list.</p>
+                <p class="text-gray-500 dark:text-gray-400">Anyone can see this project in the solutions list.</p>
               </div>
             </div>
             <div>
@@ -35,7 +35,7 @@
                 </div>
                 <div class="pl-7 text-sm leading-6">
                   <%= form.label :is_public_false, 'Private to you' %>
-                  <p class="text-gray-500 dark:text-gray-400">Only you can see this project in the submissions list.</p>
+                  <p class="text-gray-500 dark:text-gray-400">Only you can see this project in the solutions list.</p>
                 </div>
               </div>
             </div>

--- a/app/views/lessons/v2_project_submissions/index.html.erb
+++ b/app/views/lessons/v2_project_submissions/index.html.erb
@@ -18,11 +18,12 @@
           <%= @lesson.course.title %> : (<%= @lesson.title %>)
         </h4>
       </div>
-      <% if @current_user_submission.nil? %>
-        <div id="add-submission-button">
+
+      <div id="add-submission-button">
+        <% if @current_user_submission.nil? %>
           <%= render 'lessons/v2_project_submissions/add_button', lesson: @lesson %>
-        </div>
-      <% end %>
+        <% end %>
+      </div>
     </header>
 
     <%= turbo_frame_tag 'submissions-list', data: { test_id: 'submissions-list', controller: 'sort' } do %>

--- a/spec/system/v2_lesson_project_submissions/add_submission_spec.rb
+++ b/spec/system/v2_lesson_project_submissions/add_submission_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Add a Project Submission' do
           expect(page).to have_content(user.username)
         end
 
-        expect(page).not_to have_content('Add submission')
+        expect(page).not_to have_content('Add solution')
 
         using_session('another_user') do
           sign_in(another_user)

--- a/spec/system/v2_lesson_project_submissions/delete_submission_spec.rb
+++ b/spec/system/v2_lesson_project_submissions/delete_submission_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Deleting a Project Submission' do
       end
     end
 
-    expect(page).to have_content('Add submission')
+    expect(page).to have_content('Add solution')
 
     within(:test_id, 'submissions-list') do
       expect(page).not_to have_content(user.username)


### PR DESCRIPTION
Because:
* A few final touches before we start rolling this out to users.

This commit:
* Move the add solution button hook outside of the current users solution conditional - this is needed for the button to display correctly when the user deletes their solution after refreshing the page.
* Change "Add submission" button text to "Add solution" - to fit the solutions title.
* Add a hidden class to the drop down so it does not flash visible for a brief moment during re-render
