### PR TITLE
Fix: Mermaid diagramming with internal navigation links

### DIFF
--- a/app/javascript/controllers/diagramming_controller.js
+++ b/app/javascript/controllers/diagramming_controller.js
@@ -4,6 +4,7 @@ import mermaid from 'mermaid';
 export default class DiagrammingController extends Controller {
   /* eslint-disable class-methods-use-this */
   connect() {
-    mermaid.initialize({ startOnLoad: true, theme: 'dark' });
+    mermaid.initialize({ startOnLoad: false, theme: 'dark' });
+    mermaid.init();
   }
 }


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
I noticed an issue recently with mermaid diagramming where the markdown was being rendered raw rather than drawing the actual diagram.
![image](https://github.com/TheOdinProject/theodinproject/assets/88392688/1b58215a-2347-4ba8-8876-de7cec9eb2cf)

Steps to reproduce:
1. Visit the [Foundations Course](https://www.theodinproject.com/paths/foundations/courses/foundations)
2. Scroll to the lesson on Revisiting Rock Paper Scissors and click it

You should see the above screenshot content on the page (meaning the diagram isn't rendered properly). This only happens when visiting from a clicked link on the site. If you refresh or visit that page directly via its URL, the diagram will render properly. This made me think it was probably introduced alongside recent Turbo changes. Using `git bisect`, I tracked it down to #3845, which introduced Turbo Drive globally.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Use method for lazier initialization of `mermaid` in the `DiagrammingController`. Using its `startOnLoad = true` leads to issues with Turbo Drive navigation.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
The `mermaid.init()` method has been [deprecated in v10 of mermaid](https://mermaid.js.org/config/usage.html#calling-mermaid-init-deprecated) and will eventually be removed. Whenever #3716 is addressed, this will need to change again to use their currently preferred method of async initialization.

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
