### PR TITLE
Feature: Like styling tweaks.

### DIFF
--- a/app/assets/images/icons/heart.svg
+++ b/app/assets/images/icons/heart.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24" stroke-width="1.5" stroke="gray">
   <path stroke-linecap="round" stroke-linejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12z" />
 </svg>

--- a/app/components/project_submissions/like_component.html.erb
+++ b/app/components/project_submissions/like_component.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag dom_id(project_submission, :likes) do %>
-  <%= button_to project_submission_v2_like_path(project_submission), method: http_action, disabled: current_users_submission, class: "text-gray-500 dark:text-gray-300 mr-4 flex items-center #{'hint--top' unless current_users_submission}", data: { test_id: 'like-submission' }, aria: { label: 'Like submission' } do %>
-    <span class="mr-1" data-test-id="like-count"><%= project_submission.cached_votes_total %></span>
+  <%= button_to project_submission_v2_like_path(project_submission), method: http_action, disabled: current_users_submission, class: "mr-4 flex items-center #{'hint--top' unless current_users_submission}", data: { test_id: 'like-submission' }, aria: { label: 'Like submission' } do %>
+    <span class="mr-1 text-sm text-gray-500 dark:text-gray-300" data-test-id="like-count"><%= project_submission.cached_votes_total %></span>
     <%= inline_svg_tag 'icons/heart.svg', class: "h-5 w-5 #{bg_color_class}", aria: true, title: 'heart', desc: 'heart icon' %>
   <% end %>
 <% end %>

--- a/app/components/project_submissions/like_component.rb
+++ b/app/components/project_submissions/like_component.rb
@@ -14,9 +14,9 @@ module ProjectSubmissions
     end
 
     def bg_color_class
-      return 'text-teal-700' if current_users_submission || project_submission.liked?
+      return 'text-teal-700 stroke-teal-700' if current_users_submission || project_submission.liked?
 
-      ''
+      'stroke-gray-500 stroke-2 text-transparent'
     end
   end
 end


### PR DESCRIPTION
Because:
* A few tweaks to make the like component look more polished.

This commit:
* Use smaller font size for the like count
* Display like heart icon with no fill color when submission us unliked

Before:
<img width="393" alt="Screenshot 2023-07-23 at 20 58 02" src="https://github.com/TheOdinProject/theodinproject/assets/7963776/add2ea48-6b49-4d86-a7ee-a59ddc0fc65f">

After:
<img width="544" alt="Screenshot 2023-07-23 at 20 52 07" src="https://github.com/TheOdinProject/theodinproject/assets/7963776/bace8fa7-9183-4aa4-a30c-fff7a4d01c17">

