### PR TITLE
Chore: Refactor flag actions to use value objects

### DIFF
--- a/app/components/flags/action_button_component.html.erb
+++ b/app/components/flags/action_button_component.html.erb
@@ -11,15 +11,15 @@
       <ul data-controller="disable" data-visibility-target="content" class="absolute hidden right-0 z-10 mt-2 sm:w-[500px] origin-top-right divide-y divide-gray-200 overflow-hidden rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none" tabindex="-1" role="listbox" aria-labelledby="listbox-label" aria-activedescendant="listbox-option-0">
         <div class="divide-y divide-gray-200 dark:divide-gray-600 space-y-6">
           <div class="space-y-4 px-4 pt-6">
-            <% t('flag_actions').each do |flag_action| %>
+            <% Flags::Action.each do |flag_action| %>
               <div class="relative flex items-start">
                 <div class="absolute flex h-6 items-center">
-                  <%= form.radio_button :action_taken, flag_action.fetch(:value), class: 'h-4 w-4 border-gray-300 dark:border-gray-500 dark:bg-gray-700/50 dark:checked:bg-gold-600 dark:checked:border-gold-600 dark:focus:ring-offset-gray-800 text-gold-600 focus:ring-gold-600', data: { action: 'click->disable#enable' } %>
+                  <%= form.radio_button :action_taken, flag_action.value, class: 'h-4 w-4 border-gray-300 dark:border-gray-500 dark:bg-gray-700/50 dark:checked:bg-gold-600 dark:checked:border-gold-600 dark:focus:ring-offset-gray-800 text-gold-600 focus:ring-gold-600', data: { action: 'click->disable#enable' } %>
                 </div>
 
                 <div class="pl-7 text-sm leading-6">
-                  <%= form.label :"action_taken_#{flag_action.fetch(:value)}", flag_action.fetch(:name), class: 'font-semibold text-gray-800 dark:text-gray-200' %>
-                  <p class="text-gray-500 dark:text-gray-400 text-xs"><%= flag_action.fetch(:description) %></p>
+                  <%= form.label :"action_taken_#{flag_action.value}", flag_action.name, class: 'font-semibold text-gray-800 dark:text-gray-200' %>
+                  <p class="text-gray-500 dark:text-gray-400 text-xs"><%= flag_action.description %></p>
                 </div>
               </div>
             <% end %>

--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -34,4 +34,8 @@ class Flag < ApplicationRecord
       resolved_by_id: resolved_by.id
     )
   end
+
+  def action_taken
+    Flags::Action.for(taken_action)
+  end
 end

--- a/app/models/flags/action.rb
+++ b/app/models/flags/action.rb
@@ -1,0 +1,15 @@
+Flags::Action = Data.define(:value, :name, :description, :past_tense) do
+  include Enumerable
+
+  def self.all
+    I18n.t('flag_actions').map { |action| new(**action) }
+  end
+
+  def self.each(&block)
+    all.each(&block)
+  end
+
+  def self.for(value)
+    all.find { |action| action.value == value }
+  end
+end

--- a/app/views/admin_v2/flags/index.html.erb
+++ b/app/views/admin_v2/flags/index.html.erb
@@ -70,7 +70,7 @@
                   </td>
 
                   <% if params[:status] == "resolved" %>
-                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= flag.taken_action %></td>
+                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500"><%= flag.action_taken.past_tense %></td>
                   <% end %>
                   <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-0">
                     <%= link_to 'View', admin_v2_flag_path(flag), class: 'underline hover:text-gray-800 hover:no-underline' %>

--- a/app/views/admin_v2/flags/show.html.erb
+++ b/app/views/admin_v2/flags/show.html.erb
@@ -10,7 +10,7 @@
 
         <% if @flag.resolved? %>
           <%= render Ui::BadgeComponent.new(color: 'gray') do %>
-            <%= t('flag_actions').find { |action| action[:value] == @flag.taken_action }.fetch(:past_tense).capitalize %>
+            <%= @flag.action_taken.past_tense %>
           <% end %>
         <% end %>
       </div>

--- a/config/locales/flag_actions.yml
+++ b/config/locales/flag_actions.yml
@@ -3,19 +3,19 @@ en:
     - value: dismiss
       name: Dismiss
       description: Theres no action to be taken. Mark this flag as dismissed
-      past_tense: dismissed
+      past_tense: Dismissed
 
     - value: ban
       name: Ban User
       description: Ban the user who submitted this project and hide all their solutions
-      past_tense: banned
+      past_tense: Banned
 
     - value: removed_project_submission
       name: Remove Project Submission
       description: Remove the project submission from the site
-      past_tense: project submission removed
+      past_tense: Project submission removed
 
     - value: notified_user
       name: Send Broken Link Notification
       description: Send the user who submitted this project a notification asking them to fix the broken link
-      past_tense: notified
+      past_tense: Notified

--- a/spec/models/flag_spec.rb
+++ b/spec/models/flag_spec.rb
@@ -83,4 +83,12 @@ RSpec.describe Flag do
         .and change { flag.taken_action }.from('pending').to('dismiss')
     end
   end
+
+  describe '#action_taken' do
+    it 'returns a value object for the taken_action' do
+      flag.taken_action = 'dismiss'
+
+      expect(flag.action_taken).to be_a(Flags::Action)
+    end
+  end
 end

--- a/spec/models/flags/action_spec.rb
+++ b/spec/models/flags/action_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Flags::Action do
+  describe '.all' do
+    it 'returns all available flag actions' do
+      expect(described_class.all.map(&:value)).to eq(
+        I18n.t('flag_actions').pluck(:value)
+      )
+    end
+  end
+
+  describe '.for' do
+    it 'returns the flag action for the given value' do
+      expect(described_class.for('dismiss').value).to eq('dismiss')
+    end
+  end
+end


### PR DESCRIPTION
Because:
- We were relying on primitive hashes for flag actions in multiple places.