### PR TITLE
Feature: Admin Users

### DIFF
--- a/app/controllers/admin_v2/base_controller.rb
+++ b/app/controllers/admin_v2/base_controller.rb
@@ -1,0 +1,7 @@
+# rubocop:disable Rails/ApplicationController
+module AdminV2
+  class BaseController < ActionController::Base
+    before_action :authenticate_admin_user!
+  end
+end
+# rubocop:enable Rails/ApplicationController

--- a/app/controllers/admin_v2/dashboard_controller.rb
+++ b/app/controllers/admin_v2/dashboard_controller.rb
@@ -1,5 +1,5 @@
 module AdminV2
-  class DashboardController < ApplicationController
+  class DashboardController < AdminV2::BaseController
     def show; end
   end
 end

--- a/app/controllers/admin_v2/sessions_controller.rb
+++ b/app/controllers/admin_v2/sessions_controller.rb
@@ -1,0 +1,4 @@
+module AdminV2
+  class SessionsController < Devise::SessionsController
+  end
+end

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -1,0 +1,6 @@
+class AdminUser < ApplicationRecord
+  devise :database_authenticatable, :recoverable, :trackable, :timeoutable, :validatable
+
+  validates :name, presence: true, uniqueness: true
+  validates :password, presence: true, confirmation: true, length: { minimum: 8 }
+end

--- a/app/views/admin_v2/sessions/new.html.erb
+++ b/app/views/admin_v2/sessions/new.html.erb
@@ -1,0 +1,33 @@
+<%= title('Admin - Sign in') %>
+
+<div class="bg-gray-50 min-h-screen dark:bg-gray-900">
+  <div class="page-container">
+    <div class="sm:mx-auto sm:w-full sm:max-w-md">
+      <h2 class="mt-6 text-center text-3xl font-bold tracking-tight text-gray-700 dark:text-gray-200">Sign in to your admin account</h2>
+    </div>
+
+    <div class="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
+      <%= render CardComponent.new do |card| %>
+        <%= card.with_body do %>
+          <%= form_for resource, as: resource_name, url: session_path(resource_name), builder: TailwindFormBuilder do |form| %>
+            <div class="space-y-6">
+              <div>
+                <%= form.label :email %>
+                <%= form.email_field :email, autofocus: true, required: true %>
+              </div>
+
+              <div>
+                <%= form.label :password %>
+                <%= form.password_field :password, required: true %>
+              </div>
+
+              <div>
+                <%= form.submit 'Sign in', class: 'button button--primary w-full py-2 px-4 text-sm' %>
+              </div>
+            </div>
+          <% end %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -132,7 +132,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
+  config.timeout_in = 30.minutes
 
   # If true, expires auth token on session timeout.
   # config.expire_auth_token_on_timeout = false
@@ -186,7 +186,7 @@ Devise.setup do |config|
   # Turn scoped views on. Before rendering "sessions/new", it will first check for
   # "users/sessions/new". It's turned off by default because it's slower if you
   # are using only default views.
-  # config.scoped_views = false
+  config.scoped_views = true
 
   # Configure the default scope given to Warden. By default it's the first
   # devise role declared in your routes (usually :user).

--- a/config/routes/admin_v2.rb
+++ b/config/routes/admin_v2.rb
@@ -1,3 +1,5 @@
+devise_for :admin_users, path: :admin_v2, module: :admin_v2
+
 namespace :admin_v2 do
   root to: 'dashboard#show'
   resource :dashboard, only: :show, controller: :dashboard

--- a/db/migrate/20231121083403_create_admin_users.rb
+++ b/db/migrate/20231121083403_create_admin_users.rb
@@ -1,0 +1,27 @@
+class CreateAdminUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :admin_users do |t|
+      ## Database authenticatable
+      t.string :name, null: false, default: ''
+      t.string :email, null: false, default: ''
+      t.string :encrypted_password, null: false, default: ''
+
+      ## Recoverable
+      t.string :reset_password_token
+      t.datetime :reset_password_sent_at
+
+      ## Trackable
+      t.integer :sign_in_count, default: 0, null: false
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.string :current_sign_in_ip
+      t.string :last_sign_in_ip
+
+      t.timestamps null: false
+    end
+
+    add_index :admin_users, :name, unique: true
+    add_index :admin_users, :email, unique: true
+    add_index :admin_users, :reset_password_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -29,6 +29,24 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_17_115443) do
     t.index ["resource_type", "resource_id"], name: "index_active_admin_comments_on_resource_type_and_resource_id"
   end
 
