### PR TITLE
Feature: Admin v2 announcement index screen

### DIFF
--- a/app/controllers/admin_v2/announcements_controller.rb
+++ b/app/controllers/admin_v2/announcements_controller.rb
@@ -1,0 +1,7 @@
+module AdminV2
+  class AnnouncementsController < AdminV2::BaseController
+    def index
+      @pagy, @announcements = pagy(Announcement.for_status(params.fetch(:status, :active)).ordered_by_recent, items: 20)
+    end
+  end
+end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -2,8 +2,17 @@ class Announcement < ApplicationRecord
   validates :message, presence: true
   validates :expires_at, presence: true
 
-  scope :unexpired_messages, -> { where(expires_at: Time.zone.now..Float::INFINITY).order(created_at: :desc) }
-  scope :showable_messages, ->(disabled_ids) { unexpired_messages.where.not(id: disabled_ids) }
+  scope :active, -> { where(expires_at: Time.zone.now..).order(created_at: :desc) }
+  scope :expired, -> { where(expires_at: ...Time.zone.now) }
+  scope :showable_messages, ->(disabled_ids) { active.where.not(id: disabled_ids) }
+  scope :ordered_by_recent, -> { order(created_at: :desc) }
 
   belongs_to :user, optional: true
+
+  def self.for_status(status)
+    {
+      active:,
+      expired:
+    }.fetch(status.to_sym) { active }
+  end
 end

--- a/app/views/admin_v2/announcements/index.html.erb
+++ b/app/views/admin_v2/announcements/index.html.erb
@@ -1,0 +1,77 @@
+<div class="max-w-5xl w-full mx-auto">
+  <div class="sm:flex sm:items-center max-w-5xl">
+    <div class="sm:flex-auto">
+      <h1 class="text-xl font-semibold leading-6 text-gray-900">Announcements</h1>
+      <p class="mt-2 text-sm text-gray-700">Announcements displayed to everyone on the site as a banner.</p>
+    </div>
+  </div>
+
+  <div class="mt-6">
+    <span class="isolate inline-flex rounded-md shadow-sm space-x-2">
+      <% %w[active expired].each do |status| %>
+        <%= link_to(
+              "#{Announcement.for_status(status).count} #{status.capitalize}",
+              admin_v2_announcements_path(status:),
+              class: [
+                'relative inline-flex items-center rounded-md px-3 py-2 text-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus:z-10',
+                'text-gray-800 bg-gray-100': params.fetch(:status, 'active') == status,
+                'text-gray-600 bg-white': params[:status] && params[:status] != status,
+              ]
+            ) %>
+        <% end %>
+    </span>
+  </div>
+
+  <div class="mt-8 flow-root">
+    <% if @announcements.any? %>
+      <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 max-w-5xl px-6">
+        <div class="inline-block min-w-full py-2 align-middle">
+          <table class="min-w-full divide-y divide-gray-300">
+            <thead>
+              <tr>
+                <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-0">Message</th>
+                <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Created</th>
+                <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">Expires</th>
+                <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-0"><span class="sr-only">Edit</span></th>
+              </tr>
+            </thead>
+
+            <tbody class="divide-y divide-gray-200">
+              <% @announcements.each do |announcement | %>
+                <tr>
+                  <td class=" px-3 py-4 text-xs text-gray-500 max-w-xl">
+                    <%= announcement.message %>
+                  </td>
+
+                  <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                    <span title="<%= announcement.created_at %>">
+                      <%= time_ago_in_words(announcement.created_at) %> ago
+                    </span>
+                  </td>
+
+                  <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                    <span title="<%= announcement.expires_at %>">
+                      <%= announcement.expires_at.strftime('%B %d, %Y') %>
+                    </span>
+                  </td>
+
+                  <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-0">
+                    <%= link_to 'Edit', admin_v2_announcement_path(announcement), class: 'underline hover:text-gray-800 hover:no-underline' %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+
+          <%= render Admin::PaginationComponent.new(pagy: @pagy, resource_name: 'announcements') %>
+        </div>
+      </div>
+
+    <% else %>
+      <div class="mt-6 flex flex-col items-center space-y-2 pt-10">
+        <%= inline_svg_tag 'icons/megaphone.svg', class: 'h-16 w-16 text-gray-400', aria: true %>
+        <p class="text-xl text-gray-500 leading-6"> No <%= params.fetch(:status, 'active') %> announcements found!</p>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/layouts/admin_v2/_sidebar_nav.html.erb
+++ b/app/views/layouts/admin_v2/_sidebar_nav.html.erb
@@ -2,7 +2,7 @@
 nav_links = [
   { name: 'Dashboard', path: admin_v2_root_path, icon: 'home' },
   { name: 'Flags', path: admin_v2_flags_path, icon: 'flag-outline' },
-  { name: 'Announcements', path: '#', icon: 'megaphone' }
+  { name: 'Announcements', path: admin_v2_announcements_path, icon: 'megaphone' }
 ]
 %>
 

