### PR TITLE
Chore: Renames has_live_preview column to previewable.

### DIFF
--- a/app/components/project_submissions/item_component.html.erb
+++ b/app/components/project_submissions/item_component.html.erb
@@ -9,7 +9,7 @@
     <div class="flex flex-row md:items-center">
       <%= link_to 'View code', project_submission.repo_url, target: '_blank', rel: 'noreferrer', class: 'button button--gray font-semibold mr-4', data: { test_id: 'view-code-btn' } %>
 
-      <% if project_submission.lesson.has_live_preview? %>
+      <% if project_submission.lesson.previewable? %>
         <%= link_to 'Live preview', project_submission.live_preview_url, target: '_blank', rel: 'noreferrer', class: 'button button--gray font-semibold mr-4', data: { test_id: 'live-preview-btn' } %>
       <% end %>
 

--- a/app/models/project_submission.rb
+++ b/app/models/project_submission.rb
@@ -41,7 +41,7 @@ class ProjectSubmission < ApplicationRecord
   def live_preview_allowed
     return if live_preview_url.blank?
 
-    unless lesson && lesson.has_live_preview?
+    unless lesson && lesson.previewable?
       errors.add(:live_preview_url, 'Live preview is not allowed for this project')
     end
   end

--- a/app/views/project_submissions/_form.html.erb
+++ b/app/views/project_submissions/_form.html.erb
@@ -9,7 +9,7 @@
           <% end %>
         </div>
 
-        <% if project_submission.lesson.has_live_preview? %>
+        <% if project_submission.lesson.previewable? %>
           <div>
             <%= form.label :live_preview_url, 'Live preview (optional)' %>
             <%= form.text_field :live_preview_url, leading_icon: true, placeholder: 'http://example.com', class: 'text-sm', data: { test_id: 'live-preview-url-field' } do %>

--- a/db/fixtures/lessons/database_lessons.rb
+++ b/db/fixtures/lessons/database_lessons.rb
@@ -20,7 +20,7 @@ def database_lessons
       is_project: true,
       github_path: '/databases/databases/project_sql_zoo.md',
       accepts_submission: true,
-      has_live_preview: false,
+      previewable: false,
       identifier_uuid: 'a4baeee4-7bab-47ba-8157-c8f52b204734',
     },
   }

--- a/db/fixtures/lessons/foundation_lessons.rb
+++ b/db/fixtures/lessons/foundation_lessons.rb
@@ -129,7 +129,7 @@ def foundation_lessons
       is_project: true,
       github_path: '/foundations/javascript_basics/project_rock_paper_scissors.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: '5cc2b83d-8024-4e07-82a0-38687b75c300',
     },
     'Clean Code' => {
@@ -152,7 +152,7 @@ def foundation_lessons
       is_project: true,
       github_path: '/foundations/javascript_basics/project_etch_a_sketch.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: 'fa9a5eea-a42c-4f89-9d53-6e1b8634d6ff',
     },
     'Fundamentals Part 5' => {
@@ -168,7 +168,7 @@ def foundation_lessons
       is_project: true,
       github_path: '/foundations/javascript_basics/project_calculator.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: '2aa09e04-cbfa-4b48-97a6-140a760eda08',
     },
     'Introduction to the Back End' => {
@@ -242,7 +242,7 @@ def foundation_lessons
       github_path: '/foundations/html_css/html-foundations/project-recipes.md',
       identifier_uuid: '3c8ad955-4f4e-4555-86bc-98503e1b785d',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
     },
     'Intro to CSS' => {
       title: 'Intro to CSS',
@@ -311,7 +311,7 @@ def foundation_lessons
       is_project: true,
       github_path: '/foundations/html_css/flexbox/project-landing-page.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: '22e0c585-c146-4dab-9dc0-17a20f0ecbc5',
     },
     'DOM Manipulation and Events' => {

--- a/db/fixtures/lessons/getting_hired_lessons.rb
+++ b/db/fixtures/lessons/getting_hired_lessons.rb
@@ -41,7 +41,7 @@ def getting_hired_lessons
       is_project: true,
       github_path: '/getting_hired/preparing_for_job_search/project_portfolio.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: '9e9f98a7-43bc-4e2b-9325-f858319604d5',
     },
     'Collecting Job Leads' => {
@@ -64,7 +64,7 @@ def getting_hired_lessons
       is_project: true,
       github_path: '/getting_hired/applying_and_interviewing/project_resume.md',
       accepts_submission: false,
-      has_live_preview: false,
+      previewable: false,
       identifier_uuid: '029f508f-8034-41b2-b330-bba88f0efe3b',
     },
     'Applying for Web Development Jobs' => {

--- a/db/fixtures/lessons/html_and_css_lessons.rb
+++ b/db/fixtures/lessons/html_and_css_lessons.rb
@@ -199,7 +199,7 @@ def html_and_css_lessons
       description: 'Learn about how browsers style your HTML.',
       is_project: true,
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       github_path: '/intermediate_html_css/forms/project_sign_up_form.md',
       identifier_uuid: '91ab41f2-9c9d-449a-8461-329a5f7ecb1e'
     },
