### PR TITLE
remove opencollective iframe from support page

### DIFF
--- a/app/javascript/stylesheets/static-pages.css
+++ b/app/javascript/stylesheets/static-pages.css
@@ -1,6 +1,5 @@
 /* Support Us page, custom CSS */
 #support-us iframe {
-  height: 100%;
   max-width: 100%;
 }
 

--- a/app/views/static_pages/support_us.html.erb
+++ b/app/views/static_pages/support_us.html.erb
@@ -17,9 +17,7 @@
     <div class="mt-8 text-center">
       <%= link_to 'Donate now!', 'https://opencollective.com/theodinproject/donate?amount=5', class: 'button button--primary text-base px-12 py-4', target: '_blank' %>
     </div>
-    <div class="mt-8 flex">
-      <script src='https://opencollective.com/theodinproject/banner.js?style={"h2":{"color":"rgb(112, 112, 128)"}}'></script>
-    </div>
+    <%# <script src='https://opencollective.com/theodinproject/banner.js?style={"h2":{"color":"rgb(112, 112, 128)"}}'></script> %>
   </section>
 
   <section class='bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400'>


### PR DESCRIPTION
the OC widget is broken and looks bad on our homepage.

I asked for help in the OC slack channel, but couldn't resolve it, so for now let's just remove it.

If i find a solution that makes it look right, we can put it back.
