### PR TITLE
Chore: Switch our Redis provider to Heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -13,10 +13,7 @@
       ],
       "addons": [
         "heroku-postgresql:mini",
-        {
-          "plan": "rediscloud:30",
-          "as": "REDIS"
-        }
+        "heroku-redis:mini"
       ],
       "env": {
         "STAGING": {


### PR DESCRIPTION
Because:
* To bump Sidekiq to the latest version, we need an up to date version of Redis too.
