### PR TITLE
Feature: clean up usage of gold text

### DIFF
--- a/app/components/announcement_component.html.erb
+++ b/app/components/announcement_component.html.erb
@@ -6,7 +6,7 @@
         <p><%= announcement.message %></p>
         <% if announcement.learn_more_url.present? %>
           <p class="block sm:ml-2 sm:inline-block">
-            <a href="<%= announcement.learn_more_url %>" class="font-bold underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300">
+            <a href="<%= announcement.learn_more_url %>" class="font-bold underline text-gray-900 hover:text-gray-700 dark:text-gray-100 dark:hover:text-gray-300">
               Learn more
               <span aria-hidden="true"> &rarr;</span>
             </a>

--- a/app/components/announcement_component.html.erb
+++ b/app/components/announcement_component.html.erb
@@ -6,7 +6,7 @@
         <p><%= announcement.message %></p>
         <% if announcement.learn_more_url.present? %>
           <p class="block sm:ml-2 sm:inline-block">
-            <a href="<%= announcement.learn_more_url %>" class="font-bold text-gold-600 underline hover:text-gold-500">
+            <a href="<%= announcement.learn_more_url %>" class="font-bold underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300">
               Learn more
               <span aria-hidden="true"> &rarr;</span>
             </a>

--- a/app/components/faq/item_component.html.erb
+++ b/app/components/faq/item_component.html.erb
@@ -20,7 +20,7 @@
       </span>
     </button>
   </dt>
-  <dd class="mt-4 pr-8 hidden max-w-none prose prose-gray-500 prose-a:text-gold-600 dark:prose-invert dark:antialiased" data-visibility-target="content" data-test-id="faq-answer">
+  <dd class="mt-4 pr-8 hidden max-w-none prose prose-gray-500 dark:prose-invert dark:antialiased" data-visibility-target="content" data-test-id="faq-answer">
     <%= item.fetch(:answer).html_safe %>
   </dd>
 </div>

