### PR TITLE
Feature: Rename button--clear to button--secondary and drop old secondary class

### DIFF
--- a/app/components/oauth/connect_button_component.html.erb
+++ b/app/components/oauth/connect_button_component.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <%= button_to omniauth_authorize_path(resource_name, provider), class: 'button button--clear w-full py-2 px-4 text-sm font-medium text-gray-500 focus:ring-0 dark:focus:ring-offset-gray-800', title: provider, data: { test_id: "#{provider}-btn", turbo: false } do %>
+  <%= button_to omniauth_authorize_path(resource_name, provider), class: 'button button--secondary w-full py-2 px-4 text-sm font-medium text-gray-500 focus:ring-0 dark:focus:ring-offset-gray-800', title: provider, data: { test_id: "#{provider}-btn", turbo: false } do %>
     <span class="sr-only">Sign in with <%= provider.capitalize %></span>
     <%= inline_svg_tag "icons/#{provider}.svg", class: 'h-5 w-5', aria: true, title: "#{provider} icon" %>
   <% end %>

--- a/app/components/paths/view_button_component.html.erb
+++ b/app/components/paths/view_button_component.html.erb
@@ -1,5 +1,5 @@
 <% if current_user.present? %>
- <%= button_to path_url(path), method: :get, class: "button button--clear #{classes}" do %>
+ <%= button_to path_url(path), method: :get, class: "button button--secondary #{classes}" do %>
     View
   <% end %>
 <% else %>

--- a/app/helpers/button_helper.rb
+++ b/app/helpers/button_helper.rb
@@ -2,7 +2,7 @@ module ButtonHelper
   def sign_up_button
     link_to 'Sign up', sign_up_path, class: 'button button--primary'
   end
-  
+
   def curriculum_button
     link_to 'View curriculum', paths_path, class: 'button button--primary text-base'
   end

--- a/app/helpers/button_helper.rb
+++ b/app/helpers/button_helper.rb
@@ -4,11 +4,11 @@ module ButtonHelper
   end
 
   def sign_in_button
-    link_to 'Sign in', sign_in_path, class: 'button button--clear'
+    link_to 'Sign in', sign_in_path, class: 'button button--secondary'
   end
 
   def create_new_account_button
-    link_to 'Create new account', new_registration_path(resource_name), class: 'button button--clear'
+    link_to 'Create new account', new_registration_path(resource_name), class: 'button button--secondary'
   end
 
   def curriculum_button
@@ -20,6 +20,6 @@ module ButtonHelper
   end
 
   def chat_button
-    link_to 'Open Discord', ODIN_CHAT_URL, class: 'button button--clear px-4', target: '_blank', rel: 'noreferrer'
+    link_to 'Open Discord', ODIN_CHAT_URL, class: 'button button--secondary px-4', target: '_blank', rel: 'noreferrer'
   end
 end

