### PR TITLE
Chore: Only Update Likes Component When Using Likes

### DIFF
--- a/app/components/project_submissions/like_component.html.erb
+++ b/app/components/project_submissions/like_component.html.erb
@@ -1,5 +1,5 @@
 <%= turbo_frame_tag dom_id(project_submission, :likes) do %>
-  <%= button_to project_submission_like_path(project_submission), method: :put, disabled: current_users_submission, class: "mr-4 flex items-center #{'hint--top' unless current_users_submission}", data: { test_id: 'like-submission' }, aria: { label: 'Like submission' } do %>
+  <%= button_to project_submission_like_path(project_submission), method: :put, disabled: current_users_submission, class: "mr-4 flex items-center #{'hint--top' unless current_users_submission}", data: { test_id: 'like-submission' }, aria: { label: tooltip_text } do %>
     <span class="mr-1 text-sm text-gray-500 dark:text-gray-300" data-test-id="like-count"><%= project_submission.likes_count %></span>
     <%= inline_svg_tag 'icons/heart.svg', class: "h-5 w-5 #{bg_color_class}", aria: true, title: 'heart', desc: 'heart icon' %>
   <% end %>

--- a/app/components/project_submissions/like_component.rb
+++ b/app/components/project_submissions/like_component.rb
@@ -14,5 +14,11 @@ module ProjectSubmissions
 
       'stroke-gray-500 stroke-2 text-transparent'
     end
+
+    def tooltip_text
+      return 'Unlike solution' if current_users_submission || project_submission.liked?
+
+      'Like solution'
+    end
   end
 end

--- a/app/views/project_submissions/likes/create.turbo_stream.erb
+++ b/app/views/project_submissions/likes/create.turbo_stream.erb
@@ -1,3 +1,0 @@
-<%= turbo_stream.replace @project_submission do %>
-  <%= render ProjectSubmissions::ItemComponent.new(project_submission: @project_submission) %>
-<% end %>

--- a/app/views/project_submissions/likes/update.turbo_stream.erb
+++ b/app/views/project_submissions/likes/update.turbo_stream.erb
@@ -1,3 +1,3 @@
-<%= turbo_stream.replace @project_submission do %>
-  <%= render ProjectSubmissions::ItemComponent.new(project_submission: @project_submission) %>
+<%= turbo_stream.replace dom_id(@project_submission, :likes) do %>
+  <%= render ProjectSubmissions::LikeComponent.new(project_submission: @project_submission) %>
 <% end %>

--- a/spec/components/project_submissions/like_component_spec.rb
+++ b/spec/components/project_submissions/like_component_spec.rb
@@ -10,6 +10,15 @@ RSpec.describe ProjectSubmissions::LikeComponent, type: :component do
 
       expect(page).to have_css('.stroke-teal-700')
     end
+
+    it 'renders an "unlike" tooltip' do
+      project_submission = create(:project_submission, :liked)
+      component = described_class.new(project_submission:)
+
+      render_inline(component)
+
+      expect(page).to have_css('[aria-label="Unlike solution"]')
+    end
   end
 
   context 'when the the project submission is unliked' do
@@ -20,6 +29,15 @@ RSpec.describe ProjectSubmissions::LikeComponent, type: :component do
       render_inline(component)
 
       expect(page).to have_css('.stroke-gray-500')
+    end
+
+    it 'renders a "like" tooltip' do
+      project_submission = create(:project_submission, :unliked)
+      component = described_class.new(project_submission:)
+
+      render_inline(component)
+
+      expect(page).to have_css('[aria-label="Like solution"]')
     end
   end
 


### PR DESCRIPTION
Because:
- Previously we were replacing the entire solutions component when liking/unliking. We did that to allow the list to auto sort based on the likes count of each solution. But we have recently replaced auto sorting with a user controlled manual sort. This allows us to be more efficient with likes, and only send the HTML we need over the wire.

This commit:
* Update the likes component instead of the solutions component with Turbo when liking/unliking
* Removes the likes/create.turbo_stream.html view. This must have accidentally got into the codebase at some point, we only use an update action with likes.
* Updates the like icon tool tip to show an appropriate message based on the state - before it was only showing "Like submission"