### PR TITLE
Chore: Remove data attributes from sort component

### DIFF
--- a/app/components/sort_component.html.erb
+++ b/app/components/sort_component.html.erb
@@ -20,7 +20,7 @@
 
       <% options.each do |option| %>
         <li class="text-gray-900 dark:text-gray-200 relative cursor-default select-none py-2 pl-8 pr-4" id="listbox-option-0" role="option">
-          <%= link_to request.params.merge(sort: option.fetch(:value), direction: option.fetch(:direction)), role: 'menuitem', tabindex: '-1', data: tag.attributes(data: data_attributes) do %>
+          <%= link_to request.params.merge(sort: option.fetch(:value), direction: option.fetch(:direction)), role: 'menuitem', tabindex: '-1' do %>
             <span class="font-normal text-sm block <%= 'font-semibold' if selected?(option) %>"><%= option.fetch(:label) %> </span>
           <% end %>
           <% if selected?(option) %>

--- a/app/components/sort_component.rb
+++ b/app/components/sort_component.rb
@@ -1,8 +1,7 @@
 class SortComponent < ApplicationComponent
-  def initialize(options:, selected: {}, data_attributes: {})
+  def initialize(options:, selected: {})
     @options = options
     @selected = selected
-    @data_attributes = data_attributes
   end
 
   def selected_option
@@ -15,7 +14,7 @@ class SortComponent < ApplicationComponent
 
   private
 
-  attr_reader :options, :selected, :data_attributes
+  attr_reader :options, :selected
 
   def selected?(option)
     return option[:default] if selected.compact.empty?

--- a/app/views/lessons/project_submissions/index.html.erb
+++ b/app/views/lessons/project_submissions/index.html.erb
@@ -25,7 +25,6 @@
           <div class="w-64">
             <%= render SortComponent.new(
                   selected: { value: params[:sort], direction: params[:direction] },
-                  data_attributes: { turbo_frame: 'submissions-list' },
                   options: [
                     { value: 'created_at', label: 'Newest', direction: 'desc', default: true },
                     { value: 'created_at', label: 'Oldest', direction: 'asc', default: false },


### PR DESCRIPTION
Because:
- We only use the data attributes parameter to pass in the turbo frame the sort should change. But, the sort component is already inside of the turbo frame it changes.