### PR TITLE
Fix: Sections not being inserted into liver preview

### DIFF
--- a/app/components/markdown/preview_component.html.erb
+++ b/app/components/markdown/preview_component.html.erb
@@ -1,7 +1,7 @@
 <div id="preview-container">
   <%= render ContentContainerComponent.new(classes: 'pt-6') do %>
     <% if markdown.present? %>
-      <%= sanitize MarkdownConverter.new(markdown).as_html, tags: allowed_tags %>
+      <%= sanitize MarkdownConverter.new(markdown).as_html, tags: allowed_tags, attributes: allowed_attributes %>
     <% else %>
       <p>Nothing to preview yet!</p>
     <% end %>

--- a/app/components/markdown/preview_component.rb
+++ b/app/components/markdown/preview_component.rb
@@ -4,7 +4,11 @@ class Markdown::PreviewComponent < ApplicationComponent
   end
 
   def allowed_tags
-    Rails::HTML5::SafeListSanitizer::DEFAULT_ALLOWED_TAGS + %w[details summary]
+    Rails::HTML5::SafeListSanitizer::DEFAULT_ALLOWED_TAGS + %w[details summary section]
+  end
+
+  def allowed_attributes
+    Rails::HTML5::SafeListSanitizer::DEFAULT_ALLOWED_ATTRIBUTES + %w[id]
   end
 
   private


### PR DESCRIPTION
Because:
- Sections and their ids are being striped out of live previews by Rails sanitiser.

This commit:
- Allow sections and ids within live previews