### PR TITLE
Feature: Add clear feature to Markdown preview page

### DIFF
--- a/app/javascript/controllers/share_preview_controller.js
+++ b/app/javascript/controllers/share_preview_controller.js
@@ -18,6 +18,6 @@ export default class SharePreviewController extends Controller {
   }
 
   toggleButton() {
-    this.buttonTarget.classList.toggle('hidden', this.inputTarget.value.length === 0);
+    this.buttonTargets.forEach((button) => button.classList.toggle('hidden', this.inputTarget.value.length === 0));
   }
 }

--- a/app/javascript/controllers/share_preview_controller.js
+++ b/app/javascript/controllers/share_preview_controller.js
@@ -18,6 +18,6 @@ export default class SharePreviewController extends Controller {
   }
 
   toggleButton() {
-    this.buttonTargets.forEach((button) => button.classList.toggle('hidden', this.inputTarget.value.length === 0));
+    this.buttonTarget.classList.toggle('hidden', this.inputTarget.value.length === 0);
   }
 }

--- a/app/views/lessons/previews/show.html.erb
+++ b/app/views/lessons/previews/show.html.erb
@@ -18,13 +18,13 @@
               </button>
             </div>
             <div class="flex items-center mb-3">
-              <%= button_to lessons_preview_path, class: 'button button--secondary py-2 px-3', method: :get do %>
-                <%= inline_svg_tag 'icons/trash.svg', class: 'h-3 w-3 mr-2', aria: true, title: 'clear', desc: 'clear icon' %>
-                Clear
-              <% end %>
-              <%= button_to '#', class: 'hidden button button--secondary py-2 px-3 ml-2', method: :get, data: { share_preview_target: 'button', action: 'share-preview#share' } do %>
+              <%= button_to '#', class: 'hidden button button--secondary py-2 px-3', method: :get, data: { share_preview_target: 'button', action: 'share-preview#share' } do %>
                 <%= inline_svg_tag 'icons/share.svg', class: 'h-3 w-3 mr-2', aria: true, title: 'share', desc: 'share icon' %>
                 Share
+              <% end %>
+              <%= button_to lessons_preview_path, class: 'button button--secondary py-2 px-3 ml-2', method: :get do %>
+                <%= inline_svg_tag 'icons/trash.svg', class: 'h-3 w-3 mr-2', aria: true, title: 'clear', desc: 'clear icon' %>
+                Clear
               <% end %>
             </div>
           </div>

--- a/app/views/lessons/previews/show.html.erb
+++ b/app/views/lessons/previews/show.html.erb
@@ -10,18 +10,23 @@
         <div data-controller='tabs share-preview' data-share-preview-url-value="<%= lessons_preview_share_path(format: :turbo_stream) %>" data-tabs-index='0' data-tabs-active-class="text-gray-700 bg-gray-300/50 hover:bg-gray-300 dark:bg-gray-700/90" data-tabs-inactive-class="hidden">
           <div class="flex justify-between">
             <div class="flex items-center mb-3">
-              <button data-action="tabs#change" class="text-gray-600 bg-gray-300/50 hover:text-gray-800 hover:bg-gray-200 dark:bg-gray-700/40 dark:text-gray-300 rounded-md border border-transparent px-3 py-1.5 font-medium cursor-pointer focus:outline-none" data-tabs-target='tab'>
+              <button data-action="tabs#change" class="text-gray-600 bg-gray-300/50 hover:text-gray-800 hover:bg-gray-200 dark:bg-gray-700/40 dark:text-gray-300 dark:hover:text-gray-200 dark:hover:bg-gray-600 rounded-md border border-transparent px-3 py-1.5 font-medium cursor-pointer focus:outline-none" data-tabs-target='tab'>
                 Write
               </button>
-              <button data-action="tabs#change" class="ml-2 text-gray-600 hover:text-gray-800 hover:bg-gray-200 dark:bg-gray-700/40 dark:text-gray-300 rounded-md border border-transparent px-3 py-1.5 font-medium cursor-pointer focus:outline-none" data-tabs-target='tab'>
+              <button data-action="tabs#change" class="ml-2 text-gray-600 hover:text-gray-800 hover:bg-gray-200 dark:bg-gray-700/40 dark:text-gray-300 dark:hover:text-gray-200 dark:hover:bg-gray-600 rounded-md border border-transparent px-3 py-1.5 font-medium cursor-pointer focus:outline-none" data-tabs-target='tab'>
                 Preview
               </button>
             </div>
-
-            <%= button_to '#', class: 'hidden button button--secondary py-2 px-3', method: :get, data: { share_preview_target: 'button', action: 'share-preview#share' } do %>
-              <%= inline_svg_tag 'icons/share.svg', class: 'h-3 w-3 mr-2', aria: true, title: 'share', desc: 'share icon' %>
-              Share
-            <% end %>
+            <div class="flex items-center mb-3">
+              <%= button_to lessons_preview_path, class: 'hidden button button--secondary py-2 px-3', method: :get, data: { share_preview_target: 'button' } do %>
+                <%= inline_svg_tag 'icons/trash.svg', class: 'h-3 w-3 mr-2', aria: true, title: 'clear', desc: 'clear icon' %>
+                Clear
+              <% end %>
+              <%= button_to '#', class: 'hidden button button--secondary py-2 px-3 ml-2', method: :get, data: { share_preview_target: 'button', action: 'share-preview#share' } do %>
+                <%= inline_svg_tag 'icons/share.svg', class: 'h-3 w-3 mr-2', aria: true, title: 'share', desc: 'share icon' %>
+                Share
+              <% end %>
+            </div>
           </div>
 
           <div data-tabs-target="panel" class="mx-auto">

--- a/app/views/lessons/previews/show.html.erb
+++ b/app/views/lessons/previews/show.html.erb
@@ -18,7 +18,7 @@
               </button>
             </div>
             <div class="flex items-center mb-3">
-              <%= button_to lessons_preview_path, class: 'hidden button button--secondary py-2 px-3', method: :get, data: { share_preview_target: 'button' } do %>
+              <%= button_to lessons_preview_path, class: 'button button--secondary py-2 px-3', method: :get do %>
                 <%= inline_svg_tag 'icons/trash.svg', class: 'h-3 w-3 mr-2', aria: true, title: 'clear', desc: 'clear icon' %>
                 Clear
               <% end %>


### PR DESCRIPTION
## Because

Doing a hard refresh every time you make a change to the markdown you're testing is not the best experience and so is manually removing the markdown. Also, buttons in dark mode should be neatly highlighted!

## This PR

- Adds input clearing functionality
- Fixes lack of hover background colour change in dark mode

## Issue

nil

## Additional Information


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If applicable, this PR includes new or updated automated tests
