### PR TITLE
Chore: Remove old/invalid Homepage projects

### DIFF
--- a/lib/tasks/data_migrations/remove_old_homepage_submissions.rake
+++ b/lib/tasks/data_migrations/remove_old_homepage_submissions.rake
@@ -1,0 +1,19 @@
+namespace :data_migrations do
+  desc 'Remove old Homepage project submissions'
+  task remove_old_homepage_submissions: :environment do
+    homepage_project = Lesson.find_by!(title: 'Homepage')
+    submissions = homepage_project.project_submissions.where('created_at < ?', 3.months.ago)
+
+    puts "removing #{submissions.count} old Homepage submissions"
+
+    progressbar = ProgressBar.create(total: submissions.count, format: '%t: |%w%i| Completed: %c %a %e')
+
+    submissions.find_each do |submission|
+      submission.destroy!
+    rescue StandardError => e
+      progressbar.log "Error with submission ##{submission.id}: #{e.message}"
+    ensure
+      progressbar.increment
+    end
+  end
+end


### PR DESCRIPTION
Because:
- We previously changed the instructions to clarify the solution learners submit for the Homepage project should not be their personal portfolio. But, many of the older submission are still personal portfolios, and we think they could be causing some confusion with learners submitting new solutions.

This commit
- Adds a data migration to remove any solutions attached to the Homepage project that were submitted more than  3 months ago.


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