--- a/config/routes/admin_v2.rb
+++ b/config/routes/admin_v2.rb
@@ -5,4 +5,5 @@ namespace :admin_v2 do
   resource :dashboard, only: :show, controller: :dashboard
 
   resources :flags, only: %i[index show update]
+  resources :announcements
 end

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -4,15 +4,24 @@ RSpec.describe Announcement do
   it { is_expected.to validate_presence_of(:message) }
   it { is_expected.to validate_presence_of(:expires_at) }
 
-  describe '.unexpired_messages' do
-    it 'returns unexpired messages' do
+  describe '.active' do
+    it 'returns active announcements' do
       announcement_expires_tomorrow = create(:announcement, expires_at: 1.day.from_now)
       announcement_expires_next_week = create(:announcement, expires_at: 1.week.from_now)
       create(:announcement, expires_at: 1.hour.ago)
 
-      expect(described_class.unexpired_messages).to contain_exactly(
+      expect(described_class.active).to contain_exactly(
         announcement_expires_tomorrow, announcement_expires_next_week
       )
+    end
+  end
+
+  describe '.expired' do
+    it 'returns expired messages' do
+      create(:announcement, expires_at: 1.day.from_now)
+      expired_announcement = create(:announcement, expires_at: 1.hour.ago)
+
+      expect(described_class.expired).to contain_exactly(expired_announcement)
     end
   end
 
@@ -27,6 +36,44 @@ RSpec.describe Announcement do
       expect(described_class.showable_messages(disabled_announcement_ids)).to contain_exactly(
         unseen_unexpired_message
       )
+    end
+  end
+
+  describe '.ordered_by_recent' do
+    it 'returns messages ordered by created_at in descending order' do
+      announcement1 = create(:announcement, created_at: 1.day.ago)
+      announcement2 = create(:announcement, created_at: 1.hour.ago)
+      announcement3 = create(:announcement, created_at: 1.week.ago)
+
+      expect(described_class.ordered_by_recent).to eq([announcement2, announcement1, announcement3])
+    end
+  end
+
+  describe '.for_status' do
+    context 'when status is active' do
+      it 'returns active announcements' do
+        active_announcement = create(:announcement, expires_at: 1.day.from_now)
+        create(:announcement, expires_at: 1.day.ago)
+
+        expect(described_class.for_status('active')).to contain_exactly(active_announcement)
+      end
+    end
+
+    context 'when status is expired' do
+      it 'returns expired announcements' do
+        create(:announcement, expires_at: 1.day.from_now)
+        expired_announcement = create(:announcement, expires_at: 1.day.ago)
+
+        expect(described_class.for_status('expired')).to contain_exactly(expired_announcement)
+      end
+    end
+
+    context 'when status is unknown' do
+      it 'defaults to active announcements' do
+        active_announcement = create(:announcement, expires_at: 1.day.from_now)
+
+        expect(described_class.for_status('unknown')).to contain_exactly(active_announcement)
+      end
     end
   end
 end


### PR DESCRIPTION
Because:
- As an admin, I want to see and manage all announcements
- Relates to: https://github.com/TheOdinProject/top-meta/issues/291

This commit:
- Adds announcements controller and index view to admin v2
- Allows filtering between active and expired announcements
- Renames announcement `unexpired_messages` scope to `active`