### PR TITLE
Feature: Admin V2 - Deactivate team members

### DIFF
--- a/app/assets/images/icons/user-minus.svg
+++ b/app/assets/images/icons/user-minus.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M22 10.5h-6m-2.25-4.125a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0ZM4 19.235v-.11a6.375 6.375 0 0 1 12.75 0v.109A12.318 12.318 0 0 1 10.374 21c-2.331 0-4.512-.645-6.374-1.766Z" />
+</svg>
+

--- a/app/components/Ui/dropdown/trigger_component.html.erb
+++ b/app/components/Ui/dropdown/trigger_component.html.erb
@@ -1,4 +1,4 @@
-<button type="button" data-action="click->visibility#toggle" class="flex text-sm focus:outline-none" aria-expanded="false" aria-haspopup="true">
+<button type="button" data-action="click->visibility#toggle" class="flex text-sm focus:outline-none" aria-expanded="false" aria-haspopup="true" data-test-id="dropdown-button">
   <span class="sr-only">Open user menu</span>
   <%= content %>
 </button>

--- a/app/controllers/admin_v2/team_controller.rb
+++ b/app/controllers/admin_v2/team_controller.rb
@@ -3,6 +3,7 @@ module AdminV2
     def show
       @pending_team_members = AdminUser.pending
       @active_team_members = AdminUser.active
+      @deactivated_team_members = AdminUser.deactivated
     end
   end
 end

--- a/app/controllers/admin_v2/team_members/deactivations_controller.rb
+++ b/app/controllers/admin_v2/team_members/deactivations_controller.rb
@@ -1,0 +1,18 @@
+module AdminV2
+  class TeamMembers::DeactivationsController < AdminV2::BaseController
+    rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+
+    def create
+      team_member = AdminUser.find(params[:team_member_id])
+
+      team_member.deactivate!(deactivator: current_admin_user)
+      redirect_to admin_v2_team_path, notice: "#{team_member.name} deactivated"
+    end
+
+    private
+
+    def record_not_found
+      redirect_to admin_v2_team_path, alert: 'Team member not found'
+    end
+  end
+end

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -2,6 +2,8 @@ class AdminUser < ApplicationRecord
   devise :invitable, :database_authenticatable, :recoverable, :trackable, :timeoutable, :validatable,
          password_length: 8..128
 
+  belongs_to :deactivated_by, class_name: 'AdminUser', optional: true
+
   validates :name, presence: true, uniqueness: true
 
   enum status: { pending: 'pending', active: 'active', deactivated: 'deactivated' }
@@ -10,6 +12,20 @@ class AdminUser < ApplicationRecord
 
   def initials
     name.split.map(&:first).join
+  end
+
+  def active_for_authentication?
+    super && !deactivated?
+  end
+
+  def inactive_message
+    deactivated? ? :deactivated : super
+  end
+
+  def deactivate!(deactivator:)
+    return unless active?
+
+    update!(status: :deactivated, deactivated_by: deactivator, deactivated_at: Time.current)
   end
 
   private

--- a/app/views/admin_v2/team/_member.html.erb
+++ b/app/views/admin_v2/team/_member.html.erb
@@ -1,4 +1,4 @@
-<li class="flex items-center gap-x-4 py-5">
+<li class="flex items-center gap-x-4 py-5" id="<%= dom_id(team_member) %>">
   <div class="h-8 w-8 rounded-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center">
     <span class="font-semibold text-sm"><%= team_member.initials.upcase %></span>
   </div>
@@ -22,6 +22,15 @@
         <%= link_to admin_v2_team_member_password_resets_path(team_member), data: { turbo_method: :post, turbo_frame: '_top' }, class: "text-gray-700 dark:text-gray-300 whitespace-nowrap group flex items-center px-3 py-2 text-sm #{'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300' if current_page?(edit_users_profile_path)}" do %>
           <%= inline_svg_tag 'icons/envelope.svg', class: 'mr-3 h-6 w-6 text-gray-400 group-hover:text-gray-500 dark:text-gray-300 dark:group-hover:text-gray-400' %>
           Send password reset email
