### PR TITLE
Fix: Create review app action

### DIFF
--- a/.github/workflows/heroku-review-app-on-label.yml
+++ b/.github/workflows/heroku-review-app-on-label.yml
@@ -3,9 +3,6 @@ on:
   pull_request:
     types: [labeled]
 
-permissions:
-  contents: read
-
 jobs:
   create-review-app:
     if: ${{ github.event.label.name == 'create-review-app' }}


### PR DESCRIPTION
Because:
* The permissions set within the label were conflicting with the permissions we already have on our action settings, causing the job to fail.
* See https://github.com/TheOdinProject/theodinproject/actions/runs/5641371440/job/15279321454 and https://stackoverflow.com/questions/70435286/resource-not-accessible-by-integration-on-github-post-repos-owner-repo-ac

This commit:
* Remove the permissions key from the action.
