### PR TITLE
Feature: Hide live preview input and button

### DIFF
--- a/app/components/project_submissions/item_component.html.erb
+++ b/app/components/project_submissions/item_component.html.erb
@@ -8,7 +8,10 @@
 
     <div class="flex flex-row md:items-center">
       <%= link_to 'View code', project_submission.repo_url, target: '_blank', rel: 'noreferrer', class: 'button button--gray font-semibold mr-4', data: { test_id: 'view-code-btn' } %>
-      <%= link_to 'Live preview', project_submission.live_preview_url, target: '_blank', rel: 'noreferrer', class: 'button button--gray font-semibold mr-4', data: { test_id: 'live-preview-btn' } %>
+
+      <% if project_submission.lesson.has_live_preview? %>
+        <%= link_to 'Live preview', project_submission.live_preview_url, target: '_blank', rel: 'noreferrer', class: 'button button--gray font-semibold mr-4', data: { test_id: 'live-preview-btn' } %>
+      <% end %>
 
       <div class="flex-none absolute top-7 right-0 md:relative md:top-auto md:right-auto" data-controller="visibility" data-action="visibility:click:outside->visibility#off" data-visibility-visible-value="false">
         <button type="button" data-action="click->visibility#toggle" data-test-id="submission-action-menu-btn" class="-m-2.5 block p-2.5 text-gray-500 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100" id="options-menu-0-button" aria-expanded="false" aria-haspopup="true">

--- a/app/views/lessons/v2_project_submissions/_form.html.erb
+++ b/app/views/lessons/v2_project_submissions/_form.html.erb
@@ -9,12 +9,14 @@
           <% end %>
         </div>
 
-        <div>
-          <%= form.label :live_preview_url, 'Live preview (optional)' %>
-          <%= form.text_field :live_preview_url, leading_icon: true, placeholder: 'http://example.com', class: 'text-sm', data: { test_id: 'live-preview-url-field' } do %>
-            <%= inline_svg_tag 'icons/link.svg', class: 'h-5 w-5 text-gray-400', aria: true, title: 'Project live preview', desc: 'Link icon' %>
-          <% end %>
-        </div>
+        <% if project_submission.lesson.has_live_preview? %>
+          <div>
+            <%= form.label :live_preview_url, 'Live preview (optional)' %>
+            <%= form.text_field :live_preview_url, leading_icon: true, placeholder: 'http://example.com', class: 'text-sm', data: { test_id: 'live-preview-url-field' } do %>
+              <%= inline_svg_tag 'icons/link.svg', class: 'h-5 w-5 text-gray-400', aria: true, title: 'Project live preview', desc: 'Link icon' %>
+            <% end %>
+          </div>
+        <% end %>
 
         <fieldset class="mt-2">
           <legend class="text-sm font-medium leading-6 text-gray-900 dark:text-white">Privacy</legend>

--- a/spec/support/pages/project_submissions/form.rb
+++ b/spec/support/pages/project_submissions/form.rb
@@ -6,6 +6,7 @@ module Pages
 
       option :repo_url, default: -> { 'https://github.com/myname/my-project' }
       option :live_preview_url, default: -> { 'https://myprojectlivepreview.com' }
+      option :has_live_preview, default: -> { true }
 
       def self.fill_in_and_submit(**args)
         new(**args)
@@ -22,7 +23,7 @@ module Pages
 
       def fill_in
         find(:test_id, 'repo-url-field').fill_in(with: @repo_url)
-        find(:test_id, 'live-preview-url-field').fill_in(with: @live_preview_url)
+        find(:test_id, 'live-preview-url-field').fill_in(with: @live_preview_url) if @has_live_preview
         self
       end
 


### PR DESCRIPTION
Because:
* Some solutions do not accept previews - for example the early Ruby projects.

This commit:
* If the project does not accept live previews...
  * Hide the live preview input.
  * hide the live preview button