### PR TITLE
Fix: Admin v2 - Successful sign in sometimes redirects to learners sign in page

### DIFF
--- a/app/controllers/admin_v2/sessions_controller.rb
+++ b/app/controllers/admin_v2/sessions_controller.rb
@@ -2,6 +2,10 @@ module AdminV2
   class SessionsController < Devise::SessionsController
     private
 
+    def after_sign_in_path_for(_resource)
+      admin_v2_dashboard_path
+    end
+
     def after_sign_out_path_for(_resource_or_scope)
       new_admin_user_session_path
     end

--- a/spec/system/admin_v2/sign_in_and_out_spec.rb
+++ b/spec/system/admin_v2/sign_in_and_out_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Admin V2 Sign in and sign out' do
         fill_in 'Password', with: admin_user.password
         click_button 'Sign in'
 
-        expect(page).to have_current_path(admin_v2_root_path)
+        expect(page).to have_current_path(admin_v2_dashboard_path)
       end
     end
 


### PR DESCRIPTION
Because:
- It was using the `after_sign_in_path_for` callback in the ApplicationController meant for learners sign in. It  tries to find a stored location and will fallback to the learners dashboard if there is none. Because we're signing in as an admin, it was failing an auth check when redirecting to the learners dashboard and redirecting again to the learner sign in page.
- closes: #4601 

This commit:
- Override the `after_sign_in_path_for` callback with admin specific behaviour when signing in as an admin.