### PR TITLE
Feature: Separate Area for Admin v2

### DIFF
--- a/app/controllers/admin_v2/dashboard_controller.rb
+++ b/app/controllers/admin_v2/dashboard_controller.rb
@@ -1,0 +1,5 @@
+module AdminV2
+  class DashboardController < ApplicationController
+    def show; end
+  end
+end

--- a/app/views/admin_v2/dashboard/show.html.erb
+++ b/app/views/admin_v2/dashboard/show.html.erb
@@ -1,0 +1,1 @@
+<h1>Welcome to the Admin V2 Dashboard</h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   match '500' => 'errors#internal_server_error', via: :all
 
   draw(:redirects)
+  draw(:admin_v2)
   ActiveAdmin.routes(self)
 
   require 'sidekiq/web'

--- a/config/routes/admin_v2.rb
+++ b/config/routes/admin_v2.rb
@@ -1,0 +1,4 @@
+namespace :admin_v2 do
+  root to: 'dashboard#show'
+  resource :dashboard, only: :show, controller: :dashboard
+end

--- a/spec/system/admin_v2/dashboard_spec.rb
+++ b/spec/system/admin_v2/dashboard_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin V2 Dashboard' do
+  it 'displays the admin v2 dashboard' do
+    visit admin_v2_root_path
+
+    expect(page).to have_content('Welcome to the Admin V2 Dashboard')
+  end
+end


### PR DESCRIPTION
Because:
- We need a separate area and namespace for the new admin so we can work on building it out while keeping the current admin system running in parallel.

This commit:
- Adds a admin_v2 routes file where all new admin routes will be kept - to separate them from the user facing routes.
- Adds an admin v2 dashboard controller and view
- Adds a basic system test to make sure everything is wired up correctly - this will be changed to a more useful admin sign in spec in a follow up PR.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes https://github.com/TheOdinProject/theodinproject/issues/4266

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
