### PR TITLE
Fix: Ada's Social Link

### DIFF
--- a/config/locales/team.yml
+++ b/config/locales/team.yml
@@ -238,5 +238,5 @@ en:
 
         - name: "Ada Chiu"
           image: "https://avatars.githubusercontent.com/u/13413986?v=4"
-          url: "https://github.com/adachiu"
+          url: "https://x.com/adachiu_design?s=21&t=7GZYEoXo0zA059kKCNhTdA"
 


### PR DESCRIPTION
Because:
* It was accidentally changed in a previous PR