--- a/app/javascript/components/project-submissions/components/submissions-list.jsx
+++ b/app/javascript/components/project-submissions/components/submissions-list.jsx
@@ -68,7 +68,8 @@ const SubmissionsList = ({
               {' '}
             </span>
             <a
-              className="text-gold"
+              className="underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400
+               dark:hover:text-gray-300"
               data-test-id="view-all-projects-link"
               href={allSubmissionsPath}
             >

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,9 +1,9 @@
 <%= title('Internal Server Error (500)') %>
 
-<p class="text-base text-gold-600">500</p>
+<p class="text-base text-slate-600">500</p>
 <h1 class="mt-4 text-5xl text-slate-900 font-bold">Server error</h1>
 <p class="leading-7 mt-6 text-slate-600">We're sorry, but something went wrong.</p>
 <div class="mt-10 flex items-center justify-center gap-x-6">
   <%= link_to 'Go back home', root_path, class: 'button button--primary' %>
-  <a href="https://github.com/TheOdinProject/theodinproject/issues/new/choose" class="text-gold-600 hover:text-gold-500">Report an issue on GitHub <span aria-hidden="true">&rarr;</span></a>
+  <a href="https://github.com/TheOdinProject/theodinproject/issues/new/choose" class="underline hover:no-underline text-gray-600 hover:text-gray-800">Report an issue on GitHub <span aria-hidden="true">&rarr;</span></a>
 </div>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,8 +1,8 @@
 <%= title('Internal Server Error (500)') %>
 
-<p class="text-base text-slate-600">500</p>
-<h1 class="mt-4 text-5xl text-slate-900 font-bold">Server error</h1>
-<p class="leading-7 mt-6 text-slate-600">We're sorry, but something went wrong.</p>
+<p class="text-base text-gray-600">500</p>
+<h1 class="mt-4 text-5xl text-gray-900 font-bold">Server error</h1>
+<p class="leading-7 mt-6 text-gray-600">We're sorry, but something went wrong.</p>
 <div class="mt-10 flex items-center justify-center gap-x-6">
   <%= link_to 'Go back home', root_path, class: 'button button--primary' %>
   <a href="https://github.com/TheOdinProject/theodinproject/issues/new/choose" class="underline hover:no-underline text-gray-600 hover:text-gray-800">Report an issue on GitHub <span aria-hidden="true">&rarr;</span></a>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,8 +1,8 @@
 <%= title('Unprocessable entity (500)') %>
 
-<p class="text-base text-slate-600">422</p>
-<h1 class="mt-4 text-5xl text-slate-900 font-bold">Unprocessable entity</h1>
-<p class="leading-7 mt-6 text-slate-600">The change you wanted was rejected. Maybe you tried to change something you didn't have access to</p>
+<p class="text-base text-gray-600">422</p>
+<h1 class="mt-4 text-5xl text-gray-900 font-bold">Unprocessable entity</h1>
+<p class="leading-7 mt-6 text-gray-600">The change you wanted was rejected. Maybe you tried to change something you didn't have access to</p>
 <div class="mt-10 flex items-center justify-center gap-x-6">
   <%= link_to 'Go back home', root_path, class: 'button button--primary' %>
   <a href="https://github.com/TheOdinProject/theodinproject/issues/new/choose" class="underline hover:no-underline text-gray-600 hover:text-gray-800">Report an issue on GitHub <span aria-hidden="true">&rarr;</span></a>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,9 +1,9 @@
 <%= title('Unprocessable entity (500)') %>
 
-<p class="text-base text-gold-600">422</p>
+<p class="text-base text-slate-600">422</p>
 <h1 class="mt-4 text-5xl text-slate-900 font-bold">Unprocessable entity</h1>
 <p class="leading-7 mt-6 text-slate-600">The change you wanted was rejected. Maybe you tried to change something you didn't have access to</p>
 <div class="mt-10 flex items-center justify-center gap-x-6">
   <%= link_to 'Go back home', root_path, class: 'button button--primary' %>
-  <a href="https://github.com/TheOdinProject/theodinproject/issues/new/choose" class="text-gold-600 hover:text-gold-500">Report an issue on GitHub <span aria-hidden="true">&rarr;</span></a>
+  <a href="https://github.com/TheOdinProject/theodinproject/issues/new/choose" class="underline hover:no-underline text-gray-600 hover:text-gray-800">Report an issue on GitHub <span aria-hidden="true">&rarr;</span></a>
 </div>

--- a/app/views/lessons/_project_submissions.html.erb
+++ b/app/views/lessons/_project_submissions.html.erb
@@ -8,7 +8,7 @@
   <div>
     <p class="text-center py-6 px-0">
       <span> Showing <%= limit %> most liked submissions -
-      <%= link_to 'View full list of solutions', lesson_v2_project_submissions_path(lesson), class: 'text-gold', data: { test_id: 'view-all-projects-link' } %>
+      <%= link_to 'View full list of solutions', lesson_v2_project_submissions_path(lesson), class: 'underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300', data: { test_id: 'view-all-projects-link' } %>
     </p>
   </div>
 <% else %>

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -36,7 +36,7 @@
               ) %>
         <% elsif @lesson.accepts_submission? %>
           <p class="mb-7">
-            Please <%= link_to 'Sign in', sign_in_path, class: 'text-gold' %> or <%= link_to 'Sign up', sign_up_path, class: 'text-gold', data: {test_id: 'sign_up'} %> to view user submissions for this project!
+            Only logged in users can view user submissions for this project
           </p>
         <% end %>
 
@@ -45,7 +45,7 @@
     <% end %>
 
     <div class="py-10">
-      <%= link_to github_edit_url(@lesson), target: :_blank, rel: 'noreferrer noopener', class: 'text-gold-600 hover:underline' do %>
+      <%= link_to github_edit_url(@lesson), target: :_blank, rel: 'noreferrer noopener', class: 'underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300' do %>
         <span class="fab fa-github mr-1"></span>
         Improve this lesson on GitHub
       <% end %>

--- a/app/views/paths/index.html.erb
+++ b/app/views/paths/index.html.erb
@@ -12,7 +12,6 @@
               <%= image_tag @foundations.badge_uri, alt: "#{@foundations.title} badge", class: 'w-24 h-24' %>
             <% end %>
             <div class="flex items-center flex-col sm:block">
-              <h3 class="text-sm text-gold-600">Start here</h3>
               <%= link_to path_path(@foundations), class: 'no-underline' do %>
                 <h2 class="text-3xl font-medium text-gray-800 dark:text-gray-300">Foundations</h2>
               <% end %>
@@ -57,7 +56,7 @@
             <% end %>
 
             <div class="w-full flex justify-between pt-6">
-              <p class=" text-gold-600">PATH</p>
+              <p>PATH</p>
               <p class=" text-gray-500 dark:text-gray-400"><%= path.courses.size %> Courses</p>
             </div>
           <% end %>

--- a/app/views/paths/index.html.erb
+++ b/app/views/paths/index.html.erb
@@ -56,7 +56,7 @@
             <% end %>
 
             <div class="w-full flex justify-between pt-6">
-              <p>PATH</p>
+              <p class="text-gray-500">PATH</p>
               <p class=" text-gray-500 dark:text-gray-400"><%= path.courses.size %> Courses</p>
             </div>
           <% end %>

--- a/app/views/static_pages/about.html.erb
+++ b/app/views/static_pages/about.html.erb
@@ -28,7 +28,7 @@
       <h2 class="mb-4 font-bold text-2xl">Want to contact us?</h2>
 
       <p class="pb-8 max-w-md mx-auto dark:text-gray-400 text-gray-500">
-        Connect with our friendly community on discord, a chat and networking platform or <a href="mailto:theodinprojectcontact@gmail.com" class="text-gold hover:underline">send us an email</a>.
+        Connect with our friendly community on discord, a chat and networking platform or <a href="mailto:theodinprojectcontact@gmail.com" class="underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300">send us an email</a>.
       </p>
 
       <%= link_to 'Chat on Discord', ODIN_CHAT_URL, class: 'button button--clear px-4', target: '_blank', rel: 'noreferrer' %>

--- a/app/views/static_pages/contributing/_hall_of_fame.html.erb
+++ b/app/views/static_pages/contributing/_hall_of_fame.html.erb
@@ -22,7 +22,7 @@
     <div class="text-center no-underline hover:underline py-6">
       <%= link_to 'View All Contributors',
           github_link('theodinproject/graphs/contributors'),
-          class: 'text-gold-600',
+          class: 'underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300',
           target: '_blank',
           rel: 'noreferrer' %>
     </div>

--- a/app/views/static_pages/dashboard_steps/_github_link.html.erb
+++ b/app/views/static_pages/dashboard_steps/_github_link.html.erb
@@ -1,5 +1,5 @@
 <div class="flex justify-center">
-  <%= link_to github_link("theodinproject/edit/main/#{filename}"), target: :_blank, rel: 'noreferrer noopener', class: 'text-gold-600 text-lg block mt-14' do %>
+  <%= link_to github_link("theodinproject/edit/main/#{filename}"), target: :_blank, rel: 'noreferrer noopener', class: 'underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 text-lg block mt-14' do %>
     <span class="fab fa-github mr-1"></span>
     <span>Suggest improvements for this page on GitHub</span>
   <% end %>

--- a/app/views/static_pages/home/_success_stories.html.erb
+++ b/app/views/static_pages/home/_success_stories.html.erb
@@ -12,7 +12,7 @@
         </div>
 
         <div class="flex-1">
-            <p><%= link_to story.student_name, story.social_media_link, class: 'underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300' %></p>
+            <p><%= link_to story.student_name, story.social_media_link, class: 'underline hover:no-underline text-gray-900 hover:text-gray-700 dark:text-gray-200 dark:hover:text-gray-300' %></p>
           <div class="text-lg"><%= story.story_content.truncate_words(30).html_safe %></div>
         </div>
       </div>

--- a/app/views/static_pages/home/_success_stories.html.erb
+++ b/app/views/static_pages/home/_success_stories.html.erb
@@ -12,7 +12,7 @@
         </div>
 
         <div class="flex-1">
-            <p><%= link_to story.student_name, story.social_media_link, class: 'text-gold-600' %></p>
+            <p><%= link_to story.student_name, story.social_media_link, class: 'underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300' %></p>
           <div class="text-lg"><%= story.story_content.truncate_words(30).html_safe %></div>
         </div>
       </div>

--- a/app/views/static_pages/success_stories.html.erb
+++ b/app/views/static_pages/success_stories.html.erb
@@ -13,7 +13,7 @@
               <%= image_tag "success_stories/#{story.avatar_path_name}", alt: "#{story.student_name}'s avatar", class: 'w-full shadow-inner aspect-auto' %>
             </div>
             <div class="flex flex-col text-center sm:text-left">
-              <p class="font-bold"><%= link_to story.student_name, story.social_media_link, class: 'underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300' %></p>
+              <p class="font-bold"><%= link_to story.student_name, story.social_media_link, class: 'underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-200 dark:hover:text-gray-300' %></p>
               <p class="text-gray-500 dark:text-gray-400"><%= story.job_title %></p>
             </div>
           </div>

--- a/app/views/static_pages/success_stories.html.erb
+++ b/app/views/static_pages/success_stories.html.erb
@@ -13,7 +13,7 @@
               <%= image_tag "success_stories/#{story.avatar_path_name}", alt: "#{story.student_name}'s avatar", class: 'w-full shadow-inner aspect-auto' %>
             </div>
             <div class="flex flex-col text-center sm:text-left">
-              <p class="font-bold"><%= link_to story.student_name, story.social_media_link, class: 'text-gold' %></p>
+              <p class="font-bold"><%= link_to story.student_name, story.social_media_link, class: 'underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300' %></p>
               <p class="text-gray-500 dark:text-gray-400"><%= story.job_title %></p>
             </div>
           </div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -6,7 +6,7 @@
     <h2 class="mt-6 text-center text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-200">Sign up for free</h2>
     <p class="block mt-2 text-center text-sm text-gray-600 dark:text-gray-300">
       Or
-      <%= link_to 'sign in to your existing account', sign_in_path, class: 'font-medium underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300' %>
+      <%= link_to 'sign in to your existing account', sign_in_path, class: 'font-medium underline hover:no-underline text-gray-700 hover:text-gray-800 dark:text-gray-300 dark:hover:text-gray-300' %>
     </p>
   </div>
 

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -6,7 +6,7 @@
     <h2 class="mt-6 text-center text-3xl font-bold tracking-tight text-gray-900 dark:text-gray-200">Sign up for free</h2>
     <p class="block mt-2 text-center text-sm text-gray-600 dark:text-gray-300">
       Or
-      <%= link_to 'sign in to your existing account', sign_in_path, class: 'font-medium text-gold-600 hover:text-gold-500' %>
+      <%= link_to 'sign in to your existing account', sign_in_path, class: 'font-medium underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300' %>
     </p>
   </div>
 

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -7,7 +7,7 @@
       <h2 class="mt-6 text-center text-3xl font-bold tracking-tight text-gray-700 dark:text-gray-200">Sign in to your account</h2>
       <p class="mt-2 text-center text-sm text-gray-600 dark:text-gray-300">
         Or
-        <%= link_to 'sign up for a new account', sign_up_path, class: 'font-medium text-gold-600 hover:text-gold-500' %>
+        <%= link_to 'sign up for a new account', sign_up_path, class: 'font-medium underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300' %>
       </p>
     </div>
 

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -7,7 +7,7 @@
       <h2 class="mt-6 text-center text-3xl font-bold tracking-tight text-gray-700 dark:text-gray-200">Sign in to your account</h2>
       <p class="mt-2 text-center text-sm text-gray-600 dark:text-gray-300">
         Or
-        <%= link_to 'sign up for a new account', sign_up_path, class: 'font-medium underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300' %>
+        <%= link_to 'sign up for a new account', sign_up_path, class: 'font-medium underline hover:no-underline text-gray-700 hover:text-gray-800 dark:text-gray-300 dark:hover:text-gray-300' %>
       </p>
     </div>
 


### PR DESCRIPTION
## Because
- `text-gold-600` / `text-gold` (which comes down to the same) doesn't meet minimal contrast requirements


## This PR
- cleans up all remaining in-text uses, except the main page header
 - For most pages this meant either stripping it entirely or replacing it with `underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300`
 - A few exceptions
  - The "start here" above Foundations on `/paths` has always been small, and without color didn't stand out at all. Given that the design of the page already makes clear what is happening I opted to instead strip it entirely
  - When not logged in on a lesson page with projects a user would see "Please [Sign in](https://www.theodinproject.com/sign_in) or [Sign up](https://www.theodinproject.com/sign_up) to view user submissions for this project!". Without the gold (and even with it) this just looks silly, as its placed above the massive primary "Sign up to track progress button". Instead I've replaced it with "Only logged in users can view user submissions for this project". 


## Issue
Closes #3962 

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behavior
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section