### PR TITLE
Feature: Run daily summary after 12am UTC

### DIFF
--- a/app/models/lesson_completion.rb
+++ b/app/models/lesson_completion.rb
@@ -6,5 +6,5 @@ class LessonCompletion < ApplicationRecord
 
   validates :user_id, uniqueness: { scope: :lesson_id }
 
-  scope :created_today, -> { where('created_at >= ?', Time.zone.now.beginning_of_day) }
+  scope :completed_on, ->(date) { where(created_at: date.all_day) }
 end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -5,5 +5,5 @@ class Like < ApplicationRecord
   validates :user_id, uniqueness: { scope: %i[likeable_id likeable_type] }
   validates :likeable_type, presence: true
 
-  scope :created_today, -> { where('created_at >= ?', Time.zone.now.beginning_of_day) }
+  scope :liked_on, ->(date) { where(created_at: date.all_day) }
 end

--- a/app/models/project_submission.rb
+++ b/app/models/project_submission.rb
@@ -18,7 +18,7 @@ class ProjectSubmission < ApplicationRecord
 
   scope :only_public, -> { where(is_public: true, discarded_at: nil) }
   scope :not_removed_by_admin, -> { where(discarded_at: nil) }
-  scope :created_today, -> { where('created_at >= ?', Time.zone.now.beginning_of_day) }
+  scope :submitted_on, ->(date) { where(created_at: date.all_day) }
   scope :discardable, -> { not_removed_by_admin.where(discard_at: ..Time.zone.now) }
 
   def self.sort_by_params(column, direction = 'desc')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,7 @@ class User < ApplicationRecord
   belongs_to :path, optional: true
 
   scope :created_after, ->(date) { where(arel_table[:created_at].gt(date)) }
+  scope :signed_up_on, ->(date) { where(created_at: date.all_day) }
 
   def progress_for(course)
     @progress ||= Hash.new { |hash, c| hash[c] = CourseProgress.new(c, self) }

--- a/app/services/notifications/daily_summary.rb
+++ b/app/services/notifications/daily_summary.rb
@@ -1,11 +1,11 @@
 module Notifications
   class DailySummary
     def message
-      "**TOP Summary For #{Date.current.to_fs(:long_ordinal)}**\n" \
-        "#{User.where('created_at >= ?', start_of_day).size} users signed up\n" \
-        "#{LessonCompletion.created_today.size} lessons completed\n" \
-        "#{ProjectSubmission.created_today.size} project submissions added\n" \
-        "#{Like.created_today.size} projects liked"
+      "**TOP Summary For #{Date.yesterday.to_fs(:long_ordinal)} (UTC)**\n" \
+        "#{user_sign_up_count} users signed up\n" \
+        "#{lesson_completion_count} lessons completed\n" \
+        "#{project_submission_count} project submissions added\n" \
+        "#{project_like_count} projects liked"
     end
 
     def destination
@@ -16,8 +16,20 @@ module Notifications
 
     attr_reader :course
 
-    def start_of_day
-      Time.zone.now.beginning_of_day
+    def user_sign_up_count
+      User.signed_up_on(Time.zone.yesterday).count
+    end
+
+    def lesson_completion_count
+      LessonCompletion.completed_on(Time.zone.yesterday).count
+    end
+
+    def project_submission_count
+      ProjectSubmission.submitted_on(Time.zone.yesterday).count
+    end
+
+    def project_like_count
+      Like.liked_on(Time.zone.yesterday).count
     end
   end
 end

--- a/spec/models/lesson_completion_spec.rb
+++ b/spec/models/lesson_completion_spec.rb
@@ -10,12 +10,14 @@ RSpec.describe LessonCompletion do
 
   it { is_expected.to validate_uniqueness_of(:user_id).scoped_to(:lesson_id) }
 
-  describe '.created_today' do
-    it 'returns lessons completed today' do
-      lesson_completed_today = create(:lesson_completion, created_at: Time.zone.today)
-      create(:lesson_completion, created_at: Time.zone.today - 2.days)
+  describe '.created_on' do
+    it 'returns lessons completions created on the given date' do
+      lesson_completed_yesterday = create(:lesson_completion, created_at: Time.zone.yesterday)
+      create(:lesson_completion, created_at: Time.zone.today)
+      create(:lesson_completion, created_at: Time.zone.tomorrow)
+      create(:lesson_completion, created_at: Time.zone.yesterday - 1.day)
 
