### PR TITLE
Feature: Add lesson URL when reporting content

### DIFF
--- a/app/helpers/lessons_helper.rb
+++ b/app/helpers/lessons_helper.rb
@@ -3,16 +3,14 @@ module LessonsHelper
     github_link("curriculum/edit/main#{lesson.github_path}")
   end
 
-  def github_report_url(lesson, path)
-    # rubocop:disable Layout/LineLength
-params = {
+  def github_report_url(lesson)
+    params = {
       labels: 'Status: Needs Triage',
       template: 'suggestion.yaml',
       title: "#{lesson.title}: <Short description of your suggestion>",
-      lesson: lesson_url(lesson)
+      'lesson-link': lesson_url(lesson)
     }
 
     github_link("curriculum/issues/new?#{params.to_query}")
-    # rubocop:enable Layout/LineLength
   end
 end

--- a/app/helpers/lessons_helper.rb
+++ b/app/helpers/lessons_helper.rb
@@ -5,7 +5,14 @@ module LessonsHelper
 
   def github_report_url(lesson, path)
     # rubocop:disable Layout/LineLength
-    github_link("curriculum/issues/new?assignees=nil&labels=Status%3A+Needs+Triage&projects=&template=suggestion.yaml&title=#{lesson.title}%3A+%3CShort+description+of+your+suggestion%3E&lesson-link=https://www.theodinproject.com#{path}")
+params = {
+      labels: 'Status: Needs Triage',
+      template: 'suggestion.yaml',
+      title: "#{lesson.title}: <Short description of your suggestion>",
+      lesson: lesson_url(lesson)
+    }
+
+    github_link("curriculum/issues/new?#{params.to_query}")
     # rubocop:enable Layout/LineLength
   end
 end

--- a/app/helpers/lessons_helper.rb
+++ b/app/helpers/lessons_helper.rb
@@ -3,9 +3,9 @@ module LessonsHelper
     github_link("curriculum/edit/main#{lesson.github_path}")
   end
 
-  def github_report_url(lesson)
+  def github_report_url(lesson, path)
     # rubocop:disable Layout/LineLength
-    github_link("curriculum/issues/new?assignees=nil&labels=Status%3A+Needs+Triage&projects=&template=suggestion.yaml&title=#{lesson.title}%3A+%3CShort+description+of+your+suggestion%3E")
+    github_link("curriculum/issues/new?assignees=nil&labels=Status%3A+Needs+Triage&projects=&template=suggestion.yaml&title=#{lesson.title}%3A+%3CShort+description+of+your+suggestion%3E&lesson-link=https://www.theodinproject.com#{path}")
     # rubocop:enable Layout/LineLength
   end
 end

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -16,7 +16,7 @@
               <span>Improve on GitHub</span>
             <% end %>
 
-            <%= link_to github_report_url(@lesson), target: :_blank, rel: 'noreferrer noopener', class: 'inline-flex items-center underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 pr-5 text-sm' do %>
+            <%= link_to github_report_url(@lesson, request.path), target: :_blank, rel: 'noreferrer noopener', class: 'inline-flex items-center underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 pr-5 text-sm' do %>
               <%= inline_svg_tag 'icons/flag.svg', class: 'h-4 w-4 mr-1 inline', aria: true, title: 'Report an issue', desc: 'Report icon' %>
               <span>Report an issue</span>
             <% end %>

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -16,7 +16,7 @@
               <span>Improve on GitHub</span>
             <% end %>
 
-            <%= link_to github_report_url(@lesson, request.path), target: :_blank, rel: 'noreferrer noopener', class: 'inline-flex items-center underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 pr-5 text-sm' do %>
+            <%= link_to github_report_url(@lesson), target: :_blank, rel: 'noreferrer noopener', class: 'inline-flex items-center underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 pr-5 text-sm' do %>
               <%= inline_svg_tag 'icons/flag.svg', class: 'h-4 w-4 mr-1 inline', aria: true, title: 'Report an issue', desc: 'Report icon' %>
               <span>Report an issue</span>
             <% end %>

--- a/spec/helpers/lessons_helper_spec.rb
+++ b/spec/helpers/lessons_helper_spec.rb
@@ -12,9 +12,11 @@ RSpec.describe LessonsHelper do
   end
 
   describe '#github_report_url' do
-    let(:lesson) { create(:lesson, title: 'Ruby Basics') }
+    let(:course) { create(:course, title: 'Test Course1') }
+    let(:lesson) { create(:lesson, title: 'Ruby Basics', course:) }
 
     it 'returns the correct github url' do
+      puts(helper.github_report_url(lesson))
       expect(helper.github_report_url(lesson)).to eql(
         'https://github.com/TheOdinProject/curriculum/issues/new?labels=Status%3A+Needs+Triage&lesson-link=http%3A%2F%2Ftest.host%2Flessons%2Ftest-course1-ruby-basics&template=suggestion.yaml&title=Ruby+Basics%3A+%3CShort+description+of+your+suggestion%3E'
       )

--- a/spec/helpers/lessons_helper_spec.rb
+++ b/spec/helpers/lessons_helper_spec.rb
@@ -15,10 +15,8 @@ RSpec.describe LessonsHelper do
     let(:lesson) { create(:lesson, title: 'Ruby Basics') }
 
     it 'returns the correct github url' do
-      expect(helper.github_report_url(lesson, '/lessons/ruby-basics')).to eql(
-        # rubocop:disable Layout/LineLength
-        'https://github.com/TheOdinProject/curriculum/issues/new?assignees=nil&labels=Status%3A+Needs+Triage&projects=&template=suggestion.yaml&title=Ruby Basics%3A+%3CShort+description+of+your+suggestion%3E&lesson-link=https://www.theodinproject.com/lessons/ruby-basics'
-        # rubocop:enable Layout/LineLength
+      expect(helper.github_report_url(lesson)).to eql(
+        'https://github.com/TheOdinProject/curriculum/issues/new?labels=Status%3A+Needs+Triage&lesson-link=http%3A%2F%2Ftest.host%2Flessons%2Ftest-course1-ruby-basics&template=suggestion.yaml&title=Ruby+Basics%3A+%3CShort+description+of+your+suggestion%3E'
       )
     end
   end

--- a/spec/helpers/lessons_helper_spec.rb
+++ b/spec/helpers/lessons_helper_spec.rb
@@ -10,4 +10,16 @@ RSpec.describe LessonsHelper do
       )
     end
   end
+
+  describe '#github_report_url' do
+    let(:lesson) { create(:lesson, title: 'Ruby Basics') }
+
+    it 'returns the correct github url' do
+      expect(helper.github_report_url(lesson, '/lessons/ruby-basics')).to eql(
+        # rubocop:disable Layout/LineLength
+        'https://github.com/TheOdinProject/curriculum/issues/new?assignees=nil&labels=Status%3A+Needs+Triage&projects=&template=suggestion.yaml&title=Ruby Basics%3A+%3CShort+description+of+your+suggestion%3E&lesson-link=https://www.theodinproject.com/lessons/ruby-basics'
+        # rubocop:enable Layout/LineLength
+      )
+    end
+  end
 end


### PR DESCRIPTION
## Because
- Currently learners have to copy/paste the URL when reporting an issue via the "report an issue" link


## This PR
- Uses GitHub's ability to fill fields via url parameters to automatically fill it in when using the "report an issue" link
- Actually adds tests for "report an issue"


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests