### PR TITLE
Fix: Redis OpenSSL::SSL::SSLError

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,7 @@
+Sidekiq.configure_server do |config|
+  config.redis = { url: ENV['REDIS_URL'], ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE } }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: ENV['REDIS_URL'], ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE } }
+end


### PR DESCRIPTION
Because:
* We upgraded our Redis instance on Heroku and need to add config for the verify mode.
* Closes: https://github.com/TheOdinProject/theodinproject/issues/4139