### PR TITLE
Feature: Admin v2 flag details page

### DIFF
--- a/app/controllers/admin_v2/base_controller.rb
+++ b/app/controllers/admin_v2/base_controller.rb
@@ -1,6 +1,7 @@
 # rubocop:disable Rails/ApplicationController
 module AdminV2
   class BaseController < ActionController::Base
+    helper(Classy::Yaml::Helpers)
     include Pagy::Backend
     include CurrentTheme
 

--- a/app/controllers/admin_v2/flags_controller.rb
+++ b/app/controllers/admin_v2/flags_controller.rb
@@ -3,5 +3,15 @@ module AdminV2
     def index
       @pagy, @flags = pagy(Flag.by_status(params.fetch(:status, 'active')), items: 20)
     end
+
+    def show
+      @flag = Flag.find(params[:id])
+    end
+
+    def update
+      @flag = Flag.find(params[:id])
+      flash[:notice] = "Flag #{params[:action_taken]}"
+      redirect_to admin_v2_flag_path(@flag)
+    end
   end
 end

--- a/app/javascript/controllers/option_selector_controller.js
+++ b/app/javascript/controllers/option_selector_controller.js
@@ -1,0 +1,24 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class OptionSelector extends Controller {
+  static targets = ['option', 'buttonText', 'button', 'resetButton'];
+
+  connect() {
+    this.initialButtonText = this.buttonTarget.textContent;
+  }
+
+  select(event) {
+    this.optionTargets.forEach((element) => element.removeAttribute('data-selected', 'false'));
+    event.currentTarget.setAttribute('data-selected', 'true');
+    this.buttonTextTarget.textContent = `Confirm ${event.currentTarget.dataset.name}`;
+    this.buttonTarget.removeAttribute('disabled');
+    this.resetButtonTarget.classList.remove('hidden');
+  }
+
+  reset() {
+    this.optionTargets.forEach((element) => element.removeAttribute('data-selected', 'true'));
+    this.buttonTextTarget.textContent = this.initialButtonText;
+    this.buttonTarget.setAttribute('disabled', 'true');
+    this.resetButtonTarget.classList.add('hidden');
+  }
+}

--- a/app/views/admin_v2/flags/_actions.html.erb
+++ b/app/views/admin_v2/flags/_actions.html.erb
@@ -1,0 +1,42 @@
+<%= form_with url: admin_v2_flag_path(flag), method: :put, data: { controller: 'option-selector' } do |form| %>
+  <div class="flex gap-x-3 items-center">
+     <%= form.button 'Cancel', type: 'reset', data: { action: 'option-selector#reset', option_selector_target: 'resetButton' }, class: 'button button--secondary p-2 hidden font-semibold' %>
+
+    <label id="listbox-label" class="sr-only">Action flag</label>
+    <div class="relative" data-controller="visibility" data-action="visibility:click:outside->visibility#off">
+
+      <div class="inline-flex divide-x divide-teal-800 rounded-md shadow-sm">
+        <%= form.button disabled: true, data: { option_selector_target: 'button' }, class: 'inline-flex rounded-l-md bg-teal-700 px-3 py-2 text-white shadow-sm' do %>
+
+          <p class="text-sm font-semibold" data-option-selector-target="buttonText"><%= flag.taken_action.capitalize %></p>
+        <% end %>
+
+        <button data-action="click->visibility#toggle" type="button" class="inline-flex items-center rounded-l-none rounded-r-md bg-teal-700 p-2 hover:bg-teal-800 focus:outline-none" aria-haspopup="listbox" aria-expanded="true" aria-labelledby="listbox-label">
+          <span class="sr-only">Action the flag</span>
+          <%= inline_svg_tag 'icons/chevron-down.svg', class: 'h-5 w-5 text-white', aria: true %>
+        </button>
+      </div>
+
+      <ul data-visibility-target="content" class="absolute hidden sm:right-0 z-10 mt-2 w-72 origin-top-right divide-y divide-gray-200 overflow-hidden rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none" tabindex="-1" role="listbox" aria-labelledby="listbox-label" aria-activedescendant="listbox-option-0">
+        <% t('flag_actions').each do |flag_action| %>
+          <li class="text-gray-900 cursor-pointer hover:bg-gray-50 p-4 text-sm group" data-option-selector-target="option" data-name="<%= flag_action[:name] %>" data-action="click->option-selector#select" id="listbox-option-0" role="option">
+            <%= form.radio_button :action_taken, flag_action[:value], class: 'hidden' %>
+
+            <%= form.label :"action_taken_#{flag_action[:value]}", class: 'cursor-pointer' do %>
+              <div class="flex flex-col">
+                <div class="flex justify-between">
+                  <p class="font-normal group-data-[selected=true]:font-semibold"><%= flag_action[:name] %></p>
+                  <span class="text-teal-700 hidden group-data-[selected=true]:block">
+                    <%= inline_svg_tag 'icons/check.svg', class: 'h-5 w-5', aria: true %>
+                  </span>
+                </div>
+
+                <p class="text-gray-500 mt-2"><%= flag_action[:description] %></p>
+              </div>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+<% end %>

