### PR TITLE
Feature: courses use the split lesson/project counts

### DIFF
--- a/app/views/users/_skill.html.erb
+++ b/app/views/users/_skill.html.erb
@@ -8,13 +8,13 @@
       <%= link_to path_course_url(course.path, course) do %>
         <h3 class="text-gray-700 font-medium text-lg mb-0 dark:text-gray-300"><%= course.title %></h3>
       <% end %>
-      <p class="text-sm text-gray-500 dark:text-gray-400"><%= course.lessons.size %> lessons</p>
+      <p class="text-sm text-gray-500 dark:text-gray-400"><%= pluralize(course.lessons_count, 'Lesson') %> / <%= pluralize(course.projects_co>
     </div>
   </div>
 
   <div class="pt-4 md:pt-0">
     <% if course_completed_by_user?(course, current_user) %>
-      <%= link_to 'Open', path_course_path(course.path, course), class: 'button button--secondary button--medium', data: { test_id: "#{course.title.downcase}-open-btn" } %>
+      <%= link_to 'Open', path_course_path(course.path, course), class: 'button button--secondary button--medium', data: { test_id: "#{course>
     <% elsif current_user.started_course?(course) %>
       <%= link_to 'Resume',
         lesson_url(next_lesson_to_complete(course, current_user.lesson_completions_for_course(course))),


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
The purpose of this PR is it reduces confusion on how much lessons each course have in the dashboard interface by displaying the number of lessons independently from number of projects, as I already clarified in this issue I opened: https://github.com/TheOdinProject/theodinproject/issues/4542

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
* courses viewed in the dashboard now follows the syntax of "(Number of lessons) Lesson(s) / (Number of projects) Project(s)"

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #4542

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If applicable, this PR includes new or updated automated tests
