### PR TITLE
Feature: Add new lessons from ESM/Webpack restructure to both pathways

### DIFF
--- a/db/fixtures/lessons/javascript_lessons.rb
+++ b/db/fixtures/lessons/javascript_lessons.rb
@@ -65,7 +65,7 @@ def javascript_lessons
       description: 'ES6 Modules',
       is_project: false,
       github_path: '/javascript/organizing_your_javascript_code/es6_modules.md',
-      identifier_uuid: '0169e4d1-e381-49e0-897b-f9364ac10e51',
+      identifier_uuid: 'ab4b6ccf-42e6-429e-a21b-0ef07bbb886e',
     },
     'npm' => {
       title: 'npm',
@@ -79,7 +79,7 @@ def javascript_lessons
       description: 'Webpack',
       is_project: false,
       github_path: '/javascript/organizing_your_javascript_code/webpack.md',
-      identifier_uuid: 'eedfa6c8-b041-497d-ab37-565708a1b075',
+      identifier_uuid: '3d7e10dc-6795-471d-937a-f4b50c5872f0',
     },
     'Restaurant Page' => {
       title: 'Restaurant Page',

--- a/db/fixtures/lessons/javascript_lessons.rb
+++ b/db/fixtures/lessons/javascript_lessons.rb
@@ -67,6 +67,13 @@ def javascript_lessons
       github_path: '/javascript/organizing_your_javascript_code/es6_modules.md',
       identifier_uuid: '0169e4d1-e381-49e0-897b-f9364ac10e51',
     },
+    'npm' => {
+      title: 'npm',
+      description: 'npm',
+      is_project: false,
+      github_path: '/javascript/organizing_your_javascript_code/npm.md',
+      identifier_uuid: 'bec8407e-22fb-4106-8bdf-4f65b29c1365',
+    },
     'Webpack' => {
       title: 'Webpack',
       description: 'Webpack',

--- a/db/fixtures/lessons/javascript_lessons.rb
+++ b/db/fixtures/lessons/javascript_lessons.rb
@@ -88,7 +88,7 @@ def javascript_lessons
       description: 'Revisiting Webpack',
       is_project: false,
       github_path: '/javascript/organizing_your_javascript_code/revisiting_webpack.md',
-      identifier_uuid: 'create_uuid',
+      identifier_uuid: '16848c3e-0320-4c7b-9d0d-3a3f0c902730',
     },
     'JSON' => {
       title: 'JSON',

--- a/db/fixtures/lessons/javascript_lessons.rb
+++ b/db/fixtures/lessons/javascript_lessons.rb
@@ -83,6 +83,13 @@ def javascript_lessons
       previewable: true,
       identifier_uuid: 'a1453e8f-d4e8-44ce-b30e-552c65162ac6',
     },
+    'Revisiting Webpack' => {
+      title: 'Revisiting Webpack',
+      description: 'Revisiting Webpack',
+      is_project: false,
+      github_path: '/javascript/organizing_your_javascript_code/revisiting_webpack.md',
+      identifier_uuid: 'create_uuid',
+    },
     'JSON' => {
       title: 'JSON',
       description: 'JSON',

--- a/db/fixtures/paths/full_stack_javascript/courses/javascript.rb
+++ b/db/fixtures/paths/full_stack_javascript/courses/javascript.rb
@@ -39,6 +39,7 @@ course.add_section do |section|
     javascript_lessons.fetch('Tic Tac Toe'),
     javascript_lessons.fetch('Classes'),
     javascript_lessons.fetch('ES6 Modules'),
+    javascript_lessons.fetch('npm'),
     javascript_lessons.fetch('Webpack'),
     javascript_lessons.fetch('Restaurant Page'),
     javascript_lessons.fetch('Revisiting Webpack'),

--- a/db/fixtures/paths/full_stack_javascript/courses/javascript.rb
+++ b/db/fixtures/paths/full_stack_javascript/courses/javascript.rb
@@ -41,6 +41,7 @@ course.add_section do |section|
     javascript_lessons.fetch('ES6 Modules'),
     javascript_lessons.fetch('Webpack'),
     javascript_lessons.fetch('Restaurant Page'),
+    javascript_lessons.fetch('Revisiting Webpack'),
     javascript_lessons.fetch('JSON'),
     javascript_lessons.fetch('OOP Principles'),
     javascript_lessons.fetch('Todo List'),

--- a/db/fixtures/paths/full_stack_rails/courses/javascript.rb
+++ b/db/fixtures/paths/full_stack_rails/courses/javascript.rb
@@ -38,6 +38,7 @@ course.add_section do |section|
     javascript_lessons.fetch('Tic Tac Toe'),
     javascript_lessons.fetch('Classes'),
     javascript_lessons.fetch('ES6 Modules'),
+    javascript_lessons.fetch('npm'),
     javascript_lessons.fetch('Webpack'),
     javascript_lessons.fetch('Restaurant Page'),
     javascript_lessons.fetch('Revisiting Webpack'),

--- a/db/fixtures/paths/full_stack_rails/courses/javascript.rb
+++ b/db/fixtures/paths/full_stack_rails/courses/javascript.rb
@@ -40,6 +40,7 @@ course.add_section do |section|
     javascript_lessons.fetch('ES6 Modules'),
     javascript_lessons.fetch('Webpack'),
     javascript_lessons.fetch('Restaurant Page'),
+    javascript_lessons.fetch('Revisiting Webpack'),
     javascript_lessons.fetch('JSON'),
     javascript_lessons.fetch('OOP Principles'),
     javascript_lessons.fetch('Todo List'),


### PR DESCRIPTION
## Because

In [curriculum #27953](https://github.com/TheOdinProject/curriculum/pull/27953) and [curriculum #27962](https://github.com/TheOdinProject/curriculum/pull/27962), two new lessons are being added as part of a larger ESM/Webpack rewrite + split.

## This PR

- Adds the new Revisiting Webpack lesson details
- Adds the new npm lesson details
- Adds these new lesson to both pathways' lesson lists

## Issue

N/A

## Additional Information

This will be something to only be merged after the following 3 PRs have been merged:
- (https://github.com/TheOdinProject/curriculum/pull/27953)
- (https://github.com/TheOdinProject/curriculum/pull/27961)
- (https://github.com/TheOdinProject/curriculum/pull/27962)

## Pull Request Requirements

-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If applicable, this PR includes new or updated automated tests
