### PR TITLE
Feature: add Ruby Project Management and Linting lessons

### DIFF
--- a/db/fixtures/lessons/ruby_lessons.rb
+++ b/db/fixtures/lessons/ruby_lessons.rb
@@ -135,6 +135,20 @@ def ruby_lessons
       github_path: '/ruby/object_oriented_programming_basics/object_oriented_programming.md',
       identifier_uuid: '15924a5e-c72d-44f9-8546-78b05b903274',
     },
+    'Project Management' => {
+      title: 'Project Management',
+      description: 'This lesson goes over managing Ruby projects and installing Gems.',
+      is_project: false,
+      github_path: '/ruby/object_oriented_programming_basics/managing_ruby_projects.md',
+      identifier_uuid: 'edfa2f6a-6534-41e9-bc2d-a1253bcc1c41',
+    },
+    'Linting and RuboCop' => {
+      title: 'Linting and RuboCop',
+      description: 'This lesson goes over importance of rules and how to follow them with the help of RuboCop.',
+      is_project: false,
+      github_path: '/ruby/object_oriented_programming_basics/linting_and_rubocop.md',
+      identifier_uuid: 'd0fefa97-3201-474c-9636-3592fb9399d8',
+    },
     'Tic Tac Toe' => {
       title: 'Tic Tac Toe',
       description: "It's time to flex those new muscles a bit by building Tic Tac Toe",

--- a/db/fixtures/paths/full_stack_rails/courses/ruby.rb
+++ b/db/fixtures/paths/full_stack_rails/courses/ruby.rb
@@ -73,6 +73,8 @@ course.add_section do |section|
 
   section.add_lessons(
     ruby_lessons.fetch('Object Oriented Programming'),
+    ruby_lessons.fetch('Project Management'),
+    ruby_lessons.fetch('Linting and RuboCop'),
     ruby_lessons.fetch('Tic Tac Toe'),
     ruby_lessons.fetch('Mastermind'),
   )


### PR DESCRIPTION
## Because
It'd be cool to have those lessons.


## This PR
- Adds those lessons so they actually show up in the curriculum!


## Issue
Related:
- https://github.com/TheOdinProject/curriculum/issues/27026
- https://github.com/TheOdinProject/curriculum/issues/27091

## Additional Information
Please merge these first:
- https://github.com/TheOdinProject/curriculum/pull/28040
- https://github.com/TheOdinProject/curriculum/pull/28041

Also, for all the poor WSL2 souls that have failing rspec tests:
Do not follow Cliver error output. It won't be happy with a wslpath'd Chrome on Windows side. At least, it wasn't in my case. Just install Chrome in WSL2 and it'll be happy.

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If applicable, this PR includes new or updated automated tests
