### PR TITLE
Add hashmap lesson

### DIFF
--- a/db/fixtures/lessons/javascript_lessons.rb
+++ b/db/fixtures/lessons/javascript_lessons.rb
@@ -283,15 +283,15 @@ def javascript_lessons
       github_path: '/javascript/finishing_up_with_javascript/conclusion.md',
       identifier_uuid: '4b881c82-4cba-4090-a819-17aac12ccb46',
     },
-    'HashMap' => {
-      title: 'HashMap',
+    'HashMap Data Structure' => {
+      title: 'HashMap Data Structure',
       description: 'Learn how a hash map works, to save and retrieve data',
       is_project: false,
       github_path: '/javascript/computer_science/hash_map_data_structure.md',
       identifier_uuid: 'create-uuid'
     },
-    'HashMap Project' => {
-      title: 'HashMap Project',
+    'HashMap' => {
+      title: 'HashMap',
       description: 'Build your very first hash map data structure from scratch',
       is_project: true,
       github_path: '/javascript/computer_science/project_hash_map.md',

--- a/db/fixtures/lessons/javascript_lessons.rb
+++ b/db/fixtures/lessons/javascript_lessons.rb
@@ -288,7 +288,7 @@ def javascript_lessons
       description: 'Learn how a hash map works, to save and retrieve data',
       is_project: false,
       github_path: '/javascript/computer_science/hash_map_data_structure.md',
-      identifier_uuid: 'create-uuid'
+      identifier_uuid: '7ab99479-0200-471f-8432-4a0f2df039b5'
     },
     'HashMap' => {
       title: 'HashMap',
@@ -297,7 +297,7 @@ def javascript_lessons
       github_path: '/javascript/computer_science/project_hash_map.md',
       accepts_submission: true,
       previewable: false,
-      identifier_uuid: 'create-uuid'
+      identifier_uuid: '90f1f539-fc40-46b2-91db-8c664934f5c4'
     },
   }
 end

--- a/db/fixtures/lessons/javascript_lessons.rb
+++ b/db/fixtures/lessons/javascript_lessons.rb
@@ -290,5 +290,14 @@ def javascript_lessons
       github_path: '/javascript/computer_science/hash_map_data_structure.md',
       identifier_uuid: 'create-uuid'
     },
+    'HashMap Project' => {
+      title: 'HashMap Project',
+      description: 'Build your very first hash map data structure from scratch',
+      is_project: true,
+      github_path: '/javascript/computer_science/project_hash_map.md',
+      accepts_submission: true,
+      previewable: false,
+      identifier_uuid: 'create-uuid'
+    },
   }
 end

--- a/db/fixtures/lessons/javascript_lessons.rb
+++ b/db/fixtures/lessons/javascript_lessons.rb
@@ -283,5 +283,12 @@ def javascript_lessons
       github_path: '/javascript/finishing_up_with_javascript/conclusion.md',
       identifier_uuid: '4b881c82-4cba-4090-a819-17aac12ccb46',
     },
+    'HashMap' => {
+      title: 'HashMap',
+      description: 'Learn how a hash map works, to save and retrieve data',
+      is_project: false,
+      github_path: '/javascript/computer_science/hash_map_data_structure.md',
+      identifier_uuid: 'create-uuid'
+    },
   }
 end

--- a/db/fixtures/lessons/ruby_lessons.rb
+++ b/db/fixtures/lessons/ruby_lessons.rb
@@ -318,15 +318,15 @@ def ruby_lessons
       previewable: false,
       identifier_uuid: 'cea1b51e-b97e-11eb-8529-0242ac130003',
     },
-    'HashMap' => {
-      title: 'HashMap',
+    'HashMap Data Structure' => {
+      title: 'HashMap Data Structure',
       description: 'Learn how a hash map works, to save and retrieve data',
       is_project: false,
       github_path: '/ruby/computer_science/hash_map_data_structure.md',
       identifier_uuid: 'create-uuid'
     },
-    'HashMap Project' => {
-      title: 'HashMap Project',
+    'HashMap' => {
+      title: 'HashMap',
       description: 'Build your very first hash map data structure from scratch',
       is_project: true,
       github_path: '/ruby/computer_science/project_hash_map.md',

--- a/db/fixtures/lessons/ruby_lessons.rb
+++ b/db/fixtures/lessons/ruby_lessons.rb
@@ -323,7 +323,7 @@ def ruby_lessons
       description: 'Learn how a hash map works, to save and retrieve data',
       is_project: false,
       github_path: '/ruby/computer_science/hash_map_data_structure.md',
-      identifier_uuid: 'create-uuid'
+      identifier_uuid: 'cdd4796c-4eed-498c-91a1-a673ba2c4cb8'
     },
     'HashMap' => {
       title: 'HashMap',
@@ -332,7 +332,7 @@ def ruby_lessons
       github_path: '/ruby/computer_science/project_hash_map.md',
       accepts_submission: true,
       previewable: false,
-      identifier_uuid: 'create-uuid'
+      identifier_uuid: '20b01618-5437-40c4-a362-8b5f51421b4d'
     },
   }
 end

--- a/db/fixtures/lessons/ruby_lessons.rb
+++ b/db/fixtures/lessons/ruby_lessons.rb
@@ -318,5 +318,21 @@ def ruby_lessons
       previewable: false,
       identifier_uuid: 'cea1b51e-b97e-11eb-8529-0242ac130003',
     },
