### PR TITLE
Feature: Add redirect from /blog to the TOP blog

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -55,7 +55,7 @@
             <h3 class="text-sm font-semibold leading-6 text-gray-900 dark:text-white">About us</h3>
             <ul role="list" class="mt-4 space-y-3">
               <li><%= link_to 'About', about_path, class: 'text-sm leading-6 text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white' %></li>
-              <li><%= link_to 'Blog', '/blog', target: '_blank', rel: 'noreferrer', class: 'text-sm leading-6 text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white' %></li>
+              <li><%= link_to 'Blog', blog_path, target: '_blank', rel: 'noreferrer', class: 'text-sm leading-6 text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white' %></li>
               <li><%= link_to 'Success Stories', success_stories_path, class: 'text-sm leading-6 text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white' %></li>
             </ul>
           </div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -55,7 +55,7 @@
             <h3 class="text-sm font-semibold leading-6 text-gray-900 dark:text-white">About us</h3>
             <ul role="list" class="mt-4 space-y-3">
               <li><%= link_to 'About', about_path, class: 'text-sm leading-6 text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white' %></li>
-              <li><%= link_to 'Blog', ODIN_BLOG_URL, target: '_blank', rel: 'noreferrer', class: 'text-sm leading-6 text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white' %></li>
+              <li><%= link_to 'Blog', '/blog', target: '_blank', rel: 'noreferrer', class: 'text-sm leading-6 text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white' %></li>
               <li><%= link_to 'Success Stories', success_stories_path, class: 'text-sm leading-6 text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white' %></li>
             </ul>
           </div>

--- a/config/routes/redirects.rb
+++ b/config/routes/redirects.rb
@@ -3,4 +3,5 @@ Rails.application.routes.draw do
   get '/courses/web-development-101(/lessons/:id)', to: redirect('/paths/foundations')
   get '/paths/:path_id/courses/:course_id/lessons/:id', to: redirect(Redirectors::NestedLessonRedirector.new)
   get '/discord', to: redirect(ODIN_CHAT_URL)
+  get '/blog', to: redirect(ODIN_BLOG_URL)
 end

--- a/config/routes/redirects.rb
+++ b/config/routes/redirects.rb
@@ -3,5 +3,5 @@ Rails.application.routes.draw do
   get '/courses/web-development-101(/lessons/:id)', to: redirect('/paths/foundations')
   get '/paths/:path_id/courses/:course_id/lessons/:id', to: redirect(Redirectors::NestedLessonRedirector.new)
   get '/discord', to: redirect(ODIN_CHAT_URL)
-  get '/blog', to: redirect(ODIN_BLOG_URL)
+  get '/blog', to: redirect(ODIN_BLOG_URL), as: :blog
 end

--- a/spec/requests/redirects_spec.rb
+++ b/spec/requests/redirects_spec.rb
@@ -51,4 +51,11 @@ RSpec.describe 'Redirects' do
       expect(response).to redirect_to(ODIN_CHAT_URL)
     end
   end
+
+  describe 'GET /blog' do
+    it 'redirects to the blog page' do
+      get '/blog'
+      expect(response).to redirect_to(ODIN_BLOG_URL)
+    end
+  end
 end


### PR DESCRIPTION
## Because
- Its useful to have a single canonical internal url for linking to the TOP blog, both for consistency and for being able to maintain and change it later on


## This PR
- Redirects `/blog` to https://dev.to/theodinproject
  - Changes the blog link in the footer to point to this new link
  -  Adds a new test for this behavior


## Issue
Closes #4108 


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
  - `Feature` - adds new or amends existing user-facing behavior
  - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
  - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests