### PR TITLE
Feature: Admin V2 - Edit team member

### DIFF
--- a/app/controllers/admin_v2/profile/password_controller.rb
+++ b/app/controllers/admin_v2/profile/password_controller.rb
@@ -1,0 +1,21 @@
+module AdminV2
+  class Profile::PasswordController < AdminV2::BaseController
+    def update
+      @admin_user = AdminUser.find(current_admin_user.id)
+
+      if @admin_user.update_with_password(password_params)
+        # Sign in the user by passing validation in case their password changed
+        bypass_sign_in(@admin_user)
+        redirect_to edit_admin_v2_profile_path, notice: 'Password updated'
+      else
+        render 'admin_v2/profile/edit', status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def password_params
+      params.require(:admin_user).permit(:password, :password_confirmation, :current_password)
+    end
+  end
+end

--- a/app/controllers/admin_v2/profile_controller.rb
+++ b/app/controllers/admin_v2/profile_controller.rb
@@ -1,0 +1,24 @@
+module AdminV2
+  class ProfileController < AdminV2::BaseController
+    def edit
+      # Use a separate admin user instance to avoid morphing current admin when valildation fails
+      @admin_user = AdminUser.find(current_admin_user.id)
+    end
+
+    def update
+      @admin_user = AdminUser.find(current_admin_user.id)
+
+      if @admin_user.update(profile_params)
+        redirect_to edit_admin_v2_profile_path, notice: 'Account updated'
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def profile_params
+      params.require(:profile).permit(:email, :name)
+    end
+  end
+end

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -3,7 +3,6 @@ class AdminUser < ApplicationRecord
          password_length: 8..128
 
   validates :name, presence: true, uniqueness: true
-  validates :password, presence: true
 
   enum status: { pending: 'pending', active: 'active', deactivated: 'deactivated' }
 

--- a/app/views/admin_v2/profile/edit.html.erb
+++ b/app/views/admin_v2/profile/edit.html.erb
@@ -1,0 +1,68 @@
+<%= title('Settings') %>
+
+<div class="max-w-5xl w-full mx-auto">
+  <div class="lg:grid lg:grid-cols-12 lg:gap-x-5">
+
+    <div class="space-y-6 sm:px-6 lg:px-0 lg:col-span-9">
+
+      <%= form_with model: @admin_user, url: admin_v2_profile_path, scope: :profile, builder: TailwindFormBuilder do |form| %>
+        <%= render CardComponent.new(classes: '!shadow-none border border-gray-200 dark:border-gray-800') do |card| %>
+          <% card.with_header do %>
+            <h3 class="text-xl leading-6 text-gray-800 dark:text-gray-200">Update your profile</h3>
+          <% end %>
+
+          <% card.with_body do %>
+            <div class="grid grid-cols-6 gap-6">
+
+              <div class="col-span-6 sm:col-span-3">
+                <%= form.label :name %>
+                <%= form.text_field :name, class: 'text-sm' %>
+              </div>
+
+              <div class="col-span-6 sm:col-span-4">
+                <%= form.label :email %>
+                <%= form.email_field :email, class: 'text-sm' %>
+              </div>
+            </div>
+          <% end %>
+
+          <% card.with_footer(classes: 'px-4 py-3 pt-3 bg-gray-50 text-right sm:px-6 dark:bg-gray-700/40 rounded-b-lg') do %>
+            <%= form.submit 'Save', class: 'button button--primary py-2 px-4' %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </div>
+
+    <div class="space-y-6 sm:px-6 lg:px-0 lg:col-span-9 mt-10">
+      <%= form_with model: @admin_user, url: admin_v2_profile_password_path, builder: TailwindFormBuilder do |form| %>
+        <%= render CardComponent.new(classes: '!shadow-none border border-gray-200 dark:border-gray-800') do |card| %>
+          <% card.with_header do %>
+            <h3 class="text-xl leading-6 text-gray-800 dark:text-gray-200">Change your password</h3>
+          <% end %>
+          <% card.with_body do %>
+            <div class="grid grid-cols-6 gap-6 grid-flow-row">
+              <div class="col-span-6 sm:col-span-4">
+                <%= form.label :current_password %>
+                <%= form.password_field :current_password, class: 'text-sm' %>
+              </div>
+
+              <div class="col-span-6 sm:col-span-4">
+                <%= form.label :password %>
+                <%= form.password_field :password, class: 'text-sm' %>
+              </div>
+
+              <div class="col-span-6 sm:col-span-4">
+                <%= form.label :password_confirmation %>
+                <%= form.password_field :password_confirmation, class: 'text-sm' %>
+              </div>
+            </div>
+          <% end %>
+
+          <% card.with_footer(classes: 'px-4 py-3 pt-3 bg-gray-50 text-right sm:px-6 dark:bg-gray-700/40 rounded-b-lg') do %>
+            <%= form.submit 'Save', class: 'button button--primary py-2 px-4', data: { disable_with: false } %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/admin_v2/_nav_bar.html.erb
+++ b/app/views/layouts/admin_v2/_nav_bar.html.erb
@@ -29,7 +29,7 @@
         <% end %>
 
         <% dropdown.with_item do %>
