### PR TITLE
Feature: Re-enable auto-sorting when like value changes.

### DIFF
--- a/app/components/project_submissions/item_component.html.erb
+++ b/app/components/project_submissions/item_component.html.erb
@@ -1,4 +1,12 @@
-<div id="<%= dom_id(project_submission) %>" data-test-id="submission-item">
+<div
+  id="<%= dom_id(project_submission) %>"
+  data-controller="project-submissions--item"
+  data-test-id="submission-item"
+  data-id="<%= project_submission.id %>"
+  data-autosort-target="item"
+  data-project-submissions--item-like-count-value="<%= project_submission.likes_count %>"
+  data-sort-code="<%= project_submission.likes_count %>">
+
   <div class="relative py-6 flex flex-col md:flex-row justify-between md:items-center">
 
     <div class="flex items-center mb-4 md:mb-0">

--- a/app/components/project_submissions/item_controller.js
+++ b/app/components/project_submissions/item_controller.js
@@ -1,0 +1,25 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+  static targets = ['likeCount'];
+
+  static values = {
+    likeCount: String,
+  };
+
+  likeCountTargetConnected(element) {
+    const currentLikeCount = element.innerText;
+
+    if (currentLikeCount !== this.likeCountValue) {
+      this.likeCountValue = currentLikeCount;
+    }
+  }
+
+  likeCountValueChanged(value) {
+    const sortCode = this.element.dataset.sortCode
+
+    if (sortCode != value) {
+      this.element.dataset.sortCode = value;
+    }
+  }
+}

--- a/app/components/project_submissions/like_component.html.erb
+++ b/app/components/project_submissions/like_component.html.erb
@@ -1,6 +1,9 @@
 <%= turbo_frame_tag dom_id(project_submission, :likes) do %>
   <%= button_to project_submission_like_path(project_submission), method: :put, disabled: current_users_submission, class: "mr-4 flex items-center #{'hint--top' unless current_users_submission}", data: { test_id: 'like-submission' }, aria: { label: tooltip_text } do %>
-    <span class="mr-1 text-sm text-gray-500 dark:text-gray-300" data-test-id="like-count"><%= project_submission.likes_count %></span>
+    <span class="mr-1 text-sm text-gray-500 dark:text-gray-300" data-project-submissions--item-target="likeCount" data-test-id="like-count">
+      <%= project_submission.likes_count %>
+    </span>
+
     <%= inline_svg_tag 'icons/heart.svg', class: "h-5 w-5 #{bg_color_class}", aria: true, title: 'heart', desc: 'heart icon' %>
   <% end %>
 <% end %>

--- a/app/javascript/controllers/autosort_controller.js
+++ b/app/javascript/controllers/autosort_controller.js
@@ -1,0 +1,62 @@
+import { Controller } from '@hotwired/stimulus';
+import Sortable from 'sortablejs';
+import { useMutation } from 'stimulus-use';
+
+export default class extends Controller {
+  static targets = ['item'];
+
+  static values = {
+    canSort: { type: Boolean, default: false },
+  };
+
+  connect() {
+    if (this.canSortValue) {
+      this.sortable = Sortable.create(this.element, {
+        animation: 300,
+        easing: 'cubic-bezier(0.61, 1, 0.88, 1)',
+        disabled: true,
+      });
+
+      useMutation(this, {
+        attributes: true, childList: true, subtree: true, attributeFilter: ['data-sort-code'],
+      });
+    }
+  }
+
+  mutate(entries) {
+    entries.forEach((mutation) => {
+      if (mutation.type === 'attributes' && mutation.attributeName === 'data-sort-code') {
+        this.sortItems();
+      }
+    });
+  }
+
+  sortItems() {
+    const items = Array.from(this.itemTargets);
+
+    if (this.itemsAreSorted(items)) return;
+
+    const sortedItems = items.sort((a, b) => this.compareItems(a, b)).map((item) => item.dataset.id);
+    this.sortable.sort(sortedItems, true);
+  }
+
+  itemsAreSorted() {
+    return this.itemSortCodes().every((sortCode, index, items) => {
+      if (index === 0) return true;
+      return sortCode <= items[index - 1];
+    });
+  }
+
+  itemSortCodes() {
+    return this.itemTargets.map((item) => this.getSortCode(item));
+  }
+
+  /* eslint-disable class-methods-use-this */
+  getSortCode(item) {
+    return parseFloat(item.getAttribute('data-sort-code')) || 0;
+  }
+
+  compareItems(left, right) {
+    return this.getSortCode(right) - this.getSortCode(left);
+  }
+}

--- a/app/views/lessons/project_submissions/index.html.erb
+++ b/app/views/lessons/project_submissions/index.html.erb
@@ -39,7 +39,7 @@
         <% card.with_body(classes: 'py-4 px-4') do %>
           <% if @project_submissions.any? %>
 
-            <div class="divide-y">
+            <div class="divide-y" data-controller="autosort" data-autosort-can-sort-value="<%= params[:sort] == 'likes_count' %>">
               <% @project_submissions.each do |project_submission| %>
                 <%= render ProjectSubmissions::ItemComponent.new(project_submission:) %>
               <% end %>


### PR DESCRIPTION
Because:
- Previously, we would auto sort the solutions by their likes count when a like value changed.
- We removed it because it was thought to be redundant with manual sorting now available.
- A staff member mentioned missing it, so its back!

This commit:
- Only auto-sort if the current manual sort value is by like count - we don't want this kicking in when users want to see lists ordered by newest or oldest.
- Adds an item controller for solutions which will handle updating the sort code when a like value changes.
- Reinstate the removed auto sort controller which will now observe for any mutations to the sort codes of each item.

