### PR TITLE
Chore: Update Flipper

### DIFF
--- a/db/migrate/20240529212213_change_flipper_gates_value_to_text.rb
+++ b/db/migrate/20240529212213_change_flipper_gates_value_to_text.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class ChangeFlipperGatesValueToText < ActiveRecord::Migration[7.0]
+  def up
+    # Ensure this incremental update migration is idempotent
+    return unless connection.column_exists? :flipper_gates, :value, :string
+
+    if index_exists? :flipper_gates, %i[feature_key key value]
+      remove_index :flipper_gates, %i[feature_key key value]
+    end
+    change_column :flipper_gates, :value, :text
+    add_index :flipper_gates, %i[feature_key key value], unique: true, length: { value: 255 }
+  end
+
+  def down
+    change_column :flipper_gates, :value, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_17_115443) do
+ActiveRecord::Schema[7.0].define(version: 2024_05_29_212213) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
   create_table "active_admin_comments", id: :serial, force: :cascade do |t|
@@ -108,7 +107,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_17_115443) do
   create_table "flipper_gates", force: :cascade do |t|
     t.string "feature_key", null: false
     t.string "key", null: false
-    t.string "value"
+    t.text "value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true


### PR DESCRIPTION
because:
- The latest version of Flipper wants us to run a provided db migration which changes flipper gate values to text