-          <%= link_to '#', class: "text-gray-700 dark:text-gray-300 group flex items-center px-3 py-2 text-sm #{'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300' if current_page?(edit_users_profile_path)}" do %>
+          <%= link_to edit_admin_v2_profile_path, class: "text-gray-700 dark:text-gray-300 group flex items-center px-3 py-2 text-sm #{'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300' if current_page?(edit_users_profile_path)}" do %>
             <%= inline_svg_tag 'icons/gear-solid.svg', class: 'mr-3 h-5 w-5 text-gray-400 group-hover:text-gray-500 dark:text-gray-300 dark:group-hover:text-gray-400' %>
             Settings
           <% end %>

--- a/app/views/layouts/admin_v2/_sidebar_nav.html.erb
+++ b/app/views/layouts/admin_v2/_sidebar_nav.html.erb
@@ -131,7 +131,7 @@ nav_links = [
         </li>
 
         <li class="mt-auto">
-          <%= link_to '#', class: 'group -mx-2 flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 text-gray-700 hover:bg-gray-200 hover:text-gray-800 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-gray-200' do %>
+          <%= link_to edit_admin_v2_profile_path, class: 'group -mx-2 flex gap-x-3 rounded-md p-2 text-sm font-semibold leading-6 text-gray-700 hover:bg-gray-200 hover:text-gray-800 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-gray-200' do %>
             <%= inline_svg_tag 'icons/gear.svg', class: 'h-5 w-5 shrink-0 text-gray-500 group-hover:text-gray-800 dark:text-gray-400 dark:group-hover:text-gray-200' %>
             Settings
           <% end %>

--- a/app/views/layouts/admin_v2/base.html.erb
+++ b/app/views/layouts/admin_v2/base.html.erb
@@ -11,6 +11,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta property="og:image" content="<%= image_url('og-logo.png') %>">
+    <meta name="turbo-refresh-method" content="morph">
+    <meta name="turbo-refresh-scroll" content="preserve">
 
     <%= csrf_meta_tags %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,10 @@ en:
               invalid: "The password reset link you have used is no longer active or invalid. Password reset links only work one time. <a class='underline text-blue-600 dark:text-blue-400 hover:no-underline' href='/users/password_reset/new'>Please reset your password again.</a>"
         admin_user:
           attributes:
+            current_password:
+              invalid: "Incorrect password"
+            password_confirmation:
+              confirmation: "Password and password confirmation must be the same"
             reset_password_token:
               blank: "The password reset link you have used is no longer active or invalid. Password reset links only work one time Please ask a team member to reset your password again."
               invalid: "The password reset link you have used is no longer active or invalid. Password reset links only work one time. Please ask a team member to reset your password again."

--- a/config/routes/admin_v2.rb
+++ b/config/routes/admin_v2.rb
@@ -11,4 +11,8 @@ namespace :admin_v2 do
   resources :team_members do
     resources :password_resets, only: %i[create], controller: 'team_members/password_resets'
   end
+
+  resource :profile, only: %i[edit update], controller: :profile do
+    resource :password, only: %i[update], controller: 'profile/password'
+  end
 end

--- a/spec/models/admin_user_spec.rb
+++ b/spec/models/admin_user_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe AdminUser do
   it { is_expected.to validate_uniqueness_of(:name) }
   it { is_expected.to validate_presence_of(:email) }
   it { is_expected.to validate_uniqueness_of(:email).case_insensitive }
-  it { is_expected.to validate_presence_of(:password) }
-  it { is_expected.to validate_confirmation_of(:password) }
   it { is_expected.to validate_length_of(:password).is_at_least(8) }
 
   describe 'after invitation accepted' do

--- a/spec/requests/admin_v2/profile/password_spec.rb
+++ b/spec/requests/admin_v2/profile/password_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin user profile password' do
+  describe 'PATCH #update' do
+    context 'when signed in as an admin and the form is valid' do
+      it "updates the admin user's password" do
+        admin = create(:admin_user, password: 'oldpassword')
+        sign_in(admin)
+
+        expect do
+          put admin_v2_profile_password_path, params: {
+            admin_user: {
+              password: 'newpassword',
+              password_confirmation: 'newpassword',
+              current_password: 'oldpassword'
+            }
+          }
+        end.to change { admin.reload.encrypted_password }
+
+        expect(response).to redirect_to(edit_admin_v2_profile_path)
+      end
+    end
+
+    context 'when signed in as an admin and the form is invalid' do
+      it 'returns an unprocessable entity response' do
+        admin = create(:admin_user, password: 'oldpassword')
+        sign_in(admin)
+
+        put admin_v2_profile_password_path, params: {
+          admin_user: { password: 'new', password_confirmation: 'new', current_password: 'wrongpassword' },
+        }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context 'when not signed in as an admin' do
+      it 'redirects to the sign in page' do
+        put admin_v2_profile_password_path, params: {
+          admin_user: { password: 'new', password_confirmation: 'new', current_password: 'wrongpassword' },
+        }
+
+        expect(response).to redirect_to(new_admin_user_session_path)
+      end
+    end
+  end
+end

--- a/spec/requests/admin_v2/profile_spec.rb
+++ b/spec/requests/admin_v2/profile_spec.rb
@@ -1,0 +1,68 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin user profile' do
+  describe 'GET #edit' do
+    context 'when signed in as an admin' do
+      it 'renders the edit profile page' do
+        admin = create(:admin_user)
+        sign_in(admin)
+
+        get edit_admin_v2_profile_path
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when not signed in as an admin' do
+      it 'redirects to the sign in page' do
+        user = create(:user)
+        sign_in(user)
+
+        get edit_admin_v2_profile_path
+
+        expect(response).to redirect_to(new_admin_user_session_path)
+      end
+    end
+  end
+
+  describe 'PATCH #update' do
+    context 'when signed in as an admin and the form is valid' do
+      it 'updates the admin user' do
+        admin = create(:admin_user, email: 'old@example.com', name: 'Old Name')
+        sign_in(admin)
+
+        expect do
+          put admin_v2_profile_path, params: {
+            profile: { email: 'new@example.com', name: 'New name' },
+          }
+        end.to change { admin.reload.name }.from('Old Name').to('New name')
+          .and change { admin.reload.email }.from('old@example.com').to('new@example.com')
+
+        expect(response).to redirect_to(edit_admin_v2_profile_path)
+      end
+    end
+
+    context 'when signed in as an admin and the form is invalid' do
+      it 'returns an unprocessable entity response' do
+        admin = create(:admin_user)
+        sign_in(admin)
+
+        put admin_v2_profile_path, params: {
+          profile: { email: '', name: '' },
+        }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context 'when not signed in as an admin' do
+      it 'redirects to the sign in page' do
+        put admin_v2_profile_path, params: {
+          admin_user: { email: 'test@example.com', name: 'Test' },
+        }
+
+        expect(response).to redirect_to(new_admin_user_session_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Because:
- When I have an admin account, I want to have the ability to change my password, email address and name, so I can keep my information up to date and secure.
- Closes: https://github.com/TheOdinProject/theodinproject/issues/4591

This commit:
- Adds an edit profile page for the currently signed in admin
- Reuses the styling of the user settings page to save time
- Adds a profile passwords controller because there is no registerable devise controller admin user's can use.