@@ -244,7 +244,7 @@ def html_and_css_lessons
       description: "Use what you've learned to Complete this project",
       is_project: true,
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       github_path: '/intermediate_html_css/grid/project_admin_dashboard.md',
       identifier_uuid: 'c35f0b7b-4d21-4d26-91e2-4af78519ae5f'
     },
@@ -282,7 +282,7 @@ def html_and_css_lessons
       description: 'Create a fully responsive personal portfolio.',
       is_project: true,
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       github_path: '/advanced_html_css/responsive_design/project_personal_portfolio.md',
       identifier_uuid: 'd99b0c9d-cc6c-44e6-bab0-1c9a83edcfa3'
     },

--- a/db/fixtures/lessons/javascript_lessons.rb
+++ b/db/fixtures/lessons/javascript_lessons.rb
@@ -34,7 +34,7 @@ def javascript_lessons
       is_project: true,
       github_path: '/javascript/organizing_your_javascript_code/project_library.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: '67338e32-0121-44bd-98c2-2f8e6b299adf',
     },
     'Factory Functions and the Module Pattern' => {
@@ -50,7 +50,7 @@ def javascript_lessons
       is_project: true,
       github_path: '/javascript/organizing_your_javascript_code/project_tic_tac_toe.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: '47798979-cdc8-4c86-a70d-05ffb51d5aac',
     },
     'Classes' => {
@@ -80,7 +80,7 @@ def javascript_lessons
       is_project: true,
       github_path: '/javascript/organizing_your_javascript_code/project_restaurant_page.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: 'a1453e8f-d4e8-44ce-b30e-552c65162ac6',
     },
     'OOP Principles' => {
@@ -96,7 +96,7 @@ def javascript_lessons
       is_project: true,
       github_path: '/javascript/organizing_your_javascript_code/project_todo_list.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: '5934b09a-ca38-4968-8df1-720456b7af9a',
     },
     'Linting' => {
@@ -161,7 +161,7 @@ def javascript_lessons
       is_project: true,
       github_path: '/javascript/asynchronous_javascript_and_apis/project_weather_app.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: '5212a020-85ed-4e43-84ec-6b583b57e8cb',
     },
     'A Very Brief Intro to CS' => {
@@ -184,7 +184,7 @@ def javascript_lessons
       is_project: true,
       github_path: '/javascript/computer_science/project_recursion.md',
       accepts_submission: true,
-      has_live_preview: false,
+      previewable: false,
       identifier_uuid: 'eaf37749-a971-4bd4-af79-6e166e55346a',
     },
     'Time Complexity' => {
@@ -214,7 +214,7 @@ def javascript_lessons
       is_project: true,
       github_path: '/javascript/computer_science/project_linked_lists.md',
       accepts_submission: true,
-      has_live_preview: false,
+      previewable: false,
       identifier_uuid: 'd2c7044f-8a4a-4740-a455-e6467bcea25d',
     },
     'Binary Search Trees' => {
@@ -223,7 +223,7 @@ def javascript_lessons
       is_project: true,
       github_path: '/javascript/computer_science/project_binary_search_trees.md',
       accepts_submission: true,
-      has_live_preview: false,
+      previewable: false,
       identifier_uuid: '6932753f-ca06-458e-af92-1871eaf5e211',
     },
     'Knights Travails' => {
@@ -232,7 +232,7 @@ def javascript_lessons
       is_project: true,
       github_path: '/javascript/computer_science/project_knights_travails.md',
       accepts_submission: true,
-      has_live_preview: false,
+      previewable: false,
       identifier_uuid: 'd4c45487-98b8-4da6-8159-b75f7681b994',
     },
     'Testing Basics' => {
@@ -248,7 +248,7 @@ def javascript_lessons
       is_project: true,
       github_path: '/javascript/testing_javascript/project_testing_practice.md',
       accepts_submission: true,
-      has_live_preview: false,
+      previewable: false,
       identifier_uuid: '319ce38c-f68b-4bba-b9f7-25df452f0523',
     },
     'More Testing' => {
@@ -264,7 +264,7 @@ def javascript_lessons
       is_project: true,
       github_path: '/javascript/testing_javascript/project_battleship.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: '62702165-7705-47ba-a308-dd39c561e057',
     },
     "Where's Waldo (A Photo Tagging App) (OLD)" => {
@@ -273,7 +273,7 @@ def javascript_lessons
       is_project: true,
       github_path: '/javascript/javascript_and_the_backend/project_wheres_waldo_a_photo_tagging_app.md',
       accepts_submission: false,
-      has_live_preview: false,
+      previewable: false,
       identifier_uuid: '386dd44a-31dc-45dc-a535-cd5508365c86',
     },
     'Conclusion' => {

--- a/db/fixtures/lessons/node_js_lessons.rb
+++ b/db/fixtures/lessons/node_js_lessons.rb
@@ -27,7 +27,7 @@ def node_js_lessons
       is_project: true,
       github_path: '/nodeJS/introduction_to_nodeJS/project_basic_informational_site.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: 'de746d83-dcce-48f0-a0ba-72d117d0ac05',
     },
     'Introduction to MongoDB' => {
@@ -64,7 +64,7 @@ def node_js_lessons
       is_project: true,
       github_path: '/nodeJS/express_and_mongoose/project_mini_message_board.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: '0270683a-d1e1-49f1-996e-ab721c251354',
     },
     'Deployment' => {
@@ -94,7 +94,7 @@ def node_js_lessons
       is_project: true,
       github_path: '/nodeJS/express_and_mongoose/project_express_105_forms_and_deployment.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: 'de07c671-e8c7-47c0-88fe-219b66308bd4',
     },
     'Inventory Application' => {
@@ -103,7 +103,7 @@ def node_js_lessons
       is_project: true,
       github_path: '/nodeJS/express_and_mongoose/project_inventory_application.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: '5b7bcdb8-38d5-46ea-846b-c12bfb0290ef',
     },
     'Authentication Basics' => {
@@ -126,7 +126,7 @@ def node_js_lessons
       is_project: true,
       github_path: '/nodeJS/authentication/project_members_only.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: 'dc36f70d-cc3b-47c5-958f-0c09ca61ca78',
     },
     'API Basics' => {
@@ -149,7 +149,7 @@ def node_js_lessons
       is_project: true,
       github_path: '/nodeJS/apis/project_blog_api.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: 'ad8a46e7-a42b-420b-804d-afafb0c60d2c',
     },
     'Testing Routes and Controllers' => {
@@ -172,7 +172,7 @@ def node_js_lessons
       is_project: true,
       github_path: '/nodeJS/final_project/project_odin_book.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: 'c0d6ba51-620e-49e0-8583-924f38754874',
     },
     'Conclusion' => {

--- a/db/fixtures/lessons/react_lessons.rb
+++ b/db/fixtures/lessons/react_lessons.rb
@@ -76,7 +76,7 @@ def react_lessons
       is_project: true,
       github_path: '/react/states_and_effects/project_cv_application.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: 'f3b5cee3-a255-4c72-8022-942cbddf0b86',
     },
     'How To Deal With Side Effects' => {
@@ -92,7 +92,7 @@ def react_lessons
       is_project: true,
       github_path: '/react/states_and_effects/project_memory_card.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: '87bbed05-daf2-4c45-a549-fc9ecfa2657c',
     },
     'Class Based Components' => {
@@ -157,7 +157,7 @@ def react_lessons
       is_project: true,
       github_path: '/react/the_react_ecosystem/project_shopping_cart.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: '60bb8597-19db-4d6f-9eca-059743206de5',
     },
     'Managing State With The Context API' => {
@@ -201,7 +201,7 @@ def react_lessons
       is_project: true,
       github_path: '/react/react_and_the_backend/project_wheres_waldo_a_photo_tagging_app.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: '386dd44a-31dc-45dc-a535-cd5508365c86',
     },
     'Messaging App' => {
@@ -210,7 +210,7 @@ def react_lessons
       is_project: true,
       github_path: '/react/react_and_the_backend/project_messaging_app.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: '8e0206b5-e189-4ec3-b58b-c7f0afb84570',
     },
     'Conclusion' => {

--- a/db/fixtures/lessons/ruby_lessons.rb
+++ b/db/fixtures/lessons/ruby_lessons.rb
@@ -98,7 +98,7 @@ def ruby_lessons
       is_project: true,
       github_path: '/ruby/basic_ruby_projects/project_caesar_cipher.md',
       accepts_submission: true,
-      has_live_preview: false,
+      previewable: false,
       identifier_uuid: '47e7c8ab-0dc8-4d6b-bc23-d9674b174007',
     },
     'Sub Strings' => {
@@ -107,7 +107,7 @@ def ruby_lessons
       is_project: true,
       github_path: '/ruby/basic_ruby_projects/project_sub_strings.md',
       accepts_submission: true,
-      has_live_preview: false,
+      previewable: false,
       identifier_uuid: '9445341e-1907-4269-b866-446a3a08d3b9',
     },
     'Stock Picker' => {
@@ -116,7 +116,7 @@ def ruby_lessons
       is_project: true,
       github_path: '/ruby/basic_ruby_projects/project_stock_picker.md',
       accepts_submission: true,
-      has_live_preview: false,
+      previewable: false,
       identifier_uuid: '89096a08-7abf-481b-9464-a82a65872e8e',
     },
     'Bubble Sort' => {
@@ -125,7 +125,7 @@ def ruby_lessons
       is_project: true,
       github_path: '/ruby/basic_ruby_projects/project_bubble_sort.md',
       accepts_submission: true,
-      has_live_preview: false,
+      previewable: false,
       identifier_uuid: '5b332db6-e7f7-4232-9531-a35096d61c81',
     },
     'Object Oriented Programming' => {
@@ -141,7 +141,7 @@ def ruby_lessons
       is_project: true,
       github_path: '/ruby/object_oriented_programming_basics/project_tic_tac_toe.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: '49bd96f3-f358-46f2-8e2a-c91d44c2cf85',
     },
     'Mastermind' => {
@@ -150,7 +150,7 @@ def ruby_lessons
       is_project: true,
       github_path: '/ruby/object_oriented_programming_basics/project_mastermind.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: '0333fa64-534c-4b31-9a3e-8c89d84f7618',
     },
     'Files and Serialization' => {
@@ -166,7 +166,7 @@ def ruby_lessons
       is_project: true,
       github_path: '/ruby/files_and_serialization/project_event_manager.md',
       accepts_submission: true,
-      has_live_preview: false,
+      previewable: false,
       identifier_uuid: 'a47be9ab-7c78-44c2-b098-ec63d82af1cf',
     },
     'Hangman' => {
@@ -175,7 +175,7 @@ def ruby_lessons
       is_project: true,
       github_path: '/ruby/files_and_serialization/project_hangman.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: '8a5dda78-b387-4a4e-b2af-aed0561ed633',
     },
     'Blocks' => {
@@ -212,7 +212,7 @@ def ruby_lessons
       is_project: true,
       github_path: '/ruby/computer_science/project_recursion.md',
       accepts_submission: true,
-      has_live_preview: false,
+      previewable: false,
       identifier_uuid: '062acc7a-b1b0-4c9d-a7e8-e08bae7a9c0d',
     },
     'Time Complexity' => {
@@ -242,7 +242,7 @@ def ruby_lessons
       is_project: true,
       github_path: '/ruby/computer_science/project_linked_lists.md',
       accepts_submission: true,
-      has_live_preview: false,
+      previewable: false,
       identifier_uuid: '93a87bae-96c3-47af-a106-62ded20f12c3',
     },
     'Binary Search Trees' => {
@@ -251,7 +251,7 @@ def ruby_lessons
       is_project: true,
       github_path: '/ruby/computer_science/project_binary_search_trees.md',
       accepts_submission: true,
-      has_live_preview: false,
+      previewable: false,
       identifier_uuid: '00c3096f-0ab0-49e2-9eef-54afc9182f80',
     },
     'Knights Travails' => {
@@ -260,7 +260,7 @@ def ruby_lessons
       is_project: true,
       github_path: '/ruby/computer_science/project_knights_travails.md',
       accepts_submission: true,
-      has_live_preview: false,
+      previewable: false,
       identifier_uuid: 'fb6c9850-7fc6-4cdb-bf62-804e706788de',
     },
     'Test Driven Development' => {
@@ -283,7 +283,7 @@ def ruby_lessons
       is_project: true,
       github_path: '/ruby/testing_ruby_with_rspec/project_connect_four.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: '33440cca-8fbf-46fe-9265-67d938fe1d8c',
     },
     'Ruby Final Project' => {
@@ -292,7 +292,7 @@ def ruby_lessons
       is_project: true,
       github_path: '/ruby/conclusion/project_ruby_final.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: 'acf6c3f1-915a-4878-8224-2c5f12b1e43b',
     },
     'Conclusion' => {
@@ -315,7 +315,7 @@ def ruby_lessons
       is_project: true,
       github_path: '/ruby/advanced_ruby/project_custom_enumerables.md',
       accepts_submission: true,
-      has_live_preview: false,
+      previewable: false,
       identifier_uuid: 'cea1b51e-b97e-11eb-8529-0242ac130003',
     },
   }

