### PR TITLE
Chore: Refactor submissions blank state to hide and display using a only pseudo class modifier

### DIFF
--- a/app/views/lessons/project_submissions/_blank_state.html.erb
+++ b/app/views/lessons/project_submissions/_blank_state.html.erb
@@ -1,8 +1,0 @@
-<div class="p-8 pb-16" id="project-solutions-blank-state">
-  <div class="text-center">
-    <%= inline_svg_tag 'icons/folder-plus.svg', class: 'mx-auto h-12 w-12 text-gray-400 dark:text-gray-500', aria: true, title: 'No solutions', desc: 'No solutions icon' %>
-
-    <h3 class="mt-2 text-xl font-semibold text-gray-900 dark:text-gray-200">No solutions</h3>
-    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Be the first</p>
-  </div>
-</div>

--- a/app/views/lessons/project_submissions/create.turbo_stream.erb
+++ b/app/views/lessons/project_submissions/create.turbo_stream.erb
@@ -4,5 +4,4 @@
   <% end %>
 <% end %>
 
-<%= turbo_stream.remove 'project-solutions-blank-state' %>
 <%= turbo_stream.update 'add-submission-button', '' %>

--- a/app/views/lessons/project_submissions/destroy.turbo_stream.erb
+++ b/app/views/lessons/project_submissions/destroy.turbo_stream.erb
@@ -3,9 +3,3 @@
 <%= turbo_stream.update 'add-submission-button' do %>
   <%= render 'lessons/project_submissions/add_button', lesson: @lesson %>
 <% end %>
-
-<% if @lesson.project_submissions.none? %>
-  <%= turbo_stream.append 'submissions-list' do %>
-    <%= render 'lessons/project_submissions/blank_state' %>
-  <% end %>
-<% end %>

--- a/app/views/lessons/project_submissions/index.html.erb
+++ b/app/views/lessons/project_submissions/index.html.erb
@@ -28,19 +28,24 @@
       </header>
 
       <%= turbo_frame_tag 'submissions-list', data: { test_id: 'submissions-list', controller: 'sort' } do %>
-        <% if @lesson.project_submissions.any? %>
-          <%= render ProjectSubmissions::ItemComponent.new(project_submission: @current_user_submission, current_user:) do |component| %>
-            <%= component.with_title(title: current_user.username, url: dashboard_path) %>
-          <% end %>
-
-          <% @project_submissions.each do |project_submission| %>
-            <%= render ProjectSubmissions::ItemComponent.new(project_submission:, current_user:) do |component| %>
-              <%= component.with_title(title: project_submission.user.username) %>
-            <% end %>
-          <% end %>
-        <% else %>
-          <% render 'lessons/project_submissions/blank_state' %>
+        <%= render ProjectSubmissions::ItemComponent.new(project_submission: @current_user_submission, current_user:) do |component| %>
+          <%= component.with_title(title: current_user.username, url: dashboard_path) %>
         <% end %>
+
+        <% @project_submissions.each do |project_submission| %>
+          <%= render ProjectSubmissions::ItemComponent.new(project_submission:, current_user:) do |component| %>
+            <%= component.with_title(title: project_submission.user.username) %>
+          <% end %>
+        <% end %>
+
+        <div class="p-8 pb-16 hidden only:block">
+          <div class="text-center">
+            <%= inline_svg_tag 'icons/folder-plus.svg', class: 'mx-auto h-12 w-12 text-gray-400 dark:text-gray-500', aria: true, title: 'No solutions', desc: 'No solutions icon' %>
+
+            <h3 class="mt-2 text-xl font-semibold text-gray-900 dark:text-gray-200">No solutions</h3>
+            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">Be the first</p>
+          </div>
+        </div>
       <% end %>
     </div>
   <% end %>


### PR DESCRIPTION
Because:
* It simplifies the code.

This commit:
* Adds an only pseudo class modifier to display the blank state it is the only item in the submissions list container, otherwise hide it.
* Remove the submissions blank state partial
* Removes the any if condition around submission items
* Removes the turbo stream to remove the blank state when adding a new submission
