### PR TITLE
Feature: Use Tailwind prose plugin on support page

### DIFF
--- a/app/views/static_pages/support_us.html.erb
+++ b/app/views/static_pages/support_us.html.erb
@@ -6,9 +6,9 @@
       <div class='col-span-12 md:col-start-3 md:col-span-8 space-y-8'>
         <div class='text-center'>
           <h1 class='page-heading-title'>Support the Project</h1>
-          <p class='max-w-prose mx-auto prose prose-gray dark:prose-invert text-gray-500 dark:text-gray-400'>
+          <p class='max-w-prose mx-auto prose prose-gray dark:prose-invert text-gray-600 dark:text-gray-300'>
             From the very beginning, The Odin Project has been committed to providing a world-class and completely free coding curriculum for anyone and everyone eager to learn.
-            <strong>With your generous donations</strong>, we can continue to inspire thousands of aspiring developers, irrespective of their background or financial status.
+            With your generous donations, we can continue to inspire thousands of aspiring developers, irrespective of their background or financial status.
           </p>
         </div>
       </div>
@@ -23,97 +23,52 @@
   <section class='bg-gray-100 dark:bg-gray-800 text-gray-600 dark:text-gray-400'>
     <div class='page-container'>
       <div class='grid grid-cols-12'>
-        <div class='col-span-12 md:col-start-3 md:col-span-8'>
-          <h2 class='font-bold text-center mb-16 text-2xl'>Frequently Asked Questions</h2>
-          <ul>
-            <li class="mb-8">
-              <h3 class="text-lg mb-2">How will my money be used?</h3>
-              <div class="text-sm">
-                Your money will be used to pay for the costs of running The Odin Project. This includes paying for the servers that host the website, the domain name, and any other costs associated with running the project. Your money does <i>not</i> go towards paying the maintainers. All of our expenses are documented directly on the <%= link_to 'Open Collective website.', 'https://opencollective.com/theodinproject', class: 'text-blue-800 dark:text-blue-300 font-semibold underline', target: '_blank' %>
-                <br>
-                <br>
-                If you're reading this in July or August of 2023, there is no expense data on Open Collective because we have not yet used any funds from donations there. As we receive donations, and use the money to pay for expenses, the expense data will be updated on Open Collective.
-              </div>
-            </li>
-            <li class="mb-8">
-              <h3 class="text-lg mb-2">How can I donate?</h3>
-              <div class="text-sm">
-                You can donate via <%= link_to 'Open Collective', 'https://opencollective.com/theodinproject', class: 'text-blue-800 dark:text-blue-300 font-semibold underline', target: '_blank' %>, by setting up a recurring donation or with a one time payment.
-              </div>
-            </li>
-            <li class="mb-8">
-              <h3 class="text-lg mb-2">What form of payments can I use?</h3>
-              <div class="text-sm">
-              You can usually pay by credit card through our Open Collective page. They also offer bank transfer, Paypal, or other means in addition to or instead of credit card payments. When you go through the contribution flow, you'll see all the available payment methods.
-              </div>
-            </li>
-            <li class="mb-8">
-              <h3 class="text-lg mb-2">What happens if you receive more donations than needed?</h3>
-              <div class="text-sm">
-                Any extra money that we receive will be used to improve The Odin Project, or will be saved for future needs. This includes paying for new features, paying for new servers, and paying for any other costs associated with running the project.
-              </div>
-            </li>
-            <li class="mb-8">
-              <h3 class="text-lg mb-2">How do I cancel my recurring donation?</h3>
-              <div class="text-sm">
-                You can cancel your recurring donation at any time through your Open Collective profile.
-              </div>
-            </li>
-            <li class="mb-8">
-             <h3 class="text-lg mb-2">What are the benefits of donating?</h3>
-              <div class="text-sm">
-                Your donation helps us continue to provide a world-class and completely free coding curriculum for anyone and everyone eager to learn. We believe that this material should be available for free to anyone that needs it, and donations from those that have the means to contribute help keep it available for everyone!
-                <br><br>
-                In additon to the above, donors get a special 'backer' role in our discord server as a small bit of recognition.
-              </div>
-            </li>
-            <li class="mb-8">
-              <h3 class="text-lg mb-2">How do I get the 'backer' role on Discord?</h3>
-              <div class="text-sm">
-                Use the <code>/opencollective</code> command in our discord server to verify your Open Collective account. You will then be automatically given the 'backer' role.
-                You will be prompted to provide your Open Collective username, which is found in the URL of your Open Collective profile. For example, if your profile URL is <code>https://opencollective.com/rick-astley</code> your username is <code>rick-astley</code>.
-                <br>
-                <br>
-                If you want to remove the role for any reason, contact staff on discord through ModMail.
-              </div>
-            </li>
-            <li class="mb-8">
-              <h3 class="text-lg mb-2">Do users with the 'backer' role get any exclusive benefits?</h3>
-              <div class="text-sm">
-                No. The role is just a way for us to show our appreciation for your support.
-              </div>
-            </li>
-            <li class="mb-8">
-              <h3 class="text-lg mb-2">Does becoming a donor mean I get priority support in the chat?</h3>
-              <div class="text-sm">
-                No. We feel strongly that everyone should be treated equally in our community, regardless of whether or not they are a donor.
-              </div>
-            </li>
-            <li class="mb-8">
-              <h3 class="text-lg mb-2">I cannot afford to donate right now. What are some other ways I can help The Odin Project?</h3>
-              <div class="text-sm">
-                You can help us by <%= link_to 'contributing to our open source projects.', contributing_path, class: 'text-blue-800 dark:text-blue-300 font-semibold underline', target: '_blank' %> You can also help us by spreading the word about The Odin Project. Tell your friends, family, and coworkers about us. Share our content on social media. The more people that know about us, the more people we can help.
-              </div>
-            </li>
-            <li class="mb-8">
-              <h3 class="text-lg mb-2">What ever happend to Thinkful? Viking Code School?</h3>
-              <div class="text-sm">
-                When The Odin Project was created by Eric Trautman in 2013, it was primarily funded by Eric's other project, the for-profit Viking Code School. Eric wanted Odin to be free, and kept it that way by placing a small ad for Viking Code School on the website.
-                <br> <br>
-                In late 2017, Viking Code School was acquired by Thinkful. As a part of that acquisition, Thinkful agreed to continue funding The Odin Project, in return for an ad on The Odin Project website.
-                <br> <br>
-                In 2019, Thinkful was acquired by Chegg. Chegg was nothing but supportive, and continued funding us the entire time. However we began to feel that it might be in our best interest to become self-funding, to avoid the risk of being acquired by a company that might not be as supportive.
-                <br> <br>
-                In 2023, we decided to begin the process of parting ways with Chegg, and become self-funding. We are now funded entirely by donations.
-              </div>
-            </li>
-            <li class="mb-8">
-              <h3 class="text-lg mb-2">I still have questions. How can I contact you?</h3>
-              <div class="text-sm">
-                You can contact us through modmail on our discord server, or through email.  See our <%= link_to 'contact us', about_path(anchor: 'contact-us'), class: 'text-blue-800 dark:text-blue-300 font-semibold underline', target: '_blank' %> page for details.
-              </div>
-            </li>
-          </ul>
+        <div class='col-span-12 md:col-start-3 md:col-span-8 prose dark:prose-invert max-w-none prose-a:text-blue-800 dark:prose-a:text-blue-300'>
+          <h2 class="text-center mb-16">Frequently Asked Questions</h2>
+
+          <h3>How will my money be used?</h3>
+          <p>Your money will be used to pay for the costs of running The Odin Project. This includes paying for the servers that host the website, the domain name, and any other costs associated with running the project. Your money does <i>not</i> go towards paying the maintainers. All of our expenses are documented directly on the <%= link_to 'Open Collective website.', 'https://opencollective.com/theodinproject', target: '_blank' %></p>
+
+          <h3>How can I donate?</h3>
+          <p>You can donate via <%= link_to 'Open Collective', 'https://opencollective.com/theodinproject', target: '_blank' %>, by setting up a recurring donation or with a one time payment.</p>
+
+          <h3>What form of payments can I use?</h3>
+          <p>You can usually pay by credit card through our Open Collective page. They also offer bank transfer, Paypal, or other means in addition to or instead of credit card payments. When you go through the contribution flow, you'll see all the available payment methods.</p>
+
+          <h3>What happens if you receive more donations than needed?</h3>
+          <p>Any extra money that we receive will be used to improve The Odin Project, or will be saved for future needs. This includes paying for new features, paying for new servers, and paying for any other costs associated with running the project.</p>
+
+          <h3>How do I cancel my recurring donation?</h3>
+          <p>You can cancel your recurring donation at any time through your Open Collective profile.</p>
+
+          <h3>What are the benefits of donating?</h3>
+          <p>Your donation helps us continue to provide a world-class and completely free coding curriculum for anyone and everyone eager to learn. We believe that this material should be available for free to anyone that needs it, and donations from those that have the means to contribute help keep it available for everyone!</p>
+          <p>In additon to the above, donors get a special 'backer' role in our discord server as a small bit of recognition.</p>
+
+          <h3>How do I get the 'backer' role on Discord?</h3>
+          <p>
+            Use the <code>/opencollective</code> command in our discord server to verify your Open Collective account. You will then be automatically given the 'backer' role.
+            You will be prompted to provide your Open Collective username, which is found in the URL of your Open Collective profile. For example, if your profile URL is <code>https://opencollective.com/rick-astley</code> your username is <code>rick-astley</code>.
+          </p>
+          <p>If you want to remove the role for any reason, contact staff on discord through ModMail.</p>
+
+          <h3>Do users with the 'backer' role get any exclusive benefits?</h3>
+          <p>No. The role is just a way for us to show our appreciation for your support.</p>
+
+          <h3>Does becoming a donor mean I get priority support in the chat?</h3>
+          <p>No. We feel strongly that everyone should be treated equally in our community, regardless of whether or not they are a donor.</p>
+
+          <h3>I cannot afford to donate right now. What are some other ways I can help The Odin Project?</h3>
+          <p>You can help us by <%= link_to 'contributing to our open source projects.', contributing_path, target: '_blank' %> You can also help us by spreading the word about The Odin Project. Tell your friends, family, and coworkers about us. Share our content on social media. The more people that know about us, the more people we can help.</p>
+
+          <h3>What ever happend to Thinkful? Viking Code School?</h3>
+          <p>When The Odin Project was created by Eric Trautman in 2013, it was primarily funded by Eric's other project, the for-profit Viking Code School. Eric wanted Odin to be free, and kept it that way by placing a small ad for Viking Code School on the website.</p>
+          <p>In late 2017, Viking Code School was acquired by Thinkful. As a part of that acquisition, Thinkful agreed to continue funding The Odin Project, in return for an ad on The Odin Project website.</p>
+          <p>In 2019, Thinkful was acquired by Chegg. Chegg was nothing but supportive, and continued funding us the entire time. However we began to feel that it might be in our best interest to become self-funding, to avoid the risk of being acquired by a company that might not be as supportive.</p>
+          <p>In 2023, we decided to begin the process of parting ways with Chegg, and become self-funding. We are now funded entirely by donations.</p>
+
+          <h3>I still have questions. How can I contact you?</h3>
+          <p>You can contact us through modmail on our discord server, or through email.  See our <%= link_to 'contact us', about_path(anchor: 'contact-us'), target: '_blank' %> page for details.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Because:
* It simplifies the markup
* Consistency with content on other pages.

This commit:
* Use the prose plugin on the base element
* Removes styling of individual elements
* Remove August expenses disclaimer; we have a couple of expenses in OC now.