--- a/db/fixtures/lessons/ruby_on_rails_lessons.rb
+++ b/db/fixtures/lessons/ruby_on_rails_lessons.rb
@@ -13,7 +13,7 @@ def ruby_on_rails_lessons
       is_project: true,
       github_path: '/ruby_on_rails/introduction/project_installing_rails.md',
       accepts_submission: false,
-      has_live_preview: false,
+      previewable: false,
       identifier_uuid: '9dbd5caa-a77d-4731-8897-542aae2984e3',
       installation_lesson: true,
     },
@@ -58,7 +58,7 @@ def ruby_on_rails_lessons
       is_project: true,
       github_path: '/ruby_on_rails/rails_basics/project_blog_app.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: '00167c46-3d50-410f-947a-729571744920'
     },
     'Active Record Basics' => {
@@ -74,7 +74,7 @@ def ruby_on_rails_lessons
       is_project: true,
       github_path: '/ruby_on_rails/active_record_basics/project_micro_reddit.md',
       accepts_submission: true,
-      has_live_preview: false,
+      previewable: false,
       identifier_uuid: 'f46373db-e4e2-4aec-866e-b0123fc7928e',
     },
     'The Asset Pipeline' => {
@@ -111,7 +111,7 @@ def ruby_on_rails_lessons
       is_project: true,
       github_path: '/ruby_on_rails/forms_and_authentication/project_forms.md',
       accepts_submission: true,
-      has_live_preview: false,
+      previewable: false,
       identifier_uuid: '3f3fa50c-9223-4178-b86a-6b50caf30896',
     },
     'Sessions, Cookies and Authentication' => {
@@ -127,7 +127,7 @@ def ruby_on_rails_lessons
       is_project: true,
       github_path: '/ruby_on_rails/forms_and_authentication/project_members_only.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: '038fc7b2-11df-4d95-9cc9-f6006e51ec2d',
     },
     'Active Record Queries' => {
@@ -150,7 +150,7 @@ def ruby_on_rails_lessons
       is_project: true,
       github_path: '/ruby_on_rails/advanced_forms_and_activerecord/project_private_events.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: '54233186-d525-4647-a001-91049353ecec',
     },
     'Active Record Callbacks' => {
@@ -173,7 +173,7 @@ def ruby_on_rails_lessons
       is_project: true,
       github_path: '/ruby_on_rails/advanced_forms_and_activerecord/project_flight_booker.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: '52cb7814-24f0-450a-9bf2-39cde4a680da',
     },
     'APIs and Building Your Own' => {
@@ -196,7 +196,7 @@ def ruby_on_rails_lessons
       is_project: true,
       github_path: '/ruby_on_rails/apis/project_kittens_api.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: '5d0433d7-f3f3-46fa-99e7-3bc5893a2599'
     },
     'Flickr API' => {
@@ -205,7 +205,7 @@ def ruby_on_rails_lessons
       is_project: true,
       github_path: '/ruby_on_rails/apis/project_flickr_api.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: '2adcd199-34b4-47e0-875c-0df9ecd61ea9',
     },
     'CSS Bundling' => {
@@ -249,7 +249,7 @@ def ruby_on_rails_lessons
       is_project: true,
       github_path: '/ruby_on_rails/mailers_advanced_topics/project_sending_confirmation_emails.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: 'bd6d78b4-cefd-4938-8818-5adfe5620c2b'
     },
     'Advanced Topics' => {
@@ -272,7 +272,7 @@ def ruby_on_rails_lessons
       is_project: true,
       github_path: '/ruby_on_rails/mailers_advanced_topics/project_final.md',
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
       identifier_uuid: '3eac603e-c8e7-4ba8-ade0-87c4e3c3de59',
     },
     'Conclusion' => {

--- a/db/migrate/20230728225009_rename_lessons_has_preview_column_name.rb
+++ b/db/migrate/20230728225009_rename_lessons_has_preview_column_name.rb
@@ -1,0 +1,5 @@
+class RenameLessonsHasPreviewColumnName < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :lessons, :has_live_preview, :previewable
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_27_165350) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_28_230910) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -137,7 +137,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_27_165350) do
     t.datetime "updated_at", precision: nil, null: false
     t.string "slug"
     t.boolean "accepts_submission", default: false, null: false
