### PR TITLE
Chore: Don't restrict Rspec output length

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,4 +20,7 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   config.order = 'random'
   config.example_status_persistence_file_path = './spec/examples.txt'
+  config.expect_with :rspec do |expectations|
+    expectations.max_formatted_output_length = nil
+  end
 end


### PR DESCRIPTION
## Because
- Rspec by default truncates the output of failed tests, but it doesn't do so in an intelligent way, instead just taking half the allowed characters from the front and the other half from the back, and replacing all characters in between with a single ellipsis. This means that with some test errors (such as the ones I encountered in #4242), it can be impossible to see which part of a string isn't matching.


## This PR
- Sets `max_formatted_output_length` to `nil`, which makes Rspec always print the full string


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.