### PR TITLE
Fix: Admin V2 - Test admin

### DIFF
--- a/db/seeds/test_admins.rb
+++ b/db/seeds/test_admins.rb
@@ -12,5 +12,6 @@ if Rails.env.development? || ENV['STAGING']
   AdminUser.find_or_create_by!(email: 'admin@odin.com') do |admin_user|
     admin_user.name = 'admin'
     admin_user.password = 'password123'
+    admin_user.status = 'active'
   end
 end


### PR DESCRIPTION
Because:
- The test admin we create in the seeds needed to be set to "active"