### PR TITLE
Fix: Note icons

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,6 +24,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap" rel="stylesheet">
 
+    <%= stylesheet_pack_tag 'application', 'data-turbo-track': 'reload' %>
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbo-track': 'reload' %>
 
     <%= javascript_pack_tag 'application', 'data-turbo-track': 'reload', defer: true %>


### PR DESCRIPTION
Because:
* We need a pack stylesheet tag to load fontawesome styles.
* Fixes: https://github.com/TheOdinProject/theodinproject/issues/4133