-    t.boolean "has_live_preview", default: false, null: false
+    t.boolean "previewable", default: false, null: false
     t.boolean "choose_path_lesson", default: false, null: false
     t.string "identifier_uuid", default: "", null: false
     t.bigint "course_id"

--- a/lib/seeds/lesson_builder.rb
+++ b/lib/seeds/lesson_builder.rb
@@ -20,7 +20,7 @@ module Seeds
         lesson.section_id = section.id
         lesson.is_project = attributes.fetch(:is_project, false)
         lesson.accepts_submission = attributes.fetch(:accepts_submission, false)
-        lesson.has_live_preview = attributes.fetch(:has_live_preview, false)
+        lesson.previewable = attributes.fetch(:previewable, false)
         lesson.position = position
         lesson.course_id = section.course_id
         lesson.choose_path_lesson = attributes.fetch(:choose_path_lesson, false)

--- a/spec/factories/lessons.rb
+++ b/spec/factories/lessons.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
     trait :project do
       is_project { true }
       accepts_submission { true }
-      has_live_preview { true }
+      previewable { true }
     end
 
     trait :complete do

--- a/spec/factories/project_submissions.rb
+++ b/spec/factories/project_submissions.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
     live_preview_url { 'http://mysite.com' }
     user
     discard_at { nil }
