### PR TITLE
Chore: Remove Capybara JavaScript driver config

### DIFF
--- a/spec/support/cuprite.rb
+++ b/spec/support/cuprite.rb
@@ -24,7 +24,6 @@ Capybara.register_driver(:odin_cuprite) do |app|
 end
 
 Capybara.default_driver = :odin_cuprite
-Capybara.javascript_driver = :odin_cuprite
 
 RSpec.configure do |config|
   config.prepend_before(:each, type: :system) do


### PR DESCRIPTION
Because:
- We use Cuprite for all our tests and don't need the JavaScript driver to be set separately.