### PR TITLE
Fix: Inconsistent link hover behaviour

### DIFF
--- a/app/javascript/stylesheets/lesson-content.css
+++ b/app/javascript/stylesheets/lesson-content.css
@@ -78,7 +78,7 @@
     @apply mt-0;
   }
 
-  .lesson-content a[href^="http"] {
+  .lesson-content a {
     @apply hover:no-underline;
   }
 


### PR DESCRIPTION
Because:
* We were only removing the underline on hover for external links. This resulted in some links sections having links with different hover behaviour.
* I think this rule was added so the links in headings wouldn't display an underline on hover - but it doesn't seem to be needed anymore.


https://github.com/TheOdinProject/theodinproject/assets/7963776/4b43c711-4674-4679-ba5d-2f34f8868451



This commit:
* Removes the http matcher regex from the lesson content link selector.
