### PR TITLE
Chore: Drop unused buttons

### DIFF
--- a/app/helpers/button_helper.rb
+++ b/app/helpers/button_helper.rb
@@ -3,14 +3,6 @@ module ButtonHelper
     link_to 'Sign up', sign_up_path, class: 'button button--primary'
   end
 
-  def sign_in_button
-    link_to 'Sign in', sign_in_path, class: 'button button--clear'
-  end
-
-  def create_new_account_button
-    link_to 'Create new account', new_registration_path(resource_name), class: 'button button--clear'
-  end
-
   def curriculum_button
     link_to 'View curriculum', paths_path, class: 'button button--primary text-base'
   end

--- a/spec/helpers/button_helper_spec.rb
+++ b/spec/helpers/button_helper_spec.rb
@@ -11,20 +11,6 @@ RSpec.describe ButtonHelper do
     end
   end
 
-  describe '#sign_in_button' do
-    it 'returns a sign-in button' do
-      expect(helper.sign_in_button).to eq('<a class="button button--clear" href="/sign_in">Sign in</a>')
-    end
-  end
-
-  describe '#create_new_account_button' do
-    it 'returns a create new account button' do
-      expect(helper.create_new_account_button).to eq(
-        '<a class="button button--clear" href="/users/sign_up">Create new account</a>'
-      )
-    end
-  end
-
   describe '#curriculum_button' do
     it 'returns the curriculum button' do
       expect(helper.curriculum_button).to eq(


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
- Neither `sign_in_button` or `create_new_account_button` are used anywhere within the app, nor do I see an use in the immediate future; we use "Sign up" as a call to action for signing up, and we (almost?) always direct people to sign up, not to sign in.


## This PR
- Drops the button definitions and their associated tests


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behavior
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
