### PR TITLE
Feature: Add copy button to Bash codesnippets

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,7 @@
   "plugins": [
     ["prismjs", {
         "languages": ["ruby", "javascript", "css", "markup", "sql", "erb", "jsx", "diff"],
-        "plugins": ["line-numbers"],
+        "plugins": ["line-numbers", "toolbar", "copy-to-clipboard"],
         "css": true
     }]
   ]

--- a/app/assets/stylesheets/stylesheets/prism-theme.css
+++ b/app/assets/stylesheets/stylesheets/prism-theme.css
@@ -33,6 +33,10 @@ code[class*=language-] {
   white-space: normal
 }
 
+pre.highlight:not(.language-bash) + .toolbar {
+  display: none;
+}
+
 .token.block-comment,
 .token.cdata,
 .token.comment,


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
It can be helpful to copy long and involved bash commands 


## This PR
- Adds a copy button to all code snippets
- Uses CSS to hide said button for all languages except bash


## Issue
Closes #4416

## Additional Information
Two notes:

- The way the CSS works, its hiding the entire toolbar, not just the copy button. The advantage of this is that we don't end up with a bunch of empty divs where the toolbar should be. The disadvantage is that if we ever add something else to that toolbar that would also get hidden, and it might not be immediately obvious why.
- I'm not entirely convinced by how the button actually works, but I think a possible redesign would be better suited for a follow up PR.


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section