### PR TITLE
Move JSON lesson earlier in JavaScript course

### DIFF
--- a/db/fixtures/lessons/javascript_lessons.rb
+++ b/db/fixtures/lessons/javascript_lessons.rb
@@ -83,6 +83,13 @@ def javascript_lessons
       previewable: true,
       identifier_uuid: 'a1453e8f-d4e8-44ce-b30e-552c65162ac6',
     },
+    'JSON' => {
+      title: 'JSON',
+      description: 'JSON',
+      is_project: false,
+      github_path: '/javascript/organizing_your_javascript_code/json.md',
+      identifier_uuid: 'ae0d44bf-60b7-4644-b61e-216a4a6b271b',
+    },
     'OOP Principles' => {
       title: 'OOP Principles',
       description: 'OOP Principles',
@@ -126,13 +133,6 @@ def javascript_lessons
       is_project: false,
       github_path: '/javascript/javascript_in_the_real_world/what_is_es6.md',
       identifier_uuid: 'f5c4b108-adf8-41af-bf3b-a38dd409a67d',
-    },
-    'JSON' => {
-      title: 'JSON',
-      description: 'JSON',
-      is_project: false,
-      github_path: '/javascript/asynchronous_javascript_and_apis/json.md',
-      identifier_uuid: 'ae0d44bf-60b7-4644-b61e-216a4a6b271b',
     },
     'Asynchronous Code' => {
       title: 'Asynchronous Code',


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Learners are currently being introduced to JSON via localstorage in the Todo List project. People thought it made sense to have the lesson on JSON occur before this point.

See also: [this PR](https://github.com/TheOdinProject/curriculum/pull/27086) on the curriculum repo.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Moves the JSON lesson in the lesson fixtures.
- Updates the lesson's path to look in `/javascript/organizing_your_javascript_code/` rather than `/javascript/asynchronous_javascript_and_apis/`

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
