### PR TITLE
Fix: improves a11y on images' alt attribute

### DIFF
--- a/app/components/about_page/belief_component.html.erb
+++ b/app/components/about_page/belief_component.html.erb
@@ -1,6 +1,6 @@
 <div class="sm:grid sm:grid-cols-12 sm:gap-x-6 pb-14">
   <div class="flex sm:col-span-2 justify-center ">
-    <%= image_tag @belief[:image_path], alt: @belief[:image_alt], class: 'w-20 h-20' %>
+    <%= image_tag @belief[:image_path], alt: '', class: 'w-20 h-20' %>
   </div>
 
   <div class="sm:col-span-10 text-center sm:text-left space-y-3">

--- a/app/components/course/badge_component.html.erb
+++ b/app/components/course/badge_component.html.erb
@@ -7,7 +7,7 @@
 <% else %>
   <%= link_to path_course_path(course.path, course) do %>
     <div class="shadow-md dark:shadow-none rounded-full flex <%= yass(default_badge: size) %>" data-test-id='default-badge'>
-      <%= image_tag badge, alt: "#{course.title}", class: 'p-2.5' %>
+      <%= image_tag badge, alt: course.title, class: 'p-2.5' %>
     </div>
   <% end %>
 <% end %>

--- a/app/components/course/badge_component.html.erb
+++ b/app/components/course/badge_component.html.erb
@@ -7,7 +7,7 @@
 <% else %>
   <%= link_to path_course_path(course.path, course) do %>
     <div class="shadow-md dark:shadow-none rounded-full flex <%= yass(default_badge: size) %>" data-test-id='default-badge'>
-      <%= image_tag badge, alt: "#{course.title} badge", class: 'p-2.5' %>
+      <%= image_tag badge, alt: "#{course.title}", class: 'p-2.5' %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/courses/progress/show.html.erb
+++ b/app/views/courses/progress/show.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag dom_id(@course, 'progress') do %>
   <%= render ProgressCircle::Component.new(percentage: @percentage, options: @progress_options) do |component| %>
     <%= component.with_icon do %>
-      <%= inline_svg(params.fetch(:badge_path, 'icons/odin-icon.svg'), alt: "#{@course.title} badge", class: 'bg-inherit rounded-full') %>
+      <%= inline_svg(params.fetch(:badge_path, 'icons/odin-icon.svg'), alt: "#{@course.title}", class: 'bg-inherit rounded-full') %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/courses/progress/show.html.erb
+++ b/app/views/courses/progress/show.html.erb
@@ -1,7 +1,7 @@
 <%= turbo_frame_tag dom_id(@course, 'progress') do %>
   <%= render ProgressCircle::Component.new(percentage: @percentage, options: @progress_options) do |component| %>
     <%= component.with_icon do %>
-      <%= inline_svg(params.fetch(:badge_path, 'icons/odin-icon.svg'), alt: "#{@course.title}", class: 'bg-inherit rounded-full') %>
+      <%= inline_svg(params.fetch(:badge_path, 'icons/odin-icon.svg'), alt: @course.title, class: 'bg-inherit rounded-full') %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/paths/index.html.erb
+++ b/app/views/paths/index.html.erb
@@ -9,7 +9,7 @@
         <div class=" flex justify-between items-center flex-col sm:flex-row space-y-4 sm:space-y-0">
           <div class="flex flex-col space-y-5 sm:space-x-6 sm:space-y-0 sm:flex-row items-center">
             <%= link_to path_path(@foundations), class: 'p-2 dark:bg-gray-700/50 rounded-full' do %>
-              <%= image_tag @foundations.badge_uri, alt: "#{@foundations.title}", class: 'w-24 h-24' %>
+              <%= image_tag @foundations.badge_uri, alt: @foundations.title, class: 'w-24 h-24' %>
             <% end %>
             <div class="flex items-center flex-col sm:block">
               <%= link_to path_path(@foundations), class: 'no-underline' do %>
@@ -52,7 +52,7 @@
         <%= render CardComponent.new(classes: 'flex flex-col') do |card| %>
           <% card.with_header(classes: 'flex flex-col justify-between items-center') do %>
             <%= link_to path_path(path), class: 'p-2 dark:bg-gray-700/50 rounded-full' do %>
-              <%= image_tag path.badge_uri, alt: "#{path.title}", class: 'w-24 h-24' %>
+              <%= image_tag path.badge_uri, alt: path.title, class: 'w-24 h-24' %>
             <% end %>
 
             <div class="w-full flex justify-between pt-6">

--- a/app/views/paths/index.html.erb
+++ b/app/views/paths/index.html.erb
@@ -9,7 +9,7 @@
         <div class=" flex justify-between items-center flex-col sm:flex-row space-y-4 sm:space-y-0">
           <div class="flex flex-col space-y-5 sm:space-x-6 sm:space-y-0 sm:flex-row items-center">
             <%= link_to path_path(@foundations), class: 'p-2 dark:bg-gray-700/50 rounded-full' do %>
