### PR TITLE
Fix: Resolves Lesson Preview share bug on Safari.

### DIFF
--- a/app/javascript/components/lesson-preview/components/share-button.jsx
+++ b/app/javascript/components/lesson-preview/components/share-button.jsx
@@ -11,10 +11,40 @@ const ShareButton = ({ content }) => {
     }
   }, [content]);
 
-  const handleOnClick = async () => {
+  /**
+   * Helper method to get the name of the browser we are using. The conditional tree's
+   * order matters since some UserAgent strings are included in the same browsers.
+   * 
+   * The reason we care about the specific browser is because the Clipboard
+   * API's implementation across browser's is inconsistent. For example, ClipboardItem
+   * is not available on Firefox. Chrome will complain about the MIME type.
+   * @returns A string of a relevant browser name, or undefined.
+   */
+  const getBrowserName = () => {
+    if(navigator.userAgent.indexOf("Firefox") !== -1)
+      return "Firefox";
+    else if(navigator.userAgent.indexOf("Chrome") !== -1)
+      return "Chrome";
+    else if(navigator.userAgent.indexOf("Safari") !== -1)
+      return "Safari";
+    
+    return undefined;   
+}
+
+  const getPreviewLink = async () => {
     const response = await axios.post('/lessons/preview', { content });
-    const previewLink = response.data.preview_link;
-    navigator.clipboard.writeText(previewLink).then(() => setCopied(true));
+    return response.data.preview_link;
+  }
+
+  const handleOnClick = async () => {
+    const browserName = getBrowserName();
+    
+    if (browserName === 'Safari') {
+      navigator.clipboard.write([new ClipboardItem({ "text/plain": getPreviewLink() })])
+        .then(() => setCopied(true));
+    } else {
+      navigator.clipboard.writeText(await getPreviewLink()).then(() => setCopied(true));
+    }
   };
 
   return (


### PR DESCRIPTION
## Because
This PR resolves the bug that @ManonLef reported with sharing lesson previews. The issue lives [here](https://github.com/TheOdinProject/theodinproject/issues/4014).

The Clipboard's API's usage across browser's is very inconsistent, which led to some of the changes in this PR.

## This PR
- Adds a method to detect the browser in the Share Button component.
- Uses this method to determine how to write the preview link to the clipboard.
- If the browser is Safari, the ClipboardItem object is used.
- If the browser is anything else, the existing clipboard logic fires.

## Issue
Closes #4014 

## Additional Information
I'm not in love with having to detect the Browser the way I did, but felt this was the simplest solution for now. I found no documentation on using browser features as a more-sturdy approach.

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
