### PR TITLE
Update convert_img to skip images with alt text of empty str

### DIFF
--- a/lib/kramdown/converter/odin_html.rb
+++ b/lib/kramdown/converter/odin_html.rb
@@ -8,7 +8,8 @@ module Kramdown
       EXTERNAL_LINK_ATTRIBUTES = { target: '_blank', rel: 'noopener noreferrer' }.freeze
 
       def convert_img(element, _indent)
-        return super if @stack.last.type == :a
+        
+        return super if @stack.last.type == :a or element.attr['alt'] == ""
 
         attributes = { href: element.attr['src'] }.merge(EXTERNAL_LINK_ATTRIBUTES)
         %(<a#{html_attributes(attributes)}>#{super}</a>)

--- a/spec/services/markdown_converter_spec.rb
+++ b/spec/services/markdown_converter_spec.rb
@@ -80,13 +80,25 @@ RSpec.describe MarkdownConverter do
     end
 
     context 'when the markdown contains images' do
-      it 'wraps images in links' do
+      it 'wraps images in links when alt attr is valid string' do
         markdown = <<~MARKDOWN
           ![an image](https://example.com/image.jpeg)
         MARKDOWN
 
         html_result = <<~HTML
           <p><a href="https://example.com/image.jpeg" target="_blank" rel="noopener noreferrer"><img src="https://example.com/image.jpeg" alt="an image" /></a></p>
+        HTML
+
+        expect(described_class.new(markdown).as_html).to eq(html_result)
+      end
+
+      it 'does not wrap images in links when alt attr is empty string' do
+        markdown = <<~MARKDOWN
+          ![](https://example.com/image.jpeg){: alt=""}
+        MARKDOWN
+
+        html_result = <<~HTML
+          <p><img src="https://example.com/image.jpeg" alt="" /></p>
         HTML
 
         expect(described_class.new(markdown).as_html).to eq(html_result)


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Currently we wrap *every* image in an anchor element so that it can be opened in a new window, in order to potentially see a larger version of the image (if it's been scaled down to fit within the context of a lesson). There's going to be instances when we don't want to do that, such as when an image is purely decorative with an empty string alt text.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Updates the convert_img to skip images with `alt=""`
- Adds a test to ensure the above works as intended

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
@KevinMulhern lmk if there's a better way to grab the alt text of the img that's attempted to being converted in this function. 

There may be other issues we may want to consider with wrapping images in anchors in the first place:

- Is it clear that clicking the image opens the image in a new tab for the full sized version? Or could it be misconstrued as an image link, e.g. the TOP logo being an "image" that links to the home page.
- Would it be an issue that opening the image in a new tab results in the image having no `alt` attribute applied; this may be a bit out of our control, as even opening the image in a new tab via right clicking > "Open image in a new tab" results in this issue.

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [ ] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [ ] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [ ] The `Because` section summarizes the reason for this PR
-   [ ] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] I have verified all tests and linters pass after making these changes.
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If applicable, this PR includes new or updated automated tests
