### PR TITLE
Chore: Remove Rails UJS

### DIFF
--- a/app/components/notification_component.html.erb
+++ b/app/components/notification_component.html.erb
@@ -1,4 +1,4 @@
-<%= link_to notification_path(@notification), method: :patch, class: 'no-underline px-4 py-4', data: { test_id: "notification-#{@notification.id}" } do %>
+<%= link_to notification_path(@notification), class: 'no-underline px-4 py-4', data: { turbo_method: :patch, test_id: "notification-#{@notification.id}" } do %>
   <li class="bg-white dark:bg-gray-800 dark:shadow-none dark:ring-1 dark:ring-white/10 dark:ring-inset shadow overflow-hidden p-4 sm:rounded-md">
     <div class="flex">
       <div class="mr-4 flex-shrink-0">

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -14,7 +14,6 @@
 // const images = require.context('../images', true)
 // const imagePath = (name) => images(name, true)
 
-import Rails from '@rails/ujs';
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 import 'hint.css/hint.min.css';
@@ -22,5 +21,3 @@ import '@fortawesome/fontawesome-free/css/all.css';
 import 'controllers';
 import '@hotwired/turbo-rails';
 import './src/custom_turbo_stream_actions';
-
-Rails.start();

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@hotwired/stimulus-webpack-helpers": "^1.0.1",
     "@hotwired/turbo-rails": "^7.3.0",
     "@rails/request.js": "^0.0.9",
-    "@rails/ujs": "^7.0.8",
     "@sentry/browser": "^7.66.0",
     "@stimulus/polyfills": "^2.0.0",
     "@tailwindcss/forms": "^0.5.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1513,11 +1513,6 @@
   resolved "https://registry.yarnpkg.com/@rails/request.js/-/request.js-0.0.9.tgz#89e2a575405dc07eb8a9b3d2fe04289e1f057cd0"
   integrity sha512-VleYUyrA3rwKMvYnz7MI9Ada85Vekjb/WVz7NuGgDO24Y3Zy9FFSpDMQW+ea/tlftD+CdX/W/sUosRA9/HkDOQ==
 
-"@rails/ujs@^7.0.8":
-  version "7.0.8"
-  resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-7.0.8.tgz#59853367d0827b3955d2c4bedfd5eba4a79d3422"
-  integrity sha512-tOQQBVH8LsUpGXqDnk+kaOGVsgZ8maHAhEiw3Git3p88q+c0Slgu47HuDnL6sVxeCfz24zbq7dOjsVYDiTpDIA==
-
 "@sentry-internal/tracing@7.66.0":
   version "7.66.0"
   resolved "https://registry.yarnpkg.com/@sentry-internal/tracing/-/tracing-7.66.0.tgz#45ea607917d55a5bcaa3229341387ff6ed9b3a2b"


### PR DESCRIPTION
Because:
* Rails Ujs has been depreciated in favor of Hotwire.
