### PR TITLE
Chore: Remove extra underline before the "Improve on Github" link on every page

### DIFF
--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -11,9 +11,9 @@
           <%= @lesson.body.html_safe %>
 
           <% component.with_footer do %>
-            <%= link_to github_edit_url(@lesson), target: :_blank, rel: 'noreferrer noopener', class: 'underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 pr-5 text-sm' do %>
+            <%= link_to github_edit_url(@lesson), target: :_blank, rel: 'noreferrer noopener', class: 'text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 pr-5 text-sm' do %>
               <%= inline_svg_tag 'icons/github.svg', class: 'h-4 w-4 mr-1 inline', aria: true, title: 'Improve on GitHub', desc: 'Github logo icon' %>
-              <span>Improve on GitHub</span>
+              <span class: 'underline hover:no-underline'>Improve on GitHub</span>
             <% end %>
 
             <%= link_to github_report_url(@lesson), target: :_blank, rel: 'noreferrer noopener', class: 'inline-flex items-center underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 pr-5 text-sm' do %>


### PR DESCRIPTION
## Because
The "Improve on Github" link currently has this extra underline prefix. This change applies underline to the span directly so there's no overflow.
Before:
![image](https://github.com/TheOdinProject/theodinproject/assets/47951993/32a493f9-9f82-41a5-b0f5-c61b0367cc62)
After:
![image](https://github.com/TheOdinProject/theodinproject/assets/47951993/2a98d172-a325-4bfe-bda7-3308222ea899)

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->

- Fixes the extra underline before "Improve on Github" span

## Issue
No open issues regarding this

## Additional Information
NA


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] I have verified all tests and linters pass after making these changes.
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If applicable, this PR includes new or updated automated tests
