### PR TITLE
Feature: Darken course title and lesson count in light theme.

### DIFF
--- a/app/views/courses/_course.html.erb
+++ b/app/views/courses/_course.html.erb
@@ -11,10 +11,10 @@
       <div class="flex flex-col items-center space-y-4 md:flex-row md:space-x-4 text-center md:space-y-0">
         <%= render Course::BadgeComponent.new(course:, options: { show_badge: true, background_color: 'bg-white dark:bg-gray-800', size: :small }) %>
         <%= link_to path_course_url(course.path, course), class: 'flex flex-col md:items-start' do %>
-          <h2 id="<%= course.title.parameterize %>" class="font-medium text-xl md:text-left text-gray-600 dark:text-gray-200">
+          <h2 id="<%= course.title.parameterize %>" class="font-medium text-xl md:text-left text-gray-900 dark:text-gray-200">
             <%= course.title %>
           </h2>
-          <span class=" text-sm text-gray-400"><%= course.lessons.size %> Lessons</span>
+          <span class=" text-sm text-gray-500"><%= course.lessons.size %> Lessons</span>
         <% end %>
       </div>
 


### PR DESCRIPTION
Because:
* The lesson count was too light - darkens the title to better match the new lesson count color.

Before:
<img width="1003" alt="Screenshot 2023-07-14 at 15 18 25" src="https://github.com/TheOdinProject/theodinproject/assets/7963776/131d8967-891c-4e31-9a87-a733e2edf3e5">

After:
<img width="979" alt="Screenshot 2023-07-14 at 15 19 11" src="https://github.com/TheOdinProject/theodinproject/assets/7963776/1f1bcaff-333c-4664-804b-bbb2483a8f9d">