+  create_table "admin_users", force: :cascade do |t|
+    t.string "name", default: "", null: false
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_admin_users_on_email", unique: true
+    t.index ["name"], name: "index_admin_users_on_name", unique: true
+    t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
+  end
+
   create_table "announcements", id: :serial, force: :cascade do |t|
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false

--- a/db/seeds/test_admins.rb
+++ b/db/seeds/test_admins.rb
@@ -8,4 +8,9 @@ if Rails.env.development? || ENV['STAGING']
       user.admin = true
     end
   end
+
+  AdminUser.find_or_create_by!(email: 'admin@odin.com') do |admin_user|
+    admin_user.name = 'admin'
+    admin_user.password = 'password123'
+  end
 end

--- a/spec/factories/admin_users.rb
+++ b/spec/factories/admin_users.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :admin_user do
+    sequence(:name) { |n| "admin#{n}" }
+    sequence(:email) { |n| "admin#{n}@odin.com" }
+    password { 'password123' }
+  end
+end

--- a/spec/models/admin_user_spec.rb
+++ b/spec/models/admin_user_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe AdminUser do
+  subject { create(:admin_user) }
+
+  it { is_expected.to validate_presence_of(:name) }
+  it { is_expected.to validate_uniqueness_of(:name) }
+  it { is_expected.to validate_presence_of(:email) }
+  it { is_expected.to validate_uniqueness_of(:email).case_insensitive }
+  it { is_expected.to validate_presence_of(:password) }
+  it { is_expected.to validate_confirmation_of(:password) }
+  it { is_expected.to validate_length_of(:password).is_at_least(8) }
+end

--- a/spec/seeds/test_admins_spec.rb
+++ b/spec/seeds/test_admins_spec.rb
@@ -27,6 +27,11 @@ RSpec.describe 'Generating Test Admins' do
       load './db/seeds/test_admins.rb'
       expect(User.count).to be > 1
     end
+
+    it 'creates an admin user' do
+      load './db/seeds/test_admins.rb'
+      expect(AdminUser.count).to eq(1)
+    end
   end
 
   context 'when production environment' do
@@ -37,6 +42,11 @@ RSpec.describe 'Generating Test Admins' do
     it 'does not create any test admins' do
       load './db/seeds/test_admins.rb'
       expect(User.count).to eq(0)
+    end
+
+    it 'does not create any test admin users' do
+      load './db/seeds/test_admins.rb'
+      expect(AdminUser.count).to eq(0)
     end
   end
 end

--- a/spec/system/admin_v2/dashboard_spec.rb
+++ b/spec/system/admin_v2/dashboard_spec.rb
@@ -1,9 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe 'Admin V2 Dashboard' do
-  it 'displays the admin v2 dashboard' do
-    visit admin_v2_root_path
-
-    expect(page).to have_content('Welcome to the Admin V2 Dashboard')
-  end
-end

--- a/spec/system/admin_v2/sign_in_spec.rb
+++ b/spec/system/admin_v2/sign_in_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin V2 Sign in' do
+  context 'with valid credentials' do
+    it 'signs the admin user in' do
+      admin_user = create(:admin_user)
+
+      visit admin_v2_root_path
+
+      fill_in 'Email', with: admin_user.email
+      fill_in 'Password', with: admin_user.password
+      click_button 'Sign in'
+
+      expect(page).to have_content('Welcome to the Admin V2 Dashboard')
+      expect(page).to have_current_path(admin_v2_root_path)
+    end
+  end
+
+  context 'with invalid credentials' do
+    it 'does not sign in the user' do
+      user = create(:user)
+
+      visit admin_v2_root_path
+
+      fill_in 'Email', with: user.email
+      fill_in 'Password', with: user.password
+      click_button 'Sign in'
+
+      expect(page).not_to have_content('Welcome to the Admin V2 Dashboard')
+      expect(page).to have_current_path(new_admin_user_session_path)
+    end
+  end
+end


### PR DESCRIPTION
Because:
- Separating admin users from normal users will make new admin more secure and robust to changes.
- closes: https://github.com/TheOdinProject/theodinproject/issues/4267

This commit:
- Adds admin_users
- Sets up devise for admins users
- Timeout admin users after 30 minutes
- Adds admin v2 sign in page
- Refactors admin v2 test for signing in
- Seeds dummy admin user
