### PR TITLE
Fix: fix typo in flag column

### DIFF
--- a/app/admin/flags.rb
+++ b/app/admin/flags.rb
@@ -34,7 +34,7 @@ ActiveAdmin.register Flag do
         Flag::REASONS.find { |reason| reason.name.to_s == reason_flag.reason }&.description
       end
       row :extra
-      row :submission_ower do
+      row :submission_owner do
         flag.project_submission.user.username
       end
       row :lesson do


### PR DESCRIPTION
## Because
There is a typo in the submission owner column of an flag: ower instead of owner


## This PR
Corrects the typo.


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.