### PR TITLE
Feature: Admin v2 back to flags link

### DIFF
--- a/app/assets/images/icons/micro/chevron-left.svg
+++ b/app/assets/images/icons/micro/chevron-left.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor">
+  <path fill-rule="evenodd" d="M9.78 4.22a.75.75 0 0 1 0 1.06L7.06 8l2.72 2.72a.75.75 0 1 1-1.06 1.06L5.47 8.53a.75.75 0 0 1 0-1.06l3.25-3.25a.75.75 0 0 1 1.06 0Z" clip-rule="evenodd" />
+</svg>

--- a/app/components/Ui/back_link_component.html.erb
+++ b/app/components/Ui/back_link_component.html.erb
@@ -1,0 +1,4 @@
+<%= link_to path, class: 'inline-flex items-center gap-2 text-sm/6 text-gray-500 hover:text-gray-700' do %>
+  <%= inline_svg_tag 'icons/micro/chevron-left.svg', class: 'h-4 w-4' %>
+  <%= name %>
+<% end %>

--- a/app/components/Ui/back_link_component.rb
+++ b/app/components/Ui/back_link_component.rb
@@ -1,0 +1,10 @@
+class Ui::BackLinkComponent < ApplicationComponent
+  def initialize(path:, name:)
+    @path = path
+    @name = name
+  end
+
+  private
+
+  attr_reader :path, :name
+end

--- a/app/views/admin_v2/flags/show.html.erb
+++ b/app/views/admin_v2/flags/show.html.erb
@@ -1,6 +1,7 @@
-<div class="max-w-4xl w-full mx-auto">
+<div class="max-w-5xl w-full mx-auto">
+  <%= render Ui::BackLinkComponent.new(path: admin_v2_flags_path, name: 'Flags') %>
 
-  <div class="flex items-center justify-between">
+  <div class="flex mt-8 items-center justify-between">
     <div>
       <h1 class="text-xl font-semibold leading-6 text-gray-900">Flag #<%= @flag.id %></h1>
       <div class="pt-3 flex gap-x-2" data-test-id="flag-status">


### PR DESCRIPTION
Because:
- When I am on the flag details page, I want an easy way to get back to the flags index page through the UI, so I can navigate through flags quickly
- Relates to: https://github.com/TheOdinProject/top-meta/issues/291

<img width="641" alt="Screenshot 2024-06-17 at 16 12 15" src="https://github.com/TheOdinProject/theodinproject/assets/7963776/18a620ee-af54-4158-ad2c-7a00260ee6f0">

This commit:
- Adds a back link component we can use on admin detail page
