### PR TITLE
Fix: Community & Installation Guides: Make full cards clickable

### DIFF
--- a/app/views/guides/community/show.html.erb
+++ b/app/views/guides/community/show.html.erb
@@ -5,7 +5,7 @@
   <section class="max-w-xl mx-auto space-y-5">
     <% @guides.each do |guide| %>
       <%= render CardComponent.new(classes: 'transistion dark:hover:bg-gray-700 hover:bg-gray-100') do |card| %>
-        <% card.with_body(classes: 'p-0') do %>
+        <% card.with_body(classes: 'px-0 py-0') do %>
           <%= link_to guide.path, class: 'p-4 block' do %>
             <div class="flex items-center gap-3">
               <%= inline_svg 'icons/book.svg', alt: 'lesson icon', class: 'w-6 dark:text-gray-500 text-gray-400 shrink-0', title: 'Guide' %>

--- a/app/views/guides/community/show.html.erb
+++ b/app/views/guides/community/show.html.erb
@@ -5,8 +5,8 @@
   <section class="max-w-xl mx-auto space-y-5">
     <% @guides.each do |guide| %>
       <%= render CardComponent.new(classes: 'transistion dark:hover:bg-gray-700 hover:bg-gray-100') do |card| %>
-        <% card.with_body(classes: 'py-4 px-4') do %>
-          <%= link_to guide.path do %>
+        <% card.with_body(classes: 'p-0') do %>
+          <%= link_to guide.path, class: 'p-4 block' do %>
             <div class="flex items-center gap-3">
               <%= inline_svg 'icons/book.svg', alt: 'lesson icon', class: 'w-6 dark:text-gray-500 text-gray-400 shrink-0', title: 'Guide' %>
                 <p class="text-gray-600 dark:text-gray-300">

--- a/app/views/guides/installations/index.html.erb
+++ b/app/views/guides/installations/index.html.erb
@@ -5,7 +5,7 @@
   <section class="max-w-xl mx-auto space-y-5">
     <% @lessons.each do |lesson| %>
       <%= render CardComponent.new(classes: 'transistion dark:hover:bg-gray-700 hover:bg-gray-100') do |card| %>
-        <% card.with_body(classes: 'p-0') do %>
+        <% card.with_body(classes: 'px-0 py-0') do %>
           <%= link_to lesson_path(lesson), class: 'p-4 block' do %>
             <div class="flex items-center gap-3">
               <%= inline_svg 'icons/book.svg', alt: 'lesson icon', class: 'w-6 dark:text-gray-500 text-gray-400 shrink-0', title: 'Lesson' %>

--- a/app/views/guides/installations/index.html.erb
+++ b/app/views/guides/installations/index.html.erb
@@ -5,8 +5,8 @@
   <section class="max-w-xl mx-auto space-y-5">
     <% @lessons.each do |lesson| %>
       <%= render CardComponent.new(classes: 'transistion dark:hover:bg-gray-700 hover:bg-gray-100') do |card| %>
-        <% card.with_body(classes: 'py-4 px-4') do %>
-          <%= link_to lesson_path(lesson) do %>
+        <% card.with_body(classes: 'p-0') do %>
+          <%= link_to lesson_path(lesson), class: 'p-4 block' do %>
             <div class="flex items-center gap-3">
               <%= inline_svg 'icons/book.svg', alt: 'lesson icon', class: 'w-6 dark:text-gray-500 text-gray-400 shrink-0', title: 'Lesson' %>
                 <p class="text-gray-600 dark:text-gray-300">


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
For both the installation guide index and the community guide show page, the full size for the card links isn't clickable. Here's a quick gif of what I mean:

![guide_links](https://github.com/TheOdinProject/theodinproject/assets/88392688/76772799-6eb5-4f9d-9983-8ccd5e6be79e)

Or, a link to the relevant pages to try for yourself:
- [installations](https://www.theodinproject.com/guides/installations)
- [community guides](https://www.theodinproject.com/guides/community)

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Styles these cards such that their links are clickable along the full height and width of the card.

Another quick gif with my changes:
![guide_links_fix](https://github.com/TheOdinProject/theodinproject/assets/88392688/97e8cc56-ebfb-43ce-b458-1d7eb85a2724)


## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If applicable, this PR includes new or updated automated tests
