### PR TITLE
Chore: Improve feature flags DX

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -25,3 +25,6 @@ load './db/seeds/test_admins.rb'
 
 # GENERATE course lesson and project counts
 load './db/seeds/update_course_counts.rb'
+
+# ADDS new feature flags to Flipper
+load './db/seeds/feature_flags.rb'

--- a/db/seeds/feature_flags.rb
+++ b/db/seeds/feature_flags.rb
@@ -1,0 +1,27 @@
+FEATURE_FLAGS = %i[].freeze
+
+# Add any new feature flags
+FEATURE_FLAGS.each do |flag|
+  next if Flipper.exist?(flag)
+
+  puts "🚀 Adding feature flag: #{flag}"
+  Flipper.add(flag)
+end
+
+# By default, always enable feature flags in development and staging environments
+if Rails.env.development? || ENV['STAGING'] == 'true'
+  FEATURE_FLAGS.each do |flag|
+    next if Flipper.enabled?(flag)
+
+    puts "🚀 Enabling feature flag: #{flag}"
+    Flipper.enable(flag)
+  end
+end
+
+# Remove any feature flags that are no longer needed
+Flipper.features.each do |feature|
+  next if FEATURE_FLAGS.include?(feature.key.to_sym)
+
+  puts "🗑 Removing feature flag: #{feature.key}"
+  feature.remove
+end


### PR DESCRIPTION
Because:
- We have to manually add new feature flags through admin in every environment
- We will usually always  want feature flags to be enabled in dev and staging environments
- We have to manually delete old feature flags through the UI

This commit:
Adds a feature_flags seeds file where we can add new feature flags which will then...
- Add any new feature flags from the FEATURE_FLAGS array to Flipper
- Enable feature flags in dev and staging environments by default
- Remove any feature flags from Flipper that are no longer in the FEATURE_FLAGS array.
