### PR TITLE
Chore: Contributing Guide - rename heading to be more general

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,7 +184,7 @@ Before you begin working on anything, make sure you follow these steps in order 
     git remote add upstream https://github.com/TheOdinProject/css-exercises.git
     ```
 
-### Working on an Issue
+### Committing Your Changes
 
 Once you have the repo forked and cloned, and the upstream remote has been set, you can begin working on your issue:
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
Just a suggestion to rename the "Working on an Issue" heading to something a little more general yet still accurate and not "exclusive" to working an a GH issue. A few times previously in Discord, people have implied they could not find the info they needed in the contributing guide and that they did not read the "Working on an Issue" part because their contribution was just a simple PR for something like a typo and not addressing an open issue.


## This PR
- Rename "Working On An Issue" heading


## Issue
N/A

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behavior
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If applicable, this PR includes new or updated automated tests
