### PR TITLE
Feature: Increase visibility of link icon when note-box headings hovered over

### DIFF
--- a/app/assets/stylesheets/stylesheets/lesson-content.css
+++ b/app/assets/stylesheets/stylesheets/lesson-content.css
@@ -27,6 +27,10 @@
     @apply bg-gray-50 p-4 my-4 border-l-4 border-gold dark:bg-gray-700/40 dark:border-gold-600 rounded;
   }
 
+  .lesson-note > h4:has(.anchor-link:hover)::before {
+    @apply invisible;
+  }
+
   .lesson-note > *:first-child::before {
     font-family: "Font Awesome 6 Free";
     content: "\f249";

--- a/app/assets/stylesheets/stylesheets/typography.css
+++ b/app/assets/stylesheets/stylesheets/typography.css
@@ -20,6 +20,6 @@
   .anchor-link:hover:before {
     content: "\f0c1";
     font-family: "Font Awesome 5 Free";
-    @apply text-gray-500 dark:text-gray-300 text-xs absolute -left-5 top-1/2 -translate-y-1/2 font-semibold hidden sm:block;
+    @apply text-gray-500 dark:text-gray-300 text-xs absolute -left-[22px] top-1/2 -translate-y-1/2 font-semibold hidden sm:block;
   }
 }


### PR DESCRIPTION
## Because

Currently, all headings' `:hover::before` link icons are absolutely positioned with `left: -1.25rem`. This is completely fine for top-level headings, but for headings in note boxes, ends up looking like the below:

![image](https://github.com/TheOdinProject/theodinproject/assets/122839503/6359613b-25fc-432a-963f-054ef7371286)

It would be nice for the link icon to be more visible on hover. I had difficulty adjusting positioning so all headings' link icons would render left of the full prose contents. Instead, I opted for making the note box icon invisible on heading hover instead.

## This PR

- Adds CSS to visually hide note boxes' icons when their headings are hovered over.

## Issue

N/A

## Additional Information

N/A

## Pull Request Requirements

-   [X] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [X] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [X] The `Because` section summarizes the reason for this PR
-   [X] The `This PR` section has a bullet point list describing the changes in this PR
-   [X] I have verified all tests and linters pass after making these changes.
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If applicable, this PR includes new or updated automated tests
