### PR TITLE
Fix: update lesson-note--variations styles a11y

### DIFF
--- a/app/javascript/stylesheets/lesson-content.css
+++ b/app/javascript/stylesheets/lesson-content.css
@@ -24,33 +24,61 @@
   }
 
   .lesson-note {
-    @apply bg-gray-50 p-4 border-l-4 border-gold dark:bg-gray-700/40 dark:border-gold-700 rounded;
+    @apply bg-gray-50 p-4 my-4 border-l-4 border-gold dark:bg-gray-700/40 dark:border-gold-600 rounded;
   }
 
-  .lesson-note > h4::before {
+  .lesson-note > *:first-child::before {
     font-family: "Font Awesome 6 Free";
     content: "\f249";
-    @apply mr-2 text-gold dark:text-gold-700;
+    @apply mr-2 text-gold dark:text-gold-600 font-bold;
+  }
+
+  .lesson-note > *:only-child::before {
+    font-family: "Font Awesome 6 Free";
+    content: "\f249";
+    @apply mr-2 -mt-2 text-gold dark:text-gold-600 block font-bold text-2xl;
   }
 
   .lesson-note--tip {
-    @apply border-green-600 dark:border-green-700;
+    @apply border-blue-600 dark:border-blue-500;
   }
 
-  .lesson-note--tip > h4::before {
-    font-family: "Font Awesome 6 Free";
+  .lesson-note--tip > *:first-child::before {
     content: "\f0eb";
-    @apply mr-2 text-green-600 dark:text-green-700;
+    @apply text-blue-600 dark:text-blue-500;
+  }
+
+  .lesson-note--tip > *:only-child::before {
+    content: "\f0eb";
+    @apply text-blue-600 dark:text-blue-500;
   }
 
   .lesson-note--warning {
-    @apply border-red-700 dark:border-red-500;
+    @apply border-orange-500 dark:border-orange-400;
   }
 
-  .lesson-note--warning > h4::before {
-    font-family: "Font Awesome 6 Free";
+  .lesson-note--warning > *:first-child::before {
+    content: "\f071";
+    @apply text-orange-500 dark:text-orange-400;
+  }
+
+  .lesson-note--warning > *:only-child::before {
+    content: "\f071";
+    @apply text-orange-500 dark:text-orange-400;
+  }
+
+  .lesson-note--critical {
+    @apply border-red-600 dark:border-red-500;
+  }
+
+  .lesson-note--critical > *:first-child::before {
     content: "\f06a";
-    @apply mr-2 text-red-700 dark:text-red-500;
+    @apply text-red-600 dark:text-red-500;
+  }
+
+  .lesson-note--critical > *:only-child::before {
+    content: "\f06a";
+    @apply text-red-600 dark:text-red-500;
   }
 
   .lesson-note > *:first-child {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,6 +14,7 @@ module.exports = {
     'lesson-note',
     'lesson-note--tip',
     'lesson-note--warning',
+    'lesson-note--critical',
     'lesson-content__panel',
     'anchor-link',
     'toc-item-active'


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->

Current `lesson-note--warning` and `lesson-note--tip` etc has colours and icons not meeting good a11y standards.


## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->

- `lesson-note` div now has vertical margins with `my-4`.
- `lesson-note--tip`'s colour is now **blue**
- `lesson-note--warning` now has **orange** colour instead of red, and uses a warning icon
- `lesson-note--critical` variation is added, with colour of **red**, and uses a critical icon
- All of lesson-note sections now will render an icon **in front of the first descendent** element (assuming `h1-h6`) with the appropriate font-size. 
- Otherwise if the section **only has one descendent** (assuming only `p`), the icon will be rendered at the top left corner, with an enlarged `font-size: 1.8rem`

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #4045 

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behavior
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If applicable, this PR includes new or updated automated tests
