### PR TITLE
Feature: Reduce kdb padding

### DIFF
--- a/app/javascript/stylesheets/lesson-content.css
+++ b/app/javascript/stylesheets/lesson-content.css
@@ -16,7 +16,7 @@
   }
 
   .lesson-content kbd {
-    @apply px-2 py-1.5 text-xs font-semibold text-gray-800 bg-gray-100 border border-gray-200 rounded-lg dark:bg-gray-600 dark:text-gray-100 dark:border-gray-500;
+    @apply px-1.5 py-1 text-xs font-semibold text-gray-800 bg-gray-100 border border-gray-200 rounded-md dark:bg-gray-600 dark:text-gray-100 dark:border-gray-500;
   }
 
   .lesson-content__panel {


### PR DESCRIPTION
Because:
* We recently changed to a smaller base font size for lesson content and the kbd padding needs tweaked to fit in.

Before
<img width="662" alt="Screenshot 2023-08-04 at 20 18 54" src="https://github.com/TheOdinProject/theodinproject/assets/7963776/430bb4b0-67fe-4156-b59f-c4873b02b080">



After
<img width="679" alt="Screenshot 2023-08-04 at 20 19 02" src="https://github.com/TheOdinProject/theodinproject/assets/7963776/37bf284d-050a-45fd-a621-a6d2e93e1136">

