### PR TITLE
Fix: Add aria-label to logo links

### DIFF
--- a/app/components/logo_component.html.erb
+++ b/app/components/logo_component.html.erb
@@ -1,3 +1,3 @@
-<%= link_to root_path do %>
+<%= link_to root_path, 'aria-label': 'Return back home' do %>
   <%= inline_svg_tag 'logo.svg', class: "#{classes} text-gray-800 dark:text-gray-300", aria: true, title: 'Odin Logo' %>
 <% end %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -4,7 +4,7 @@
     <div class="flex justify-between">
       <div class="flex">
         <div class="flex-shrink-0 flex items-center">
-          <%= link_to root_path, class: 'logo' do %>
+          <%= link_to root_path, class: 'logo', 'aria-label': 'Return back home' do %>
             <%= image_tag 'icons/odin-icon.svg', alt: 'Odin Logo', class: 'block lg:hidden h-12 w-auto' %>
           <% end %>
 

--- a/app/views/static_pages/about/_overview.html.erb
+++ b/app/views/static_pages/about/_overview.html.erb
@@ -39,7 +39,7 @@
       <div class="col-span-3 lg:col-span-1">
         <%= render CardComponent.new do |card| %>
           <% card.with_header(classes: 'flex items-center') do %>
-            <a href="https://www.github.com/theodinproject" target="_blank"><i class="fab fa-github fa-2x"></i></a>
+            <a href="https://www.github.com/theodinproject" target="_blank" aria-label="View The Odin Project on GitHub"><i class="fab fa-github fa-2x"></i></a>
             <h3 class="font-bold text-2xl inline-block ml-4">Open Source</h3>
           <% end %>
           <% card.with_body(classes: 'prose prose-gray dark:prose-invert text-gray-500 dark:text-gray-300') do %>


### PR DESCRIPTION
## Because
- Currently there isn't anything describing where the logo links go to, which presents issues when using a screen reader


## This PR
- Adds a `aria-label` to make it clear where the links go to


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behavior
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