--- a/app/views/admin_v2/flags/show.html.erb
+++ b/app/views/admin_v2/flags/show.html.erb
@@ -1,0 +1,63 @@
+<div class="max-w-4xl">
+
+  <div class="sm:flex items-center justify-between">
+    <div class="sm:flex-auto flex gap-x-2">
+      <h1 class="text-xl font-semibold leading-6 text-gray-900">Flag #<%= @flag.id %></h1>
+      <span>&middot</span>
+      <span>
+        <%= render Ui::BadgeComponent.new(color: @flag.resolved? ? 'green' : 'yellow') do %>
+          <%= @flag.status.capitalize %>
+        <% end %>
+      </span>
+    </div>
+
+    <div class="pt-2 sm:pt-0">
+      <%= render 'admin_v2/flags/actions', flag: @flag %>
+    </div>
+  </div>
+
+  <div>
+    <div class="mt-6 border-t border-gray-100">
+      <dl class="divide-y divide-gray-100">
+        <div class="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
+          <dt class="text-sm font-medium leading-6 text-gray-900">Reason</dt>
+          <dd class="mt-1 text-sm leading-6 text-gray-700 sm:col-span-2 sm:mt-0"><%= Flag::REASONS.find { |reason| reason.name.to_s == @flag.reason }&.description %></dd>
+        </div>
+
+        <div class="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
+          <dt class="text-sm font-medium leading-6 text-gray-900">Extra information</dt>
+          <dd class="mt-1 text-sm leading-6 text-gray-700 sm:col-span-2 sm:mt-0"><%= @flag.extra %></dd>
+        </div>
+
+        <div class="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
+          <dt class="text-sm font-medium leading-6 text-gray-900">Project submission repo</dt>
+          <dd class="mt-1 text-sm leading-6 text-gray-700 sm:col-span-2 sm:mt-0">
+            <%= link_to @flag.project_submission.repo_url, @flag.project_submission.repo_url, class: 'text-blue-600 underline hover:text-blue-500' %>
+          </dd>
+        </div>
+
+        <div class="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
+          <dt class="text-sm font-medium leading-6 text-gray-900">Project submission live preview</dt>
+          <dd class="mt-1 text-sm leading-6 text-gray-700 sm:col-span-2 sm:mt-0">
+            <%= link_to @flag.project_submission.live_preview_url, @flag.project_submission.live_preview_url, class: 'text-blue-600 underline hover:text-blue-500' %>
+          </dd>
+        </div>
+
+        <div class="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
+          <dt class="text-sm font-medium leading-6 text-gray-900">Project</dt>
+          <dd class="mt-1 text-sm leading-6 text-gray-700 sm:col-span-2 sm:mt-0"><%= link_to @flag.project_submission.lesson.title, lesson_path(@flag.project_submission.lesson), class: 'text-blue-600 underline hover:text-blue-500' %></dd>
+        </div>
+
+        <div class="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
+          <dt class="text-sm font-medium leading-6 text-gray-900">Who owns the project submission?</dt>
+          <dd class="mt-1 text-sm leading-6 text-gray-700 sm:col-span-2 sm:mt-0"><%= @flag.project_submission.user.username %></dd>
+        </div>
+
+        <div class="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
+          <dt class="text-sm font-medium leading-6 text-gray-900">Who created the flag?</dt>
+          <dd class="mt-1 text-sm leading-6 text-gray-700 sm:col-span-2 sm:mt-0"><%= @flag.flagger.username %></dd>
+        </div>
+      </dl>
+    </div>
+  </div>
+</div>

--- a/config/locales/flag_actions.yml
+++ b/config/locales/flag_actions.yml
@@ -1,0 +1,17 @@
+en:
+  flag_actions:
+    - value: dismiss
+      name: Dismiss
+      description: Theres no action to be taken. Mark this flag as dismissed
+
+    - value: ban
+      name: Ban User
+      description: Ban the user who submitted this project and hide all their solutions
+
+    - value: removed_project_submission
+      name: Remove Project Submission
+      description: Remove the project submission from the site
+
+    - value: notified_user
+      name: Send Broken Link Notification
+      description: Send the user who submitted this project a notification asking them to fix the broken link

--- a/config/routes/admin_v2.rb
+++ b/config/routes/admin_v2.rb
@@ -4,5 +4,5 @@ namespace :admin_v2 do
   root to: 'dashboard#show'
   resource :dashboard, only: :show, controller: :dashboard
 
-  resources :flags, only: %i[index show]
+  resources :flags, only: %i[index show update]
 end


### PR DESCRIPTION
Because:
- We are building a new Admin system and need a flag details page where we can handle individual flags
- related to https://github.com/TheOdinProject/top-meta/issues/291
- 
This commit:
- Adds a flag details view
- Flag actions will be chosen from a select instead of displayed as separate buttons

New UI for selecting choosing what action to take:

https://github.com/TheOdinProject/theodinproject/assets/7963776/e32d73d0-c120-4784-bb05-65163de38a61



Overall Page:
<img width="1198" alt="Screenshot 2024-04-01 at 17 05 42" src="https://github.com/TheOdinProject/theodinproject/assets/7963776/470c739d-3249-4205-9443-d0dcdc7f758c">


