### PR TITLE
Give donate buttons slightly more horizontal space

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -8,8 +8,8 @@
         <h2 class="text-sm text-gray-500 dark:text-gray-400">The Odin Project is funded by the community. Join us in empowering learners around the globe by supporting The Odin Project!</h2>
       </div>
       <div class="mt-4 flex justify-center space-x-4">
-        <%= link_to 'Learn more', support_us_path, class: 'button button--secondary mx-3' %>
-        <%= link_to 'https://opencollective.com/theodinproject/donate?amount=5', class: 'button button--primary relative mx-3', target: '_blank' do %>
+        <%= link_to 'Learn more', support_us_path, class: 'button button--secondary' %>
+        <%= link_to 'https://opencollective.com/theodinproject/donate?amount=5', class: 'button button--primary relative', target: '_blank' do %>
           <span class="mr-4">Donate now</span>
           <%= inline_svg_tag 'icons/arrow-right.svg', class: 'absolute right-3 h-4 w-4 ml-2', aria: false %>
         <% end %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -8,8 +8,8 @@
         <h2 class="text-sm text-gray-500 dark:text-gray-400">The Odin Project is funded by the community. Join us in empowering learners around the globe by supporting The Odin Project!</h2>
       </div>
       <div class="text-center mt-4">
-        <%= link_to 'Learn more', support_us_path, class: 'button button--secondary' %>
-        <%= link_to 'https://opencollective.com/theodinproject/donate?amount=5', class: 'button button--primary relative', target: '_blank' do %>
+        <%= link_to 'Learn more', support_us_path, class: 'button button--secondary mx-3' %>
+        <%= link_to 'https://opencollective.com/theodinproject/donate?amount=5', class: 'button button--primary relative mx-3', target: '_blank' do %>
           <span class="mr-4">Donate now</span>
           <%= inline_svg_tag 'icons/arrow-right.svg', class: 'absolute right-3 h-4 w-4 ml-2', aria: false %>
         <% end %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -7,7 +7,7 @@
         <h1 class="text-2xl mb-4 font-semibold text-gray-800 dark:text-gray-200">Support us!</h1>
         <h2 class="text-sm text-gray-500 dark:text-gray-400">The Odin Project is funded by the community. Join us in empowering learners around the globe by supporting The Odin Project!</h2>
       </div>
-      <div class="text-center mt-4">
+      <div class="mt-4 flex justify-center space-x-6">
         <%= link_to 'Learn more', support_us_path, class: 'button button--secondary mx-3' %>
         <%= link_to 'https://opencollective.com/theodinproject/donate?amount=5', class: 'button button--primary relative mx-3', target: '_blank' do %>
           <span class="mr-4">Donate now</span>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -7,7 +7,7 @@
         <h1 class="text-2xl mb-4 font-semibold text-gray-800 dark:text-gray-200">Support us!</h1>
         <h2 class="text-sm text-gray-500 dark:text-gray-400">The Odin Project is funded by the community. Join us in empowering learners around the globe by supporting The Odin Project!</h2>
       </div>
-      <div class="mt-4 flex justify-center space-x-6">
+      <div class="mt-4 flex justify-center space-x-4">
         <%= link_to 'Learn more', support_us_path, class: 'button button--secondary mx-3' %>
         <%= link_to 'https://opencollective.com/theodinproject/donate?amount=5', class: 'button button--primary relative mx-3', target: '_blank' do %>
           <span class="mr-4">Donate now</span>


### PR DESCRIPTION
## Because
Currently there is very little whitespace between the learn more and donate buttons, leading to a cramped feeling


## This PR
- Gives them both a bit of horizontal margin

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behavior
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.