### PR TITLE
Feature: Add delimiter to user count on About page

### DIFF
--- a/app/views/static_pages/about/_overview.html.erb
+++ b/app/views/static_pages/about/_overview.html.erb
@@ -5,7 +5,7 @@
     <div class="grid grid-cols-1 sm:grid-cols-3 gap-x-8 gap-y-16">
       <%= render CardComponent.new(classes: 'col-span-3 lg:col-span-1') do |card| %>
         <% card.with_body(classes: 'text-center') do %>
-          <p class="font-bold text-2xl"><%= User.count %></p>
+          <p class="font-bold text-2xl"><%= User.count.to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1,').reverse %></p>
           <p class="text-gray-500 dark:text-gray-400">Learners</p>
         <% end %>
       <% end %>

--- a/app/views/static_pages/about/_overview.html.erb
+++ b/app/views/static_pages/about/_overview.html.erb
@@ -5,7 +5,7 @@
     <div class="grid grid-cols-1 sm:grid-cols-3 gap-x-8 gap-y-16">
       <%= render CardComponent.new(classes: 'col-span-3 lg:col-span-1') do |card| %>
         <% card.with_body(classes: 'text-center') do %>
-          <p class="font-bold text-2xl"><%= User.count.to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1,').reverse %></p>
+          <p class="font-bold text-2xl"><%= number_with_delimiter(User.count) %></p>
           <p class="text-gray-500 dark:text-gray-400">Learners</p>
         <% end %>
       <% end %>


### PR DESCRIPTION
## Because
I was perusing the site and thought this tiny tweak could improve the readability of the user count on the About page.

## This PR
* Formats the `User.count` value in the Learners card to read `1,231,839` instead of `1231839`

## Issue
N/a

## Additional Information
None

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [ ] ~If this PR addresses an open issue, it is linked in the `Issue` section~
-   [ ] ~If applicable, this PR includes new or updated automated tests~
