### PR TITLE
Fix: GitHub Webhook Lesson Import Job

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -2,7 +2,7 @@ ActiveAdmin.register_page 'Dashboard' do
   menu priority: 1, label: proc { I18n.t('active_admin.dashboard') }
 
   page_action :reseed, method: :post do
-    Lessons::ImportAllContentJob.perform_async
+    Lessons::ImportAllContentJob.perform_later
     redirect_to admin_dashboard_path, notice: 'Curriculum lesson import job running 🐢 Track the progress at /sidekiq'
   end
 

--- a/app/controllers/github_webhooks_controller.rb
+++ b/app/controllers/github_webhooks_controller.rb
@@ -6,7 +6,7 @@ class GithubWebhooksController < ApplicationController
   def github_push(payload)
     event = ::GithubPushEventAdaptor.new(payload)
 
-    Lessons::UpdateContentJob.perform_async(event.modified_urls) if event.merged_to_main?
+    Lessons::UpdateContentJob.perform_later(event.modified_urls) if event.merged_to_main?
   end
 
   private

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,5 +18,6 @@ module Theodinproject
     config.exceptions_app = routes
     config.middleware.insert_after ActionDispatch::Static, Rack::Deflater
     config.assets.css_compressor = nil
+    config.active_job.queue_adapter = :sidekiq
   end
 end


### PR DESCRIPTION
Because:
- The method for triggered them needed replaced with perform_later
- Missing config to use sidekiq as active jobs backend queue