### PR TITLE
Fix: change button name to correctly reflect button type

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,7 +10,7 @@ module ApplicationHelper
     content_for(:title) { "#{input} | The Odin Project" } if input
   end
 
-  def sign_in_or_view_curriculum_button
+  def sign_up_or_view_curriculum_button
     if current_user
       curriculum_button
     else

--- a/app/views/paths/show.html.erb
+++ b/app/views/paths/show.html.erb
@@ -21,7 +21,7 @@
     <% unless user_signed_in? %>
       <p class="text-center path-description">
         <%= render 'shared/bottom_cta',
-          button: sign_in_or_view_curriculum_button,
+          button: sign_up_or_view_curriculum_button,
           heading: 'Start learning for free now!',
           sub_heading: '' %>
       </p>

--- a/app/views/static_pages/success_stories.html.erb
+++ b/app/views/static_pages/success_stories.html.erb
@@ -26,7 +26,7 @@
   </div>
 
   <%= render 'shared/bottom_cta',
-    button: sign_in_or_view_curriculum_button,
+    button: sign_up_or_view_curriculum_button,
     heading: 'Start learning for free now!',
     sub_heading: '' %>
 </div>


### PR DESCRIPTION
## Because
 - Currently the combo either show sign up or view curriculum button is called `sign_in_or_view_curriculum_button`, despite the possible actions being either `sign_up` or `view_curriculum`


## This PR
- Corrects it to `sign_up_or_view_curriculum_button`


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behavior
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.