### PR TITLE
Feature: Admin v2 - reset team member passwords

### DIFF
--- a/app/assets/images/icons/ellipsis-horizontal.svg
+++ b/app/assets/images/icons/ellipsis-horizontal.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM12.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM18.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z" />
+</svg>

--- a/app/assets/images/icons/envelope.svg
+++ b/app/assets/images/icons/envelope.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0v.243a2.25 2.25 0 0 1-1.07 1.916l-7.5 4.615a2.25 2.25 0 0 1-2.36 0L3.32 8.91a2.25 2.25 0 0 1-1.07-1.916V6.75" />
+</svg>

--- a/app/components/Ui/dropdown/component.html.erb
+++ b/app/components/Ui/dropdown/component.html.erb
@@ -11,7 +11,7 @@
     data-transition-leave="transition ease-in duration-75"
     data-transition-leave-start="transform opacity-100 scale-100"
     data-transition-leave-end="transform opacity-10 scale-95"
-    class="hidden origin-top-right absolute right-0 mt-2 w-48 rounded-md shadow-lg py-1 bg-white dark:bg-gray-800 ring-1 ring-black ring-opacity-5 focus:outline-none z-50"
+    class="hidden origin-top-right absolute right-0 mt-2 min-w-48 rounded-md shadow-lg py-1 bg-white dark:bg-gray-800 ring-1 ring-black ring-opacity-5 focus:outline-none z-50"
     role="menu"
     aria-orientation="vertical"
     aria-labelledby="user-menu-button"

--- a/app/controllers/admin_v2/passwords_controller.rb
+++ b/app/controllers/admin_v2/passwords_controller.rb
@@ -1,0 +1,17 @@
+module AdminV2
+  class PasswordsController < Devise::PasswordsController
+    def new
+      redirect_to new_admin_user_session_path, alert: 'Please sign in'
+    end
+
+    def create
+      redirect_to new_admin_user_session_path, alert: 'Please sign in'
+    end
+
+    private
+
+    def after_resetting_password_path_for(_resource)
+      admin_v2_dashboard_path
+    end
+  end
+end

--- a/app/controllers/admin_v2/team_members/password_resets_controller.rb
+++ b/app/controllers/admin_v2/team_members/password_resets_controller.rb
@@ -1,0 +1,18 @@
+module AdminV2
+  class TeamMembers::PasswordResetsController < AdminV2::BaseController
+    rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+
+    def create
+      team_member = AdminUser.find(params[:team_member_id])
+
+      team_member.send_reset_password_instructions
+      redirect_to admin_v2_team_path, notice: 'Reset password instructions sent'
+    end
+
+    private
+
+    def record_not_found
+      redirect_to admin_v2_team_path, alert: 'Team member not found'
+    end
+  end
+end

--- a/app/views/admin_users/mailer/reset_password_instructions.html.erb
+++ b/app/views/admin_users/mailer/reset_password_instructions.html.erb
@@ -1,0 +1,8 @@
+<p>Hello <%= @resource.name %>!</p>
+
+<p>Someone has sent you a link to change your Odin Project admin password. You can do this through the link below.</p>
+
+<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+
+<p>If you didn't request this, please let the team know.</p>
+<p>Your password won't change until you access the link above and create a new one.</p>

--- a/app/views/admin_v2/passwords/edit.html.erb
+++ b/app/views/admin_v2/passwords/edit.html.erb
@@ -2,7 +2,7 @@
 
 <div class="h-screen">
   <div class="page-container">
-    <h1 class="page-heading-title">Change password</h1>
+    <h1 class="page-heading-title">Change admin password</h1>
 
     <div class='max-w-xl mx-auto'>
       <%= render CardComponent.new do |card| %>

--- a/app/views/admin_v2/team/_member.html.erb
+++ b/app/views/admin_v2/team/_member.html.erb
@@ -3,7 +3,7 @@
     <span class="font-semibold text-sm"><%= team_member.initials.upcase %></span>
   </div>
 
-  <div class="min-w-0">
+  <div class="min-w-0 w-full flex items-center justify-between">
     <div class="flex items-center gap-x-2">
       <p class="text-sm font-semibold leading-6 text-gray-800 dark:text-gray-300"><%= team_member.name %></p>
       <% if team_member.pending? %>
@@ -13,5 +13,17 @@
       <% end %>
     </div>
 
