### PR TITLE
Chore: Bump fastruby manage-heroku-review-app action

### DIFF
--- a/.github/workflows/heroku-review-app-on-label.yml
+++ b/.github/workflows/heroku-review-app-on-label.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: fastruby/manage-heroku-review-app@v1.2
+      - uses: fastruby/manage-heroku-review-app@v1.3
         with:
           action: create
         env:
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: fastruby/manage-heroku-review-app@v1.2
+      - uses: fastruby/manage-heroku-review-app@v1.3
         with:
           action: destroy
         env:


### PR DESCRIPTION
Because:
- The manage-heroku-review-app maintainers have graciously made a change that will allow us to deploy pull requests from a forked origin.
- closes https://github.com/TheOdinProject/theodinproject/issues/3193