-    lesson { association :lesson, has_live_preview: true }
+    lesson { association :lesson, previewable: true }
   end
 end

--- a/spec/lib/seeds/lesson_builder_spec.rb
+++ b/spec/lib/seeds/lesson_builder_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Seeds::LessonBuilder do
       github_path: '/github/lesson_path',
       is_project: true,
       accepts_submission: true,
-      has_live_preview: true,
+      previewable: true,
     }
   end
 
@@ -59,11 +59,11 @@ RSpec.describe Seeds::LessonBuilder do
       expect(lesson.accepts_submission).to be(true)
     end
 
-    it 'builds a lesson with a true has_live_preview attribute' do
+    it 'builds a lesson with a true previewable attribute' do
       lesson_builder
 
       lesson = Lesson.find_by(identifier_uuid: 'lesson_uuid')
-      expect(lesson.has_live_preview).to be(true)
+      expect(lesson.previewable).to be(true)
     end
 
     context 'when optional attributes are not present' do
@@ -90,11 +90,11 @@ RSpec.describe Seeds::LessonBuilder do
         expect(lesson.accepts_submission).to be(false)
       end
 
-      it 'builds a lesson with a false has_live_preview attribute' do
+      it 'builds a lesson with a false previewable attribute' do
         lesson_builder
 
         lesson = Lesson.find_by(identifier_uuid: 'lesson_uuid')
