### PR TITLE
Fix: Notifying Discord when a flag is created.

### DIFF
--- a/app/controllers/project_submissions/flags_controller.rb
+++ b/app/controllers/project_submissions/flags_controller.rb
@@ -41,7 +41,7 @@ class ProjectSubmissions::FlagsController < ApplicationController
     return unless Rails.env.production?
 
     DiscordNotifier.notify(
-      Notifications::FlagSubmission.new(flag)
+      Notifications::FlagSubmission.new(@flag)
     )
   end
 end


### PR DESCRIPTION
Because:
* The flags controller was refactored with our move to project submissions v2, but we forgot to switch the flag used with the discord notifier method to an instance variable.
