### PR TITLE
Feature: Add link to lesson commit history

### DIFF
--- a/app/helpers/lessons_helper.rb
+++ b/app/helpers/lessons_helper.rb
@@ -3,6 +3,10 @@ module LessonsHelper
     github_link("curriculum/edit/main#{lesson.github_path}")
   end
 
+  def github_commits_url(lesson)
+    github_link("curriculum/commits/main#{lesson.github_path}")
+  end
+
   def github_report_url(lesson)
     params = {
       labels: 'Status: Needs Triage',

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -22,9 +22,7 @@
             <% end %>
 
             <%= link_to github_commits_url(@lesson), target: :_blank, rel: 'noreferrer noopener', class: 'underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 text-sm ml-auto text-right' do %>
-              Last updated <time datetime=<%= @lesson.updated_at.to_date %>><%= time_ago_in_words(@lesson.updated_at) %></time> ago
-              <br>
-              (see changelog)
+              See lesson changelog
             <% end %>
           <% end %>
         <% end %>

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -20,6 +20,12 @@
               <%= inline_svg_tag 'icons/flag.svg', class: 'h-4 w-4 mr-1 inline', aria: true, title: 'Report an issue', desc: 'Report icon' %>
               <span>Report an issue</span>
             <% end %>
+
+            <%= link_to github_commits_url(@lesson), target: :_blank, rel: 'noreferrer noopener', class: 'underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 text-sm ml-auto text-right' do %>
+              Last updated <time datetime=<%= @lesson.updated_at.to_date %>><%= time_ago_in_words(@lesson.updated_at) %></time> ago
+              <br>
+              (see changelog)
+            <% end %>
           <% end %>
         <% end %>
 

--- a/spec/helpers/lessons_helper_spec.rb
+++ b/spec/helpers/lessons_helper_spec.rb
@@ -11,6 +11,16 @@ RSpec.describe LessonsHelper do
     end
   end
 
+  describe '#github_commits_url' do
+    let(:lesson) { create(:lesson) }
+
+    it 'returns the github commits url for the lesson' do
+      expect(helper.github_commits_url(lesson)).to eql(
+        'https://github.com/TheOdinProject/curriculum/commits/main/lesson_course/lesson_title.md'
+      )
+    end
+  end
+
   describe '#github_report_url' do
     let(:course) { create(:course, title: 'Test Course1') }
     let(:lesson) { create(:lesson, title: 'Ruby Basics', course:) }


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
It would be good to see when a lesson was last updated and go directly to the lesson's commit history to see the changelog, directly from the lesson page itself. This should help alleviate some confusion when something in the lesson changes when someone is midway through - they'll now be able to see that it was changed and find out what the change was, without having to go to GitHub of their own accord and navigate through the files to find out.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Adds a github commit url helper method
- Adds a link to the GitHub lesson links at the end of a lesson page, showing the time of last update, and linking to that lesson's commit history.


## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #XXXXX

## Additional Information

![image](https://github.com/TheOdinProject/theodinproject/assets/122839503/bf03640b-f751-4816-a053-f3ee09e07b8d)



## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If applicable, this PR includes new or updated automated tests
