### PR TITLE
Chore: Update authentication requirement for API GET requests

### DIFF
--- a/app/controllers/api/points_controller.rb
+++ b/app/controllers/api/points_controller.rb
@@ -1,6 +1,6 @@
 class Api::PointsController < ApplicationController
   skip_before_action :verify_authenticity_token
-  before_action :authenticate, except: %i[index show]
+  before_action :authenticate
 
   def index
     render json: Point.all.order(points: :desc).limit(params[:limit]).offset(params[:offset])

--- a/spec/requests/api/points_spec.rb
+++ b/spec/requests/api/points_spec.rb
@@ -2,42 +2,89 @@ require 'rails_helper'
 
 RSpec.describe 'Static Pages' do
   describe 'GET #index' do
-    it 'returns all points ordered by the highest amount' do
-      highest_points = create(:point, points: 6)
-      middle_points = create(:point, points: 5)
-      lowest_points = create(:point, points: 1)
+    context 'when not authenticated' do
+      it 'returns 401 forbidden' do
+        get api_points_path
 
-      get api_points_path
-      expect(JSON.parse(response.body)).to eq(
-        [highest_points, middle_points, lowest_points].map(&:as_json)
-      )
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
 
-    context 'when limit and offset params are provided' do
-      it 'returns the filtererd points ordered by highest' do
+    context 'when authenticated' do
+      around do |example|
+        ClimateControl.modify(
+          ODIN_BOT_ACCESS_TOKEN: 'ODIN_BOT_ACCESS_TOKEN'
+        ) do
+          example.run
+        end
+      end
+
+      it 'returns all points ordered by the highest amount' do
+        highest_points = create(:point, points: 6)
+        middle_points = create(:point, points: 5)
+        lowest_points = create(:point, points: 1)
+
+        get(
+          api_points_path,
+          headers: { 'Authorization' => 'Token ODIN_BOT_ACCESS_TOKEN' }
+        )
+
+        expect(JSON.parse(response.body)).to eq(
+          [highest_points, middle_points, lowest_points].map(&:as_json)
+        )
+      end
+
+      it 'returns specified offset and limit to points' do
         create(:point, points: 6)
         create(:point, points: 1)
         middle_points = create(:point, points: 5)
 
-        get api_points_path(offset: 1, limit: 1)
+        get(
+          api_points_path(offset: 1, limit: 1),
+          headers: { 'Authorization' => 'Token ODIN_BOT_ACCESS_TOKEN' }
+        )
         expect(JSON.parse(response.body)).to eq([middle_points.as_json])
       end
     end
   end
 
   describe 'GET #show' do
-    it 'returns the points for that discord user' do
-      user_points = create(:point, points: 6, discord_id: 907)
+    context 'when not authenticated' do
+      it 'returns status 401' do
+        get '/api/points/907'
 
-      get api_point_path(id: 907)
-
-      expect(JSON.parse(response.body)).to eq(user_points.as_json)
+        expect(response).to have_http_status(:unauthorized)
+      end
     end
 
-    it 'returns an error message if the discord user cannot be found' do
-      get api_point_path(id: 907)
+    context 'when authenticated' do
+      around do |example|
+        ClimateControl.modify(
+          ODIN_BOT_ACCESS_TOKEN: 'ODIN_BOT_ACCESS_TOKEN'
+        ) do
+          example.run
+        end
+      end
 
-      expect(JSON.parse(response.body)).to eq({ 'message' => 'Unable to find that user' })
+      it 'returns the points for that discord user' do
+        user_points = create(:point, points: 6, discord_id: 907)
+
+        get(
+          '/api/points/907',
+          headers: { 'Authorization' => 'Token ODIN_BOT_ACCESS_TOKEN' }
+        )
+
+        expect(JSON.parse(response.body)).to eq(user_points.as_json)
+      end
+
+      it 'returns an error message if the discord user cannot be found' do
+        get(
+          '/api/points/907',
+          headers: { 'Authorization' => 'Token ODIN_BOT_ACCESS_TOKEN' }
+        )
+
+        expect(JSON.parse(response.body)).to eq({ 'message' => 'Unable to find that user' })
+      end
     end
   end
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Related to the issue in odin-bot-v2 issue of unauthenticated GET requests: https://github.com/TheOdinProject/odin-bot-v2/issues/175


## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
Changes the controller to requrie autherization of API GET Requests

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behavior
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes
-   [ ] The `Because` section summarizes the reason for this PR
-   [ ] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If applicable, this PR includes new or updated automated tests