+        <% end %>
+      <% end %>
+
+      <% if team_member.active? %>
+        <% dropdown.with_item do %>
+          <%= link_to admin_v2_team_member_deactivations_path(team_member), data: { turbo_method: :post, turbo_frame: '_top' }, class: "text-red-700 dark:text-red-300 whitespace-nowrap group flex items-center px-3 py-2 text-sm #{'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300' if current_page?(edit_users_profile_path)}" do %>
+            <%= inline_svg_tag 'icons/user-minus.svg', class: 'mr-3 h-6 w-6 text-red-700 group-hover:text-red-600 dark:text-red-300 dark:group-hover:text-red-400' %>
+            Deactivate
+          <% end %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/admin_v2/team/show.html.erb
+++ b/app/views/admin_v2/team/show.html.erb
@@ -13,6 +13,15 @@
     <% end %>
 
     <%= render partial: 'admin_v2/team/member', collection: @active_team_members, as: :team_member %>
-</ul>
+  </ul>
+
+   <div class="border-b border-gray-200 dark:border-gray-800 pb-5 mt-10">
+      <h3 class="text-base font-semibold leading-6 text-gray-800 dark:text-gray-300">Deactivated team members</h3>
+  </div>
+  <ul>
+    <%= turbo_frame_tag 'deactivated_members' do %>
+      <%= render partial: 'admin_v2/team/member', collection: @deactivated_team_members, as: :team_member %>
+    <% end %>
+  </ul>
 
 </div>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -17,6 +17,7 @@ en:
       unauthenticated: "You need to sign in or sign up before continuing."
       unconfirmed: "You have to confirm your account before continuing.<br><a href='/users/confirmation/new'>Didn't receive instructions or need them again?</a>"
       banned: "Your user account has been banned"
+      deactivated: "Your account is deactivated"
     mailer:
       confirmation_instructions:
         subject: "Confirmation instructions"

--- a/config/routes/admin_v2.rb
+++ b/config/routes/admin_v2.rb
@@ -10,6 +10,7 @@ namespace :admin_v2 do
 
   resources :team_members do
     resources :password_resets, only: %i[create], controller: 'team_members/password_resets'
+    resources :deactivations, only: %i[create], controller: 'team_members/deactivations'
   end
 
   resource :profile, only: %i[edit update], controller: :profile do

--- a/db/migrate/20240704102438_add_deactivated_to_admin_users.rb
+++ b/db/migrate/20240704102438_add_deactivated_to_admin_users.rb
@@ -1,0 +1,6 @@
+class AddDeactivatedToAdminUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :admin_users, :deactivated_at, :datetime
+    add_reference :admin_users, :deactivated_by, foreign_key: { to_table: :admin_users }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_26_164023) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_04_102438) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -55,6 +55,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_26_164023) do
     t.bigint "invited_by_id"
     t.integer "invitations_count", default: 0
     t.enum "status", default: "pending", null: false, enum_type: "status"
+    t.datetime "deactivated_at"
+    t.bigint "deactivated_by_id"
+    t.index ["deactivated_by_id"], name: "index_admin_users_on_deactivated_by_id"
     t.index ["email"], name: "index_admin_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_admin_users_on_invitation_token", unique: true
     t.index ["invited_by_id"], name: "index_admin_users_on_invited_by_id"
@@ -320,6 +323,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_26_164023) do
     t.index ["username"], name: "index_users_on_username"
   end
 
+  add_foreign_key "admin_users", "admin_users", column: "deactivated_by_id"
   add_foreign_key "announcements", "users"
   add_foreign_key "contents", "lessons"
   add_foreign_key "flags", "project_submissions"

--- a/spec/models/admin_user_spec.rb
+++ b/spec/models/admin_user_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe AdminUser do
   subject { create(:admin_user) }
 
+  it { is_expected.to belong_to(:deactivated_by).class_name('AdminUser').optional }
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_uniqueness_of(:name) }
   it { is_expected.to validate_presence_of(:email) }
@@ -24,6 +25,78 @@ RSpec.describe AdminUser do
     it 'returns the initials of the admin user' do
       admin_user = build(:admin_user, name: 'John Wick')
       expect(admin_user.initials).to eq 'JW'
