### PR TITLE
Fix: Details and summary tags not working on preview tool

### DIFF
--- a/app/components/markdown/preview_component.html.erb
+++ b/app/components/markdown/preview_component.html.erb
@@ -1,7 +1,7 @@
 <div id="preview-container">
   <%= render ContentContainerComponent.new(classes: 'pt-6') do %>
     <% if markdown.present? %>
-      <%= sanitize MarkdownConverter.new(markdown).as_html %>
+      <%= sanitize MarkdownConverter.new(markdown).as_html, tags: allowed_tags %>
     <% else %>
       <p>Nothing to preview yet!</p>
     <% end %>

--- a/app/components/markdown/preview_component.rb
+++ b/app/components/markdown/preview_component.rb
@@ -1,0 +1,13 @@
+class Markdown::PreviewComponent < ApplicationComponent
+  def initialize(markdown: '')
+    @markdown = markdown
+  end
+
+  def allowed_tags
+    Rails::HTML5::SafeListSanitizer::DEFAULT_ALLOWED_TAGS + %w[details summary]
+  end
+
+  private
+
+  attr_reader :markdown
+end

--- a/app/views/lessons/previews/create.turbo_stream.erb
+++ b/app/views/lessons/previews/create.turbo_stream.erb
@@ -1,3 +1,3 @@
 <%= turbo_stream.replace 'preview-container' do %>
-  <%= render 'lessons/previews/markdown_preview', markdown: @preview.content %>
+  <%= render Markdown::PreviewComponent.new(markdown: @preview.content) %>
 <% end %>

--- a/app/views/lessons/previews/show.html.erb
+++ b/app/views/lessons/previews/show.html.erb
@@ -36,7 +36,7 @@
           </div>
 
           <div data-tabs-target="panel" class="min-h-screen">
-          <%= render 'lessons/previews/markdown_preview', markdown: @preview.content %>
+            <%= render Markdown::PreviewComponent.new(markdown: @preview.content) %>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Because:
- We are sanitising the input, but the Rails sanitiser does not include details and summary tags in its default safe list
- Closes: https://github.com/TheOdinProject/theodinproject/issues/4488

This commit:
- Overrides the Rails Sanitiser DEFAULT_ALLOWED_TAGS array to include details and summary tags
- Moves the preview partial into a component to group the allowed tags logic with the preview.