### PR TITLE
Fix: Script tags could execute in from previews

### DIFF
--- a/app/views/lessons/previews/_markdown_preview.html.erb
+++ b/app/views/lessons/previews/_markdown_preview.html.erb
@@ -1,7 +1,7 @@
 <div id="preview-container">
   <%= render ContentContainerComponent.new(classes: 'pt-6') do %>
     <% if markdown.present? %>
-      <%= MarkdownConverter.new(markdown).as_html.html_safe %>
+      <%= sanitize MarkdownConverter.new(markdown).as_html %>
     <% else %>
       <p>Nothing to preview yet!</p>
     <% end %>


### PR DESCRIPTION
Because:
- We weren't sanitizing HTML within the outputted preview.
- Thanks to @Asartea for the report

This commit:
- Run the output through Rails's [sanitize](https://api.rubyonrails.org/classes/ActionView/Helpers/SanitizeHelper.html#method-i-sanitize) helper.

Notes
I tried a few different approaches with this:

Scrubbing the output before storing it proved to be very difficult. We're storing the content in markdown which makes it hard to differentiate legitimate script elements that will be displayed within code examples vs top level malicious script elements.

But, scrubbing the output before rendering should be enough to mitigate this issue.