-              <%= image_tag @foundations.badge_uri, alt: "#{@foundations.title} badge", class: 'w-24 h-24' %>
+              <%= image_tag @foundations.badge_uri, alt: "#{@foundations.title}", class: 'w-24 h-24' %>
             <% end %>
             <div class="flex items-center flex-col sm:block">
               <%= link_to path_path(@foundations), class: 'no-underline' do %>
@@ -52,7 +52,7 @@
         <%= render CardComponent.new(classes: 'flex flex-col') do |card| %>
           <% card.with_header(classes: 'flex flex-col justify-between items-center') do %>
             <%= link_to path_path(path), class: 'p-2 dark:bg-gray-700/50 rounded-full' do %>
-              <%= image_tag path.badge_uri, alt: "#{path.title} badge", class: 'w-24 h-24' %>
+              <%= image_tag path.badge_uri, alt: "#{path.title}", class: 'w-24 h-24' %>
             <% end %>
 
             <div class="w-full flex justify-between pt-6">

--- a/app/views/static_pages/home/_curriculum.html.erb
+++ b/app/views/static_pages/home/_curriculum.html.erb
@@ -8,7 +8,7 @@
           <% courses.each do |course| %>
             <%= link_to path_course_path(course.path, course),
               class: 'w-60 sm:w-56 bg-white dark:bg-gray-800 dark:border dark:border-gray-700 py-6 px-10 flex flex-col items-center text-center hover:shadow-lg m-4' do %>
-              <%= image_tag course.badge_uri, alt: "", class: 'h-20 w-20 sm:h-40 sm:w-40' %>
+              <%= image_tag course.badge_uri, alt: '', class: 'h-20 w-20 sm:h-40 sm:w-40' %>
               <h3 class="font-semibold text-xl mt-4">
                 <%= course.title %>
               </h3>

--- a/app/views/static_pages/home/_curriculum.html.erb
+++ b/app/views/static_pages/home/_curriculum.html.erb
@@ -8,7 +8,7 @@
           <% courses.each do |course| %>
             <%= link_to path_course_path(course.path, course),
               class: 'w-60 sm:w-56 bg-white dark:bg-gray-800 dark:border dark:border-gray-700 py-6 px-10 flex flex-col items-center text-center hover:shadow-lg m-4' do %>
-              <%= image_tag course.badge_uri, alt: "#{course.title.downcase} badge", class: 'h-20 w-20 sm:h-40 sm:w-40' %>
+              <%= image_tag course.badge_uri, alt: "", class: 'h-20 w-20 sm:h-40 sm:w-40' %>
               <h3 class="font-semibold text-xl mt-4">
                 <%= course.title %>
               </h3>

--- a/app/views/static_pages/home/_how_it_works.html.erb
+++ b/app/views/static_pages/home/_how_it_works.html.erb
@@ -9,7 +9,7 @@
 
       <% t('.items').each do |item| %>
         <div class="p-5 flex-1">
-          <%= image_tag item[:image], class: 'h-20 sm:h-32 md:h-40 inline', alt: 'how-it-works illustration' %>
+          <%= image_tag item[:image], class: 'h-20 sm:h-32 md:h-40 inline', alt: '' %>
           <h3 class='font-medium text-xl mt-8 mb-4'><%= item[:subtitle] %></h3>
           <div class="px-8 sm:px-16 md:px-0 dark:text-gray-400">
             <p><%= item[:description] %></p>

--- a/app/views/static_pages/home/_success_stories.html.erb
+++ b/app/views/static_pages/home/_success_stories.html.erb
@@ -8,7 +8,7 @@
       <% @success_stories.each do |story| %>
       <div class="px-6 sm:px-0 max-w-xl xl:max-w-none xl:w-1/2 flex pb-9">
         <div class="w-16 sm:w-24 text-center pt-4 sm:flex justify-center">
-          <%= image_tag "success_stories/#{story.avatar_path_name}", alt: "", class: 'w-12 h-12 rounded-full shadow-inner' %>
+          <%= image_tag "success_stories/#{story.avatar_path_name}", alt: '', class: 'w-12 h-12 rounded-full shadow-inner' %>
         </div>
 
         <div class="flex-1">

--- a/app/views/static_pages/home/_success_stories.html.erb
+++ b/app/views/static_pages/home/_success_stories.html.erb
@@ -8,7 +8,7 @@
       <% @success_stories.each do |story| %>
       <div class="px-6 sm:px-0 max-w-xl xl:max-w-none xl:w-1/2 flex pb-9">
         <div class="w-16 sm:w-24 text-center pt-4 sm:flex justify-center">
