### PR TITLE
Fix: Make subheading optional

### DIFF
--- a/app/views/paths/show.html.erb
+++ b/app/views/paths/show.html.erb
@@ -22,8 +22,7 @@
       <p class="text-center path-description">
         <%= render 'shared/bottom_cta',
           button: sign_up_or_view_curriculum_button,
-          heading: 'Start learning for free now!',
-          sub_heading: '' %>
+          heading: 'Start learning for free now!' %>
       </p>
     <% end %>
   </div>

--- a/app/views/shared/_bottom_cta.html.erb
+++ b/app/views/shared/_bottom_cta.html.erb
@@ -1,5 +1,7 @@
 <div class="py-20 text-center max-w-4xl mx-auto">
   <h4 class="text-2xl mb-4 font-light leading-10 text-gray-600 dark:text-gray-200"><%= heading %></h4>
+  <% if defined?sub_heading %>
   <p class="font-normal mb-10 text-gray-500 dark:text-gray-400"><%= sub_heading %></p>
+  <% end %>
   <%= button %>
 </div>

--- a/app/views/shared/_bottom_cta.html.erb
+++ b/app/views/shared/_bottom_cta.html.erb
@@ -1,6 +1,6 @@
 <div class="py-20 text-center max-w-4xl mx-auto">
   <h4 class="text-2xl mb-4 font-light leading-10 text-gray-600 dark:text-gray-200"><%= heading %></h4>
-  <% if defined?sub_heading %>
+  <% if local_assigns[:sub_heading].present? %>
   <p class="font-normal mb-10 text-gray-500 dark:text-gray-400"><%= sub_heading %></p>
   <% end %>
   <%= button %>

--- a/app/views/static_pages/about.html.erb
+++ b/app/views/static_pages/about.html.erb
@@ -40,7 +40,6 @@
   <div class="max-w-4xl mx-auto">
   <%= render 'shared/bottom_cta',
     button: contribute_button,
-    heading: 'Help the Odin Project stay current and meaningful to all future students, please contribute!',
-    sub_heading: '' %>
+    heading: 'Help the Odin Project stay current and meaningful to all future students, please contribute!' %>
   </div>
 </div>

--- a/app/views/static_pages/success_stories.html.erb
+++ b/app/views/static_pages/success_stories.html.erb
@@ -27,6 +27,5 @@
 
   <%= render 'shared/bottom_cta',
     button: sign_up_or_view_curriculum_button,
-    heading: 'Start learning for free now!',
-    sub_heading: '' %>
+    heading: 'Start learning for free now!' %>
 </div>


### PR DESCRIPTION
## Because
- Currently `shared/_bottom_cta.html.erb` requires a `sub_heading` to be passed. Sometimes this isn't wanted however, and to avoid errors people simply pass an empty string. This however leads to weird empty `p` elements.


## This PR
- Makes `sub_heading` optional, and doesn't render anything if nothing is passed
- Fixed all cases where `sub_heading` is an empty string


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behavior
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.