### PR TITLE
Fix: Circle CI Chrome install failing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 orbs:
-  browser-tools: circleci/browser-tools@1.4.1
+  browser-tools: circleci/browser-tools@1.4.4
   ruby: circleci/ruby@2.0.1
 
 executors:
@@ -52,7 +52,9 @@ jobs:
     executor: rails-executor
     steps:
       - checkout
-      - browser-tools/install-chrome
+      - browser-tools/install-chrome:
+          chrome-version: "116.0.5845.96" # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
+          replace-existing: true # TODO: remove -> https://github.com/CircleCI-Public/browser-tools-orb/issues/75
       - browser-tools/install-chromedriver
       - run:
           command:


### PR DESCRIPTION
Because:
* Google have released a new version of chrome but have not released a new version of chrome-driver for it yet. 
* https://github.com/bullet-train-co/bullet_train/commit/4fbab7b61d9c1c18591be3ed1132a8d12fdb31df