-        expect(lesson.has_live_preview).to be(false)
+        expect(lesson.previewable).to be(false)
       end
     end
 

--- a/spec/models/project_submission_spec.rb
+++ b/spec/models/project_submission_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ProjectSubmission do
 
   context 'when live preview is not allowed' do
     subject(:project_submission) do
-      build(:project_submission, lesson: create(:lesson, has_live_preview: false))
+      build(:project_submission, lesson: create(:lesson, previewable: false))
     end
 
     it do

--- a/spec/queries/lesson_project_submissions_query_spec.rb
+++ b/spec/queries/lesson_project_submissions_query_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe LessonProjectSubmissionsQuery do
   subject(:query) { described_class.new(lesson:, current_user:, limit:) }
 
-  let(:lesson) { create(:lesson, has_live_preview: true) }
+  let(:lesson) { create(:lesson, previewable: true) }
   let(:current_user) { create(:user) }
   let(:limit) { nil }
 

--- a/spec/services/messages/dead_link_spec.rb
+++ b/spec/services/messages/dead_link_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Messages::DeadLink do
     )
   end
 
-  let(:lesson) { create(:lesson, title: 'test lesson1', has_live_preview: true) }
+  let(:lesson) { create(:lesson, title: 'test lesson1', previewable: true) }
   let(:user) { create(:user, username: 'testuser1') }
 
   describe '#title' do

