### PR TITLE
Fix: Bottom border radius on settings card

### DIFF
--- a/app/views/users/profiles/edit.html.erb
+++ b/app/views/users/profiles/edit.html.erb
@@ -48,7 +48,7 @@
               </div>
             </div>
           <% end %>
-          <% card.with_footer(classes: 'px-4 py-3 pt-3 bg-gray-50 text-right sm:px-6 dark:bg-gray-700/40') do %>
+          <% card.with_footer(classes: 'px-4 py-3 pt-3 bg-gray-50 text-right sm:px-6 dark:bg-gray-700/40 rounded-b-lg') do %>
             <%= form.submit 'Save', class: 'button button--primary py-2 px-4', data: { test_id: 'save-profile-btn', disable_with: false } %>
           <% end %>
         <% end %>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -39,7 +39,7 @@
                 </div>
               </div>
             <% end %>
-            <% card.with_footer(classes: 'px-4 py-3 pt-3 bg-gray-50 text-right sm:px-6 dark:bg-gray-700/40') do %>
+            <% card.with_footer(classes: 'px-4 py-3 pt-3 bg-gray-50 text-right sm:px-6 dark:bg-gray-700/40 rounded-b-lg') do %>
               <%= form.submit 'Save', class: 'button button--primary py-2 px-4', data: { disable_with: false } %>
             <% end %>
           <% end %>


### PR DESCRIPTION
Because:
* The bottom border radius is being overlapped by the action bar on settings cards.
<img width="1008" alt="Screenshot 2023-07-21 at 01 59 04" src="https://github.com/TheOdinProject/theodinproject/assets/7963776/b1408a76-bf01-45a8-8afe-0019c2d4c0e5">


This commit:
* Adds a bottom border radius to the action bar which matches the rest of the card.


