### PR TITLE
Add feature to display the number of projects in each section

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -33,4 +33,14 @@ module ApplicationHelper
   def unread_notifications?(user)
     user.notifications.any?(&:unread?)
   end
+
+  def project_count_for_course(course)
+    true_count = course.lessons.count(&:is_project)
+    content_tag(:span, "#{true_count} Projects", class: 'text-sm text-gray-500')
+  end
+
+  def lesson_count_for_course(course)
+    true_count = course.lessons.count { |lesson| !lesson.is_project }
+    content_tag(:span, "#{true_count} Lessons", class: 'text-sm text-gray-500')
+  end
 end

--- a/app/views/courses/_course.html.erb
+++ b/app/views/courses/_course.html.erb
@@ -14,7 +14,7 @@
           <h2 id="<%= course.title.parameterize %>" class="font-medium text-xl md:text-left text-gray-900 dark:text-gray-200">
             <%= course.title %>
           </h2>
-          <span class=" text-sm text-gray-500"><%= course.lessons.size %> Lessons</span>
+          <span class=" text-sm text-gray-500"><%= lesson_count_for_course(course) %> | <%= project_count_for_course(course) %></span>
         <% end %>
       </div>
 

--- a/app/views/courses/_course.html.erb
+++ b/app/views/courses/_course.html.erb
@@ -14,7 +14,7 @@
           <h2 id="<%= course.title.parameterize %>" class="font-medium text-xl md:text-left text-gray-900 dark:text-gray-200">
             <%= course.title %>
           </h2>
-          <span class=" text-sm text-gray-500"><%= lesson_count_for_course(course) %> | <%= project_count_for_course(course) %></span>
+          <span class="text-gray-500"><%= lesson_count_for_course(course) %> | <%= project_count_for_course(course) %></span>
         <% end %>
       </div>
 


### PR DESCRIPTION
Implementing a new feature to enhance the user experience by displaying the count of projects in each section. This feature addresses issue #4331 .

Changes made:
- Introduced two new helper method `project_count_for_course` & `lesson_count_for_course`  in the `ApplicationHelper` module to calculate the number of projects in a course.
- Updated the relevant view file(s) to utilize the new helper method for displaying the project count in each section.

![image](https://github.com/TheOdinProject/theodinproject/assets/116902652/bf832a4e-3c23-473c-b2a5-b5a85c07be7f)