--- a/app/javascript/stylesheets/buttons.css
+++ b/app/javascript/stylesheets/buttons.css
@@ -16,7 +16,9 @@
   }
 
   .button--secondary {
-    @apply bg-gold-600 hover:bg-gold-700 focus:ring-gold-500
+    @apply border-gray-300 text-gray-700 hover:text-gray-700 bg-white hover:bg-gray-50
+    focus:ring-gray-400 focus:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700
+    dark:border-gray-600 dark:focus:ring-gray-600 dark:bg-transparent
   }
 
   .button--danger {
@@ -32,12 +34,6 @@
     @apply bg-white rounded-md px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset
     ring-gray-300 hover:bg-gray-50 hover:text-gray-900
     dark:bg-white/10  dark:text-white dark:hover:bg-white/20 dark:ring-transparent;
-  }
-
-  .button--clear {
-    @apply border-gray-300 text-gray-700 hover:text-gray-700 bg-white hover:bg-gray-50
-    focus:ring-gray-400 focus:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700
-    dark:border-gray-600 dark:focus:ring-gray-600 dark:bg-transparent
   }
 
   .button--dark {

--- a/app/views/courses/_course.html.erb
+++ b/app/views/courses/_course.html.erb
@@ -18,7 +18,7 @@
         <% end %>
       </div>
 
-      <%= link_to 'Open Course', path_course_url(course.path, course), class: 'button button--clear' %>
+      <%= link_to 'Open Course', path_course_url(course.path, course), class: 'button button--secondary' %>
     </div>
   <% end %>
 

--- a/app/views/lessons/_lesson_buttons.html.erb
+++ b/app/views/lessons/_lesson_buttons.html.erb
@@ -1,5 +1,5 @@
 <div class="flex flex-col justify-center max-w-sm mx-auto space-y-6 md:max-w-full md:space-y-0 md:flex-row md:space-x-7">
-  <%= link_to path_course_path(course.path, course), class: 'button button--clear px-4 font-medium', data: { test_id: 'view-course-btn' } do %>
+  <%= link_to path_course_path(course.path, course), class: 'button button--secondary px-4 font-medium', data: { test_id: 'view-course-btn' } do %>
     <i class="pr-2 text-lg far fa-map"></i>View Course
   <% end %>
 
@@ -15,11 +15,11 @@
   <% end %>
 
   <% if course.next_lesson(lesson).present? %>
-    <%= link_to lesson_path(course.next_lesson(lesson)), class: 'button button--clear px-4 font-medium', data: { test_id: 'next-lesson-btn' } do %>
+    <%= link_to lesson_path(course.next_lesson(lesson)), class: 'button button--secondary px-4 font-medium', data: { test_id: 'next-lesson-btn' } do %>
       <i class="pr-2 text-lg far fa-arrow-alt-circle-right" aria-hidden="true"></i>Next Lesson
     <% end %>
   <% elsif lesson.choose_path_lesson? %>
-    <%= link_to paths_url, class: 'button button--clear px-4 font-medium', data: { test_id: 'choose-path-lesson-btn' } do %>
+    <%= link_to paths_url, class: 'button button--secondary px-4 font-medium', data: { test_id: 'choose-path-lesson-btn' } do %>
       <i class="pr-2 text-lg fas fa-road" aria-hidden="true"></i>Choose Path
     <% end %>
   <% end %>

--- a/app/views/paths/show.html.erb
+++ b/app/views/paths/show.html.erb
@@ -12,7 +12,7 @@
       <% if current_user&.path != @path %>
         <%= button_to 'Select Path', users_paths_path(path_id: @path.id), class: 'button button--secondary', remote: false, method: :post, data: { disable_with: 'Selecting...', test_id: "#{@path.title.downcase}-select-path-btn" } %>
       <% else %>
-        <span class="button button--clear dark:bg-gray-700 hover:bg-transparent cursor-default">Selected Path</span>
+        <span class="button button--secondary dark:bg-gray-700 hover:bg-transparent cursor-default">Selected Path</span>
       <% end %>
     </section>
 

--- a/app/views/static_pages/about.html.erb
+++ b/app/views/static_pages/about.html.erb
@@ -31,7 +31,7 @@
         Connect with our friendly community on discord, a chat and networking platform or <a href="mailto:theodinprojectcontact@gmail.com" class="text-gold hover:underline">send us an email</a>.
       </p>
 
-      <%= link_to 'Chat on Discord', ODIN_CHAT_URL, class: 'button button--clear px-4', target: '_blank', rel: 'noreferrer' %>
+      <%= link_to 'Chat on Discord', ODIN_CHAT_URL, class: 'button button--secondary px-4', target: '_blank', rel: 'noreferrer' %>
     </div>
   </div>
 </div>

--- a/app/views/users/_skill.html.erb
+++ b/app/views/users/_skill.html.erb
@@ -14,14 +14,14 @@
 
   <div class="pt-4 md:pt-0">
     <% if course_completed_by_user?(course, current_user) %>
-      <%= link_to 'Open', path_course_path(course.path, course), class: 'button button--clear button--medium', data: { test_id: "#{course.title.downcase}-open-btn" } %>
+      <%= link_to 'Open', path_course_path(course.path, course), class: 'button button--secondary button--medium', data: { test_id: "#{course.title.downcase}-open-btn" } %>
     <% elsif current_user.started_course?(course) %>
       <%= link_to 'Resume',
         lesson_url(next_lesson_to_complete(course, current_user.lesson_completions_for_course(course))),
-        class: 'button button--clear button--medium',
+        class: 'button button--secondary button--medium',
         data: { test_id: "#{course.title.downcase}-resume-btn" } %>
     <% else %>
-      <%= link_to 'Start', path_course_url(course.path, course), class: 'button button--clear button--medium', data: {
+      <%= link_to 'Start', path_course_url(course.path, course), class: 'button button--secondary button--medium', data: {
             test_id: "#{course.title.downcase}-start-btn"
           } %>
     <% end %>

--- a/app/views/users/profiles/edit.html.erb
+++ b/app/views/users/profiles/edit.html.erb
@@ -61,11 +61,11 @@
         <% end %>
         <% card.with_body do %>
           <div class="inline-flex flex-col space-y-5">
-            <%= link_to users_progress_path(current_user), class: 'button button--clear px-3 py-2 text-sm', data: { turbo_method: :delete, turbo_confirm: 'Are you sure?', test_id: 'user-reset-progress-link' } do %>
+            <%= link_to users_progress_path(current_user), class: 'button button--secondary px-3 py-2 text-sm', data: { turbo_method: :delete, turbo_confirm: 'Are you sure?', test_id: 'user-reset-progress-link' } do %>
               <%= inline_svg_tag 'icons/refresh.svg', class: '-ml-0.5 mr-2 h-4 w-4 text-red-700 dark:text-red-500', aria: true, title: 'Reset icon' %>
               Reset progress
             <% end %>
-            <%= link_to registration_path(current_user), class: 'button button--clear px-3 py-2 text-sm', data: { turbo_method: :delete, turbo_confirm: 'Are you sure?', test_id: 'user-account-delete-link' } do %>
+            <%= link_to registration_path(current_user), class: 'button button--secondary px-3 py-2 text-sm', data: { turbo_method: :delete, turbo_confirm: 'Are you sure?', test_id: 'user-account-delete-link' } do %>
               <%= inline_svg_tag 'icons/trash.svg', class: '-ml-0.5 mr-2 h-4 w-4 text-red-700 dark:text-red-500', aria: true, title: 'Trash can icon' %>
               Delete account
             <% end %>

--- a/spec/helpers/button_helper_spec.rb
+++ b/spec/helpers/button_helper_spec.rb
@@ -13,14 +13,14 @@ RSpec.describe ButtonHelper do
 
   describe '#sign_in_button' do
     it 'returns a sign-in button' do
-      expect(helper.sign_in_button).to eq('<a class="button button--clear" href="/sign_in">Sign in</a>')
+      expect(helper.sign_in_button).to eq('<a class="button button--secondary" href="/sign_in">Sign in</a>')
     end
   end
 
   describe '#create_new_account_button' do
     it 'returns a create new account button' do
       expect(helper.create_new_account_button).to eq(
-        '<a class="button button--clear" href="/users/sign_up">Create new account</a>'
+        '<a class="button button--secondary" href="/users/sign_up">Create new account</a>'
       )
     end
   end
@@ -42,7 +42,7 @@ RSpec.describe ButtonHelper do
   describe '#chat_button' do
     let(:chat_button) do
       # rubocop:disable Layout/LineLength
-      '<a class="button button--clear px-4" target="_blank" rel="noreferrer" href="https://discord.gg/fbFCkYabZB">Open Discord</a>'
+      '<a class="button button--secondary px-4" target="_blank" rel="noreferrer" href="https://discord.gg/fbFCkYabZB">Open Discord</a>'
       # rubocop:enable Layout/LineLength
     end
 


### PR DESCRIPTION
## Because
- While working on #3923 @KevinMulhern rightfully pointed that out that by replacing (almost) all occurrences of `button--secondary` with `button--clear` we had essentially just replaced one with the other. This PR makes that change formal by renaming `button--clear` to `button--secondary`. While I could have renamed the old `button--secondary` to something like `button--gold` I opted to not do so given its inherent contrast issues.


## This PR
- Renames `button--secondary` to `button--clear`
- Drops the old `button--secondary` styling


## Issue
Closes #3923 

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behavior
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section