### PR TITLE
Fix email address - mailto

### DIFF
--- a/app/views/user_mailer/welcome_email.html.erb
+++ b/app/views/user_mailer/welcome_email.html.erb
@@ -226,7 +226,7 @@
               <tr>
                 <td class="contents inner" style="padding: 10px; text-align: left; width: 100%;">
                   <p class="outro-text" style="color: #4a4a4a; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;">If you have any additional questions, check out our
-                    <%= link_to 'Frequently Asked Questions', faq_url %> or feel free to reach out to <a href="mailto: theodinprojectcontact@gmail.com">theodinprojectcontact@gmail.com</a>.</p>
+                    <%= link_to 'Frequently Asked Questions', faq_url %> or feel free to reach out to <a href="mailto:theodinprojectcontact@gmail.com">theodinprojectcontact@gmail.com</a>.</p>
                   <p class="outro-text bold" style="color: #4a4a4a; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif; font-weight: bold;">Best of luck with your learning journey!</p>
                   <p class="outro-text" style="color: #4a4a4a; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;">Sincerely,</p>
                   <p class="outro-text" style="color: #4a4a4a; font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;"><span class="italicised" style="font-style: italic;">The Odin Maintainer Team</span></p>


### PR DESCRIPTION
Hi. 

Removed space after `mailto:` keyword protocol - fix for Welcome message.

## Because
Issue fix: https://github.com/TheOdinProject/theodinproject/issues/3999

## This PR
Changed to valid email address.

## Issue
#3999

## Additional Information
Useful resource:
"URLs cannot contain spaces. URL encoding normally replaces a space with a plus (+) sign, or %20."
https://www.w3schools.com/html/html_urlencode.asp#:~:text=URLs%20cannot%20contain%20spaces.,(%2B)%20sign%2C%20or%20%20.


## Pull Request Requirements
 
-   [x ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [ x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behavior
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes
-   [x ] The `Because` section summarizes the reason for this PR
-   [x ] The `This PR` section has a bullet point list describing the changes in this PR
-   [x ] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x ] If applicable, this PR includes new or updated automated tests