+    'HashMap' => {
+      title: 'HashMap',
+      description: 'Learn how a hash map works, to save and retrieve data',
+      is_project: false,
+      github_path: '/ruby/computer_science/hash_map_data_structure.md',
+      identifier_uuid: 'create-uuid'
+    },
+    'HashMap Project' => {
+      title: 'HashMap Project',
+      description: 'Build your very first hash map data structure from scratch',
+      is_project: true,
+      github_path: '/ruby/computer_science/project_hash_map.md',
+      accepts_submission: true,
+      previewable: false,
+      identifier_uuid: 'create-uuid'
+    },
   }
 end

--- a/db/fixtures/paths/full_stack_javascript/courses/javascript.rb
+++ b/db/fixtures/paths/full_stack_javascript/courses/javascript.rb
@@ -95,6 +95,8 @@ course.add_section do |section|
     javascript_lessons.fetch('Space Complexity'),
     javascript_lessons.fetch('Common Data Structures and Algorithms'),
     javascript_lessons.fetch('Linked Lists'),
+    javascript_lessons.fetch('HashMap'),
+    javascript_lessons.fetch('HashMap Project'),
     javascript_lessons.fetch('Binary Search Trees'),
     javascript_lessons.fetch('Knights Travails'),
   )

--- a/db/fixtures/paths/full_stack_javascript/courses/javascript.rb
+++ b/db/fixtures/paths/full_stack_javascript/courses/javascript.rb
@@ -95,8 +95,8 @@ course.add_section do |section|
     javascript_lessons.fetch('Space Complexity'),
     javascript_lessons.fetch('Common Data Structures and Algorithms'),
     javascript_lessons.fetch('Linked Lists'),
+    javascript_lessons.fetch('HashMap Data Structure'),
     javascript_lessons.fetch('HashMap'),
-    javascript_lessons.fetch('HashMap Project'),
     javascript_lessons.fetch('Binary Search Trees'),
     javascript_lessons.fetch('Knights Travails'),
   )

--- a/db/fixtures/paths/full_stack_rails/courses/ruby.rb
+++ b/db/fixtures/paths/full_stack_rails/courses/ruby.rb
@@ -124,6 +124,8 @@ course.add_section do |section|
     ruby_lessons.fetch('Space Complexity'),
     ruby_lessons.fetch('Common Data Structures and Algorithms'),
     ruby_lessons.fetch('Linked Lists'),
+    ruby_lessons.fetch('HashMap Project'),
+    ruby_lessons.fetch('Binary Search Trees'),
     ruby_lessons.fetch('Binary Search Trees'),
     ruby_lessons.fetch('Knights Travails'),
   )

--- a/db/fixtures/paths/full_stack_rails/courses/ruby.rb
+++ b/db/fixtures/paths/full_stack_rails/courses/ruby.rb
@@ -124,8 +124,8 @@ course.add_section do |section|
     ruby_lessons.fetch('Space Complexity'),
     ruby_lessons.fetch('Common Data Structures and Algorithms'),
     ruby_lessons.fetch('Linked Lists'),
-    ruby_lessons.fetch('HashMap Project'),
-    ruby_lessons.fetch('Binary Search Trees'),
+    ruby_lessons.fetch('HashMap Data Structure'),
+    ruby_lessons.fetch('HashMap'),
     ruby_lessons.fetch('Binary Search Trees'),
     ruby_lessons.fetch('Knights Travails'),
   )


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
Add HashMap lesson related to https://github.com/TheOdinProject/curriculum/pull/26518

@01zulfi I have tested this locally, but only one lesson can be shown at a time, either the lesson or the project in both paths. I suspect this is because of the 'create_uuid' value that I'm using instead of actual ID. I believe more job should be done to copy the first generated ID into the db before creating the newer one, unless I have used the `create_uuid` wrongly, and I should run some function to actually generated the ID before I proceed. 

Let me know if that is the problem and I will work on it.


## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Add hashmap lesson and project to javascript db/fixture and db/path
- Add hashmap lesson and project to ruby db/fixture and db/path

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
