### PR TITLE
Chore: Fix spelling of "candidate" in lesson model spec

### DIFF
--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -81,12 +81,12 @@ RSpec.describe Lesson do
       end
     end
 
-    context 'when three or more lessons share the same slug canidates' do
+    context 'when three or more lessons share the same slug candidates' do
       before do
         allow(SecureRandom).to receive(:hex).with(2).and_return('1234')
       end
 
-      it 'returns default slug canidate post fixed with the random hex' do
+      it 'returns default slug candidate post fixed with the random hex' do
         path = create(:path, short_title: 'path title')
         course = create(:course, title: 'course title', path:)
         create(:lesson, title: 'lesson title', course:)


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
The word "candidate" for friendly_id's slug candidates was misspelled in a couple of places in the file

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Fixes spelling of candidate

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section