-          <%= image_tag "success_stories/#{story.avatar_path_name}", alt: "#{story.student_name}'s avatar", class: 'w-12 h-12 rounded-full shadow-inner' %>
+          <%= image_tag "success_stories/#{story.avatar_path_name}", alt: "", class: 'w-12 h-12 rounded-full shadow-inner' %>
         </div>
 
         <div class="flex-1">

--- a/app/views/static_pages/success_stories.html.erb
+++ b/app/views/static_pages/success_stories.html.erb
@@ -10,7 +10,7 @@
         <% card.with_header do %>
           <div class="flex flex-col sm:flex-row items-center space-y-2 sm:space-y-0 sm:space-x-4">
             <div class="w-20 h-20 rounded-full overflow-hidden">
-              <%= image_tag "success_stories/#{story.avatar_path_name}", alt: "", class: 'w-full shadow-inner aspect-auto' %>
+              <%= image_tag "success_stories/#{story.avatar_path_name}", alt: '', class: 'w-full shadow-inner aspect-auto' %>
             </div>
             <div class="flex flex-col text-center sm:text-left">
               <p class="font-bold"><%= link_to story.student_name, story.social_media_link, class: 'underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-200 dark:hover:text-gray-300' %></p>

--- a/app/views/static_pages/success_stories.html.erb
+++ b/app/views/static_pages/success_stories.html.erb
@@ -10,7 +10,7 @@
         <% card.with_header do %>
           <div class="flex flex-col sm:flex-row items-center space-y-2 sm:space-y-0 sm:space-x-4">
             <div class="w-20 h-20 rounded-full overflow-hidden">
-              <%= image_tag "success_stories/#{story.avatar_path_name}", alt: "#{story.student_name}'s avatar", class: 'w-full shadow-inner aspect-auto' %>
+              <%= image_tag "success_stories/#{story.avatar_path_name}", alt: "", class: 'w-full shadow-inner aspect-auto' %>
             </div>
             <div class="flex flex-col text-center sm:text-left">
               <p class="font-bold"><%= link_to story.student_name, story.social_media_link, class: 'underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-200 dark:hover:text-gray-300' %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,19 +36,15 @@ en:
         - title: A full roadmap to becoming a developer
           description: Our free, comprehensive curriculum will equip you to be a full stack developer, no matter your current experience level.
           image_path: about_page/img-education.svg
-          image_alt: book icon
         - title: Learn by doing
           description: The most effective learning happens while building projects, so we have strategically placed them throughout our curriculum. These projects will make a strong portfolio for you to showcase on your resume.
           image_path: about_page/img-build.svg
-          image_alt: keyboard icon
         - title: Receive support from others
           description: The maintainers of the curriculum run a Discord community, with the help of countless other volunteers, where you can receive help with anything in our curriculum.
           image_path: about_page/img-people.svg
-          image_alt: people icon
         - title: Open source and community driven
           description: You can deepen your understanding and improve your GitHub skills by contributing to our open source curriculum and helping others in our Discord community.
           image_path: about_page/img-opensource.svg
-          image_alt: open source icon
     contributing:
       contributing_options:
         ways_to_contribute:
@@ -73,19 +69,15 @@ en:
         - title: Flexibility
           description: You can work on your own time. It's not 9 to 5 so you can get involved when it's convenient for you.
           image_path: 'contributing/img-clock.svg'
-          image_alt: Clock
         - title: Recognition
           description: Significant Contributors will be listed on this page and on Github.
           image_path: 'contributing/img-exposure.svg'
-          image_alt: Person with Loudspeaker
         - title: Experience
           description: You'll get the chance to work within a team of experienced engineers and to work on new and interesting features that will expand your capabilities.
           image_path: 'contributing/img-job.svg'
-          image_alt: Briefcase
         - title: Impact
           description: The features you work on or the lessons you create will help thousands of students learn life changing skills.
           image_path: 'contributing/img-community.svg'
-          image_alt: Impact
       hall_of_fame:
         members:
           - name: Erik Trautman


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->

Some images like course badges, illustrative images, and user avatars have `alt` not optimized for a11z.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->

1. For **Course Badge** images, their `alt="Ruby"` is changed to its course's name since these images are inside of links.
2. Except for the **flexbox of course badges** on landing page, their `alt=""` is set to empty since their siblings are headers with course names and their parents are links. Setting `alt` to course names would result in screen readers reading duplicate names.
3. For some **illustrative images**, their `alt=""` is set to empty since they are purely decorative and images are not conveying any meaningful messages because they have texts beside them.
4. **Users' avatars** under success stories now have `alt=""` because again they are accompanied by users' names as links and the images are just photographs of these users.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #3993 

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behavior
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If applicable, this PR includes new or updated automated tests