--- a/spec/support/pages/project_submissions/form.rb
+++ b/spec/support/pages/project_submissions/form.rb
@@ -6,7 +6,7 @@ module Pages
 
       option :repo_url, default: -> { 'https://github.com/myname/my-project' }
       option :live_preview_url, default: -> { 'https://myprojectlivepreview.com' }
-      option :has_live_preview, default: -> { true }
+      option :previewable, default: -> { true }
 
       def self.fill_in_and_submit(**args)
         new(**args)
@@ -23,7 +23,7 @@ module Pages
 
       def fill_in
         find(:test_id, 'repo-url-field').fill_in(with: @repo_url)
-        find(:test_id, 'live-preview-url-field').fill_in(with: @live_preview_url) if @has_live_preview
+        find(:test_id, 'live-preview-url-field').fill_in(with: @live_preview_url) if @previewable
         self
       end
 

--- a/spec/system/admin/flags_spec.rb
+++ b/spec/system/admin/flags_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Admin Flags' do
   let!(:flag) { create(:flag, project_submission:) }
   let(:user) { create(:user, admin: true) }
   let(:project_submission) { create(:project_submission, lesson:, user: submission_owner) }
-  let(:lesson) { create(:lesson, is_project: true, accepts_submission: true, has_live_preview: true) }
+  let(:lesson) { create(:lesson, is_project: true, accepts_submission: true, previewable: true) }
   let(:submission_owner) { create(:user, username: 'Simon Bell', email: 'simon@example.com', password: 'pa55word') }
 
   before do

--- a/spec/system/lesson_project_submissions/add_submission_spec.rb
+++ b/spec/system/lesson_project_submissions/add_submission_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'Add a Project Submission' do
   end
 
   context 'when lesson does not allow previews' do
-    let(:lesson) { create(:lesson, :project, has_live_preview: false) }
+    let(:lesson) { create(:lesson, :project, previewable: false) }
     let(:user) { create(:user) }
 
     before do
@@ -57,7 +57,7 @@ RSpec.describe 'Add a Project Submission' do
 
     it 'adds the submission without a preview' do
       Pages::ProjectSubmissions::Form
-        .new(has_live_preview: false)
+        .new(previewable: false)
         .open
         .fill_in
         .submit

--- a/spec/system/user_notification_spec.rb
+++ b/spec/system/user_notification_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'User Notifications' do
   let!(:flag) { create(:flag, project_submission:) }
   let(:project_submission) { create(:project_submission, lesson:, user: submission_owner) }
-  let(:lesson) { create(:lesson, is_project: true, accepts_submission: true, has_live_preview: true) }
+  let(:lesson) { create(:lesson, is_project: true, accepts_submission: true, previewable: true) }
   let(:submission_owner) { create(:user, username: 'Simon Bell', email: 'simon@example.com', password: 'pa55word') }
   let(:admin) { create(:user, admin: true) }
 


### PR DESCRIPTION
## Because
The new column name is Railsyer.


## This PR
- Adds a migration to rename lesson.has_live_preview to lesson.previewable
- Changes all instances of has_live_preview to be previewable in the codebase.


## Issue
Closes #4003 

## Additional Information
As a matter of clarification, the task assumed the has_live_preview column was in the project_submissions table. It was actually on the lessons table.


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behavior
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
