### PR TITLE
Chore: Enable eager loading in CI

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -14,7 +14,7 @@ Rails.application.configure do
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = false
+  config.eager_load = ENV['CI'].present?
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true


### PR DESCRIPTION
Because:
- In the event a file cannot be loaded, CI will now let us know