### PR TITLE
Fix success stories alignment

### DIFF
--- a/app/views/static_pages/home/_success_stories.html.erb
+++ b/app/views/static_pages/home/_success_stories.html.erb
@@ -4,7 +4,7 @@
       <h2 class="font-medium text-3xl text-gray-800 dark:text-gray-200">Success Stories</h2>
     </div>
 
-    <div class="max-w-7xl mx-auto mt-8 sm:mt-16 flex flex-nowrap xl:flex-wrap flex-col xl:flex-row items-center">
+    <div class="max-w-7xl mx-auto mt-8 sm:mt-16 flex flex-nowrap xl:flex-wrap flex-col xl:flex-row items-center xl:items-start">
       <% @success_stories.each do |story| %>
       <div class="px-6 sm:px-0 max-w-xl xl:max-w-none xl:w-1/2 flex pb-9">
         <div class="w-16 sm:w-24 text-center pt-4 sm:flex justify-center">


### PR DESCRIPTION
## Because
The success stories on the homepage don't align correctly.


## This PR
Fixes the success stories' alignment on the homepage.


## Issue
Closes https://github.com/TheOdinProject/theodinproject/issues/4162



## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] profile pictures and name are aligned horizontally
