### PR TITLE
Fix: Phantom timeout flash notice.

### DIFF
--- a/app/components/alerts/flash_component.rb
+++ b/app/components/alerts/flash_component.rb
@@ -1,14 +1,19 @@
 class Alerts::FlashComponent < ApplicationComponent
+  DISSALLOWED_TYPES = %i[timedout].freeze
+
   def initialize(type:, message:)
     @type = type.to_sym
     @message = message
+  end
+
+  def render?
+    DISSALLOWED_TYPES.exclude?(type)
   end
 
   def icon_path
     {
       alert: 'icons/exclamation-circle-solid.svg',
       notice: 'icons/checkmark-circle-solid.svg',
-      timedout: 'icons/exclamation-circle-solid.svg'
     }.fetch(type)
   end
 

--- a/spec/components/alerts/flash_component_spec.rb
+++ b/spec/components/alerts/flash_component_spec.rb
@@ -22,4 +22,12 @@ RSpec.describe Alerts::FlashComponent, type: :component do
       expect(page).to have_content('Success!')
     end
   end
+
+  context 'when the type is dissallowed' do
+    it 'does not render the flash' do
+      component = described_class.new(type: 'timedout', message: 'Timed out')
+
+      expect(render_inline(component).inner_html).to eq('')
+    end
+  end
 end


### PR DESCRIPTION
Because
- This is a bug with devise - https://github.com/heartcombo/devise/issues/1777
- When you are timed out, a flash will appear with "true" as the message
<img width="548" alt="Screenshot 2024-06-15 at 17 50 07" src="https://github.com/TheOdinProject/theodinproject/assets/7963776/9932355d-e3f8-453b-b5b6-7defb394c750">

This commit
- Do not render the flash component if the type is "timedout"