### PR TITLE
Feature: Give homepage hero background full width and height

### DIFF
--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -12,7 +12,7 @@
 
       <%= link_to 'View Full Curriculum', paths_url, class: 'button button--secondary text-base' %>
     </header>
-    <%= image_tag 'home-isometric.svg', alt: 'home-page-banner',:class =>'w-full h-full'%>
+    <%= image_tag 'home-isometric.svg', alt: 'home-page-banner', class: 'w-full h-full' %>
   </div>
 
   <%= render 'static_pages/home/how_it_works' %>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -12,7 +12,7 @@
 
       <%= link_to 'View Full Curriculum', paths_url, class: 'button button--secondary text-base' %>
     </header>
-    <%= image_tag 'home-isometric.svg', alt: 'home-page-banner' %>
+    <%= image_tag 'home-isometric.svg', alt: 'home-page-banner',:class =>'w-full h-full'%>
   </div>
 
   <%= render 'static_pages/home/how_it_works' %>


### PR DESCRIPTION
## Because
Upon initial loading of the homepage, the hero background moves around a bit. 
After solving this, the page will load smoothly due to browser knowing the pre-made space the banner requires.

## This PR
- Adds ``class: 'w-full h-full' `` to the homepage [banner](https://github.com/TheOdinProject/theodinproject/blob/main/app/views/static_pages/home.html.erb#L15) element.

## Issue
Closes #3949


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behavior
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