-      expect(described_class.created_today).to contain_exactly(lesson_completed_today)
+      expect(described_class.completed_on(Time.zone.yesterday)).to contain_exactly(lesson_completed_yesterday)
     end
   end
 end

--- a/spec/models/like_spec.rb
+++ b/spec/models/like_spec.rb
@@ -9,15 +9,16 @@ RSpec.describe Like do
   it { is_expected.to validate_presence_of(:likeable_type) }
   it { is_expected.to validate_uniqueness_of(:user_id).scoped_to(%i[likeable_id likeable_type]) }
 
-  describe '.created_today' do
-    it 'returns likes created today' do
-      first_like_created_today = create(:like, created_at: Time.zone.today)
-      second_like_created_today = create(:like, created_at: Time.zone.today)
-      like_not_created_today = create(:like, created_at: Time.zone.today - 2.days)
+  describe '.liked_on' do
+    it 'returns likes created on a given date' do
+      first_like_created_yesterday = create(:like, created_at: Time.zone.yesterday)
+      second_like_created_yesterday = create(:like, created_at: Time.zone.yesterday)
+      create(:like, created_at: Time.zone.today)
+      create(:like, created_at: Time.zone.tomorrow)
 
-      expect(described_class.created_today).to contain_exactly(
-        first_like_created_today,
-        second_like_created_today
+      expect(described_class.liked_on(Time.zone.yesterday)).to contain_exactly(
+        first_like_created_yesterday,
+        second_like_created_yesterday
       )
     end
   end

--- a/spec/models/project_submission_spec.rb
+++ b/spec/models/project_submission_spec.rb
@@ -62,19 +62,16 @@ RSpec.describe ProjectSubmission do
     end
   end
 
-  describe '.created_today' do
-    it 'returns projects submission created today' do
-      project_submission_created_today = create(
-        :project_submission,
-        created_at: Time.zone.today
-      )
+  describe '.submitted_on' do
+    it 'returns project submissions submitted on a given date' do
+      project_submission_submitted_yesterday = create(:project_submission, created_at: Time.zone.yesterday)
+      create(:project_submission, created_at: Time.zone.today)
+      create(:project_submission, created_at: Time.zone.tomorrow)
+      create(:project_submission, created_at: Time.zone.yesterday - 1.day)
 
-      project_submission_not_not_created_today = create(
-        :project_submission,
-        created_at: Time.zone.today - 2.days
+      expect(described_class.submitted_on(Time.zone.yesterday)).to contain_exactly(
+        project_submission_submitted_yesterday
       )
-
-      expect(described_class.created_today).to contain_exactly(project_submission_created_today)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -27,6 +27,17 @@ RSpec.describe User do
     end
   end
 
+  describe '.signed_up_on' do
+    it 'returns users who signed up on a given date' do
+      user_signed_up_yesterday = create(:user, created_at: Time.zone.yesterday)
+      create(:user, created_at: Time.zone.today)
+      create(:user, created_at: Time.zone.tomorrow)
+      create(:user, created_at: Time.zone.yesterday - 1.day)
+
+      expect(described_class.signed_up_on(Time.zone.yesterday)).to contain_exactly(user_signed_up_yesterday)
+    end
+  end
+
   describe '#progress_for' do
     let(:course) { build_stubbed(:course) }
     let(:course_progress) { instance_double(CourseProgress) }

--- a/spec/services/notifications/daily_summary_spec.rb
+++ b/spec/services/notifications/daily_summary_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Notifications::DailySummary do
 
     it 'returns the daily summary message' do
       expect(notification.message).to eql(
-        "**TOP Summary For April 10th, 2020**\n" \
+        "**TOP Summary For April 9th, 2020 (UTC)**\n" \
         "0 users signed up\n" \
         "0 lessons completed\n" \
         "0 project submissions added\n" \


### PR DESCRIPTION
Because:
- Currently, we are running this task at 11:30pm UTC which is not a full and true reflection of that day's stats.

This commit:
- Assumes the daily summary task runs after 12am UTC - the cron job has been changed to 00:30 UTC on Heroku
- Changes the daily summary task to account for users, lesson completions, projects and likes created yesterday
- Gives each model a `x_on` scope to fetch all records created on a given date.