+    <%= render Ui::Dropdown::Component.new do |dropdown| %>
+      <% dropdown.with_trigger_button do %>
+        <%= inline_svg_tag 'icons/ellipsis-horizontal.svg', class: 'h-6 w-6', aria: true %>
+      <% end %>
+
+      <% dropdown.with_item do %>
+        <%= link_to admin_v2_team_member_password_resets_path(team_member), data: { turbo_method: :post, turbo_frame: '_top' }, class: "text-gray-700 dark:text-gray-300 whitespace-nowrap group flex items-center px-3 py-2 text-sm #{'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300' if current_page?(edit_users_profile_path)}" do %>
+          <%= inline_svg_tag 'icons/envelope.svg', class: 'mr-3 h-6 w-6 text-gray-400 group-hover:text-gray-500 dark:text-gray-300 dark:group-hover:text-gray-400' %>
+          Send password reset email
+        <% end %>
+      <% end %>
+    <% end %>
   </div>
 </li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,20 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
+  activerecord:
+    errors:
+      models:
+        user:
+          attributes:
+            reset_password_token:
+              blank: "The password reset link you have used is no longer active or invalid. Password reset links only work one time. <a class='underline text-blue-600 dark:text-blue-400 hover:no-underline' href='/users/password_reset/new'>Please reset your password again.</a>"
+              invalid: "The password reset link you have used is no longer active or invalid. Password reset links only work one time. <a class='underline text-blue-600 dark:text-blue-400 hover:no-underline' href='/users/password_reset/new'>Please reset your password again.</a>"
+        admin_user:
+          attributes:
+            reset_password_token:
+              blank: "The password reset link you have used is no longer active or invalid. Password reset links only work one time Please ask a team member to reset your password again."
+              invalid: "The password reset link you have used is no longer active or invalid. Password reset links only work one time. Please ask a team member to reset your password again."
+
   static_pages:
     about:
         beliefs:

--- a/config/routes/admin_v2.rb
+++ b/config/routes/admin_v2.rb
@@ -7,4 +7,8 @@ namespace :admin_v2 do
   resources :flags, only: %i[index show update]
   resources :announcements
   resource :team, only: :show, controller: :team
+
+  resources :team_members do
+    resources :password_resets, only: %i[create], controller: 'team_members/password_resets'
+  end
 end

--- a/spec/requests/admin_v2/passwords_spec.rb
+++ b/spec/requests/admin_v2/passwords_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin users passwords' do
+  describe 'GET #new' do
+    it 'redirects to the admin sign in page' do
+      get new_admin_user_password_path
+
+      expect(response).to redirect_to(new_admin_user_session_path)
+      expect(flash[:alert]).to eq('Please sign in')
+    end
+  end
+
+  describe 'POST #create' do
+    it 'redirects to the admin sign in page' do
+      post admin_user_password_path
+
+      expect(response).to redirect_to(new_admin_user_session_path)
+      expect(flash[:alert]).to eq('Please sign in')
+    end
+  end
+end

--- a/spec/requests/admin_v2/team_members/password_resets_spec.rb
+++ b/spec/requests/admin_v2/team_members/password_resets_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe 'Team member password resets' do
+  describe 'POST #create' do
+    context 'when signed in as an admin and the team member exists' do
+      it 'sends a password reset email' do
+        admin = create(:admin_user)
+        other_admin = create(:admin_user)
+        sign_in(admin)
+
+        expect do
+          post admin_v2_team_member_password_resets_path(other_admin)
+        end.to change { ActionMailer::Base.deliveries.count }.by(1)
+
+        expect(response).to redirect_to(admin_v2_team_path)
+      end
+    end
+
+    context 'when signed in as an admin and the team member does not exist' do
+      it 'does not send a password reset email' do
+        admin = create(:admin_user)
+        sign_in(admin)
+
+        expect do
+          post admin_v2_team_member_password_resets_path(team_member_id: 101)
+        end.not_to change { ActionMailer::Base.deliveries.count }
+
+        expect(response).to redirect_to(admin_v2_team_path)
+        expect(flash[:alert]).to eq('Team member not found')
+      end
+    end
+
+    context 'when not signed in as an admin' do
+      it 'does not send a password reset email and redirects to the admin sign in page' do
+        user = create(:user)
+        admin = create(:admin_user)
+        sign_in(user)
+
+        expect do
+          post admin_v2_team_member_password_resets_path(admin)
+        end.not_to change { ActionMailer::Base.deliveries.count }
+
+        expect(response).to redirect_to(new_admin_user_session_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Because:
- When an Admin team member forgets their password, I want to be able to send them a password reset email, so they can regain access to their account.
- Closes: https://github.com/TheOdinProject/theodinproject/issues/4588

This commit
- Adds a drop down menu to admin team member items
- Adds a reset password option to the menu
- Adds Devise's reset password instructions mailer template and tweaks it for TOP admins
- Blocks access to the new and create devise password actions for all users