+    end
+  end
+
+  describe '#active_for_authentication?' do
+    context 'when admin has not been deactivated' do
+      it 'returns true' do
+        admin = create(:admin_user)
+        expect(admin).to be_active_for_authentication
+      end
+    end
+
+    context 'when admin has been deactivated' do
+      it 'returns false' do
+        admin = create(:admin_user, status: :deactivated)
+        expect(admin).not_to be_active_for_authentication
+      end
+    end
+  end
+
+  describe '#inactive_message' do
+    context 'when admin has not been deactivated' do
+      it 'returns default inactive translation key' do
+        admin = create(:admin_user)
+        expect(admin.inactive_message).to eq(:inactive)
+      end
+    end
+
+    context 'when admin has been deactivated' do
+      it 'returns banned translation key' do
+        admin = create(:admin_user, status: :deactivated)
+        expect(admin.inactive_message).to eq(:deactivated)
+      end
+    end
+  end
+
+  describe '#deactivate!' do
+    it 'deactivates the admin' do
+      admin = build(:admin_user, status: :active)
+      deactivator = build(:admin_user)
+
+      expect do
+        admin.deactivate!(deactivator:)
+      end.to change { admin.status }.from('active').to('deactivated')
+    end
+
+    it 'sets the deactivator' do
+      admin = build(:admin_user, status: :active)
+      deactivator = build(:admin_user)
+
+      expect do
+        admin.deactivate!(deactivator:)
+      end.to change { admin.deactivated_by }.from(nil).to(deactivator)
+    end
+
+    it 'sets the deactivated_at timestamp' do
+      admin = build(:admin_user, status: :active)
+      deactivator = build(:admin_user)
+
+      freeze_time do
+        expect do
+          admin.deactivate!(deactivator:)
+        end.to change { admin.deactivated_at }.from(nil).to(Time.current)
+      end
+    end
+
+    context 'when the admin is already deactivated' do
+      it 'does not deactivate the admin' do
+        admin = build(:admin_user, status: :deactivated)
+        deactivator = build(:admin_user)
+
+        expect { admin.deactivate!(deactivator:) }.not_to change { admin.status }
+      end
     end
   end
 end

--- a/spec/system/admin_v2/deactivations_spec.rb
+++ b/spec/system/admin_v2/deactivations_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin V2 team members deactivations' do
+  it 'deactivates a team member' do
+    admin = create(:admin_user, status: :active)
+    other_admin = create(:admin_user, status: :active)
+
+    sign_in(admin)
+
+    visit admin_v2_team_path
+    sleep 0.1 # dropdown animations can be slow
+
+    within("#admin_user_#{other_admin.id}") do
+      find(:test_id, 'dropdown-button').click
+      click_link('Deactivate')
+    end
+
+    within('#deactivated_members') do
+      expect(page).to have_content(other_admin.name)
+    end
+  end
+end

--- a/spec/system/admin_v2/sign_in_and_out_spec.rb
+++ b/spec/system/admin_v2/sign_in_and_out_spec.rb
@@ -29,6 +29,21 @@ RSpec.describe 'Admin V2 Sign in and sign out' do
         expect(page).to have_current_path(new_admin_user_session_path)
       end
     end
+
+    context 'when the admin is deactivated' do
+      it 'does not sign the admin in' do
+        admin_user = create(:admin_user, status: :deactivated)
+
+        visit admin_v2_root_path
+
+        fill_in 'Email', with: admin_user.email
+        fill_in 'Password', with: admin_user.password
+        click_button 'Sign in'
+
+        expect(page).to have_current_path(new_admin_user_session_path)
+        expect(page).to have_content('Your account is deactivated')
+      end
+    end
   end
 
   describe 'sign out' do


### PR DESCRIPTION
Because:
- When someone leaves the team, we want to be able to deactivate their admin account, so they don't have access when they don't need it anymore.
- Closes: https://github.com/TheOdinProject/theodinproject/issues/4593

This commit:
- Adds a "Deactivate" option to active team member items on the team page
- Moves deactivated users to a "Deactivated team members" section of the team page
- Disallows sign in for deactivated users and displays an alert