### PR TITLE
Chore: Show underline on "Improve on Github" link

### DIFF
--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -13,7 +13,7 @@
           <% component.with_footer do %>
             <%= link_to github_edit_url(@lesson), target: :_blank, rel: 'noreferrer noopener', class: 'text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 pr-5 text-sm' do %>
               <%= inline_svg_tag 'icons/github.svg', class: 'h-4 w-4 mr-1 inline', aria: true, title: 'Improve on GitHub', desc: 'Github logo icon' %>
-              <span class: 'underline hover:no-underline'>Improve on GitHub</span>
+              <span class="underline hover:no-underline">Improve on GitHub</span>
             <% end %>
 
             <%= link_to github_report_url(@lesson), target: :_blank, rel: 'noreferrer noopener', class: 'inline-flex items-center underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 pr-5 text-sm' do %>


### PR DESCRIPTION
Changed ; to = on span class

With reference to #4291. I mistakenly used colon with the class attribute for the span because I got confused with the lines above it. I am sorry for this and have edited it to put the equals (=) sign with the class attribute. The PR was merged and now the underline doesn't show under the link.
Before:
![image](https://github.com/TheOdinProject/theodinproject/assets/47951993/95f46c75-117a-4a61-99c0-efb5bc876bbf)

After:
![image](https://github.com/TheOdinProject/theodinproject/assets/47951993/36be164f-aae2-4abb-83e9-0f0bf9038112)



<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
Corrects earlier mistake

## This PR
- Corrects earlier mistake of using : instead of = 

## Issue
NA

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
#4291 

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] I have verified all tests and linters pass after making these changes.
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If applicable, this PR includes new or updated automated tests
