### PR TITLE
Feature: Admin V2 - Reactivate team members

### DIFF
--- a/app/assets/images/icons/user-plus.svg
+++ b/app/assets/images/icons/user-plus.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M18 7.5v3m0 0v3m0-3h3m-3 0h-3m-2.25-4.125a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0ZM3 19.235v-.11a6.375 6.375 0 0 1 12.75 0v.109A12.318 12.318 0 0 1 9.374 21c-2.331 0-4.512-.645-6.374-1.766Z" />
+</svg>

--- a/app/controllers/admin_v2/team_members/reactivation_controller.rb
+++ b/app/controllers/admin_v2/team_members/reactivation_controller.rb
@@ -1,0 +1,20 @@
+module AdminV2
+  class TeamMembers::ReactivationController < AdminV2::BaseController
+    rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+
+    def update
+      team_member = AdminUser.find(params[:team_member_id])
+
+      team_member.reactivate!(activator: current_admin_user)
+      team_member.invite!(current_admin_user)
+
+      redirect_to admin_v2_team_path, notice: "#{team_member.name} reactivated"
+    end
+
+    private
+
+    def record_not_found
+      redirect_to admin_v2_team_path, alert: 'Team member not found'
+    end
+  end
+end

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -3,6 +3,7 @@ class AdminUser < ApplicationRecord
          password_length: 8..128
 
   belongs_to :deactivated_by, class_name: 'AdminUser', optional: true
+  belongs_to :reactivated_by, class_name: 'AdminUser', optional: true
 
   validates :name, presence: true, uniqueness: true
 
@@ -26,6 +27,12 @@ class AdminUser < ApplicationRecord
     return unless active?
 
     update!(status: :deactivated, deactivated_by: deactivator, deactivated_at: Time.current)
+  end
+
+  def reactivate!(activator:)
+    return unless deactivated?
+
+    update!(status: :active, reactivated_by: activator, reactivated_at: Time.current)
   end
 
   private

--- a/app/views/admin_v2/team/_member.html.erb
+++ b/app/views/admin_v2/team/_member.html.erb
@@ -13,23 +13,34 @@
       <% end %>
     </div>
 
-    <%= render Ui::Dropdown::Component.new do |dropdown| %>
-      <% dropdown.with_trigger_button do %>
-        <%= inline_svg_tag 'icons/ellipsis-horizontal.svg', class: 'h-6 w-6', aria: true %>
-      <% end %>
-
-      <% dropdown.with_item do %>
-        <%= link_to admin_v2_team_member_password_resets_path(team_member), data: { turbo_method: :post, turbo_frame: '_top' }, class: "text-gray-700 dark:text-gray-300 whitespace-nowrap group flex items-center px-3 py-2 text-sm #{'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300' if current_page?(edit_users_profile_path)}" do %>
-          <%= inline_svg_tag 'icons/envelope.svg', class: 'mr-3 h-6 w-6 text-gray-400 group-hover:text-gray-500 dark:text-gray-300 dark:group-hover:text-gray-400' %>
-          Send password reset email
+    <% unless team_member == current_admin_user %>
+      <%= render Ui::Dropdown::Component.new do |dropdown| %>
+        <% dropdown.with_trigger_button do %>
+          <%= inline_svg_tag 'icons/ellipsis-horizontal.svg', class: 'h-6 w-6', aria: true %>
         <% end %>
-      <% end %>
 
-      <% if team_member.active? %>
-        <% dropdown.with_item do %>
-          <%= link_to admin_v2_team_member_deactivations_path(team_member), data: { turbo_method: :post, turbo_frame: '_top' }, class: "text-red-700 dark:text-red-300 whitespace-nowrap group flex items-center px-3 py-2 text-sm #{'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300' if current_page?(edit_users_profile_path)}" do %>
-            <%= inline_svg_tag 'icons/user-minus.svg', class: 'mr-3 h-6 w-6 text-red-700 group-hover:text-red-600 dark:text-red-300 dark:group-hover:text-red-400' %>
-            Deactivate
+        <% if team_member.active? %>
+          <% dropdown.with_item do %>
+            <%= link_to admin_v2_team_member_password_resets_path(team_member), data: { turbo_method: :post, turbo_frame: '_top' }, class: 'text-gray-700 dark:text-gray-300 whitespace-nowrap group flex items-center px-3 py-2 text-sm' do %>
+              <%= inline_svg_tag 'icons/envelope.svg', class: 'mr-3 h-5 w-5 text-gray-400 group-hover:text-gray-500 dark:text-gray-300 dark:group-hover:text-gray-400' %>
+              Send password reset email
+            <% end %>
+          <% end %>
+
+          <% dropdown.with_item do %>
+            <%= link_to admin_v2_team_member_deactivations_path(team_member), data: { turbo_method: :post, turbo_frame: '_top' }, class: 'text-red-700 dark:text-red-300 whitespace-nowrap group flex items-center px-3 py-2 text-sm' do %>
+              <%= inline_svg_tag 'icons/user-minus.svg', class: 'mr-3 h-5 w-5 text-red-700 group-hover:text-red-600 dark:text-red-300 dark:group-hover:text-red-400' %>
+              Deactivate
+            <% end %>
+          <% end %>
+        <% end %>
+
+        <% if team_member.deactivated? %>
+          <% dropdown.with_item do %>
+            <%= link_to admin_v2_team_member_reactivation_path(team_member_id: team_member), data: { turbo_method: :put, turbo_frame: '_top' }, class: 'text-gray-700 dark:text-gray-300 whitespace-nowrap group flex items-center px-3 py-2 text-sm' do %>
+              <%= inline_svg_tag 'icons/user-plus.svg', class: 'mr-3 h-5 w-5 text-gray-400 group-hover:text-gray-500 dark:text-gray-300 dark:group-hover:text-gray-400' %>
+              Reactivate
+            <% end %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/admin_v2/team/show.html.erb
+++ b/app/views/admin_v2/team/show.html.erb
@@ -7,7 +7,7 @@
     <%= link_to 'Invite new member', new_admin_user_invitation_path, class: 'button button--primary p-2', data: { turbo_frame: 'modal' } %>
   </div>
 
-  <ul role="list" class="divide-y divide-gray-100 dark:divide-gray-800 mt-8">
+  <ul role="list" id="active_members" class="divide-y divide-gray-100 dark:divide-gray-800 mt-8">
     <%= turbo_frame_tag 'pending_members' do %>
        <%= render partial: 'admin_v2/team/member', collection: @pending_team_members, as: :team_member %>
     <% end %>
@@ -15,13 +15,15 @@
     <%= render partial: 'admin_v2/team/member', collection: @active_team_members, as: :team_member %>
   </ul>
 
-   <div class="border-b border-gray-200 dark:border-gray-800 pb-5 mt-10">
-      <h3 class="text-base font-semibold leading-6 text-gray-800 dark:text-gray-300">Deactivated team members</h3>
-  </div>
-  <ul>
-    <%= turbo_frame_tag 'deactivated_members' do %>
-      <%= render partial: 'admin_v2/team/member', collection: @deactivated_team_members, as: :team_member %>
-    <% end %>
-  </ul>
+  <% if @deactivated_team_members.any? %>
+    <div class="border-b border-gray-200 dark:border-gray-800 pb-5 mt-10">
+      <h3 class="text-base font-semibold leading-6 text-gray-800 dark:text-gray-300">Deactivated</h3>
+    </div>
 
+    <ul>
+      <%= turbo_frame_tag 'deactivated_members' do %>
+        <%= render partial: 'admin_v2/team/member', collection: @deactivated_team_members, as: :team_member %>
+      <% end %>
+    </ul>
+  <% end %>
 </div>

--- a/config/routes/admin_v2.rb
+++ b/config/routes/admin_v2.rb
@@ -11,6 +11,7 @@ namespace :admin_v2 do
   resources :team_members do
     resources :password_resets, only: %i[create], controller: 'team_members/password_resets'
     resources :deactivations, only: %i[create], controller: 'team_members/deactivations'
+    resource :reactivation, only: %i[update], controller: 'team_members/reactivation'
   end
 
   resource :profile, only: %i[edit update], controller: :profile do

--- a/db/migrate/20240709052504_add_reactivation_to_admin_user.rb
+++ b/db/migrate/20240709052504_add_reactivation_to_admin_user.rb
@@ -1,0 +1,6 @@
+class AddReactivationToAdminUser < ActiveRecord::Migration[7.0]
+  def change
+    add_column :admin_users, :reactivated_at, :datetime
+    add_reference :admin_users, :reactivated_by, foreign_key: { to_table: :admin_users }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_05_122456) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_09_052504) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
   # Custom types defined in this database.
@@ -57,12 +56,15 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_05_122456) do
     t.enum "status", default: "pending", null: false, enum_type: "status"
     t.datetime "deactivated_at"
     t.bigint "deactivated_by_id"
+    t.datetime "reactivated_at"
+    t.bigint "reactivated_by_id"
     t.index ["deactivated_by_id"], name: "index_admin_users_on_deactivated_by_id"
     t.index ["email"], name: "index_admin_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_admin_users_on_invitation_token", unique: true
     t.index ["invited_by_id"], name: "index_admin_users_on_invited_by_id"
     t.index ["invited_by_type", "invited_by_id"], name: "index_admin_users_on_invited_by"
     t.index ["name"], name: "index_admin_users_on_name", unique: true
+    t.index ["reactivated_by_id"], name: "index_admin_users_on_reactivated_by_id"
     t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
   end
 
@@ -324,6 +326,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_05_122456) do
   end
 
   add_foreign_key "admin_users", "admin_users", column: "deactivated_by_id"
+  add_foreign_key "admin_users", "admin_users", column: "reactivated_by_id"
   add_foreign_key "announcements", "users"
   add_foreign_key "contents", "lessons"
   add_foreign_key "flags", "project_submissions"

--- a/spec/models/admin_user_spec.rb
+++ b/spec/models/admin_user_spec.rb
@@ -99,4 +99,44 @@ RSpec.describe AdminUser do
       end
     end
   end
+
+  describe '#reactivate!' do
+    it 'reactivates the admin' do
+      admin = build(:admin_user, status: :deactivated)
+      activator = build(:admin_user)
+
+      expect do
+        admin.reactivate!(activator:)
+      end.to change { admin.status }.from('deactivated').to('active')
+    end
+
+    it 'sets the reactivator' do
+      admin = build(:admin_user, status: :deactivated)
+      activator = build(:admin_user)
+
+      expect do
+        admin.reactivate!(activator:)
+      end.to change { admin.reactivated_by }.from(nil).to(activator)
+    end
+
+    it 'sets the reactivated_at timestamp' do
+      admin = build(:admin_user, status: :deactivated)
+      activator = build(:admin_user)
+
+      freeze_time do
+        expect do
+          admin.reactivate!(activator:)
+        end.to change { admin.reactivated_at }.from(nil).to(Time.current)
+      end
+    end
+
+    context 'when the admin is already active' do
+      it 'does not reactivate the admin' do
+        admin = build(:admin_user, status: :active)
+        activator = build(:admin_user)
+
+        expect { admin.reactivate!(activator:) }.not_to change { admin.status }
+      end
+    end
+  end
 end

--- a/spec/requests/admin_v2/team_members/reactivation_spec.rb
+++ b/spec/requests/admin_v2/team_members/reactivation_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe 'Team member reactivation' do
+  describe 'PUT #update' do
+    context 'when signed in as an admin and the team member exists' do
+      it 'reactivates the team member' do
+        admin = create(:admin_user)
+        deactivated_admin = create(:admin_user, status: :deactivated)
+
+        sign_in(admin)
+
+        expect do
+          put admin_v2_team_member_reactivation_path(team_member_id: deactivated_admin.id)
+        end.to change { deactivated_admin.reload.status }.from('deactivated').to('active')
+
+        expect(response).to redirect_to(admin_v2_team_path)
+      end
+
+      it 'sends an invitation email to the team member' do
+        admin = create(:admin_user)
+        deactivated_admin = create(:admin_user, status: :deactivated, email: 'deactivated@odin.com')
+        sign_in(admin)
+
+        expect do
+          put admin_v2_team_member_reactivation_path(team_member_id: deactivated_admin.id)
+        end.to change { ActionMailer::Base.deliveries.count }
+
+        mailer = ActionMailer::Base.deliveries.last
+
+        expect(mailer.to).to eq(['deactivated@odin.com'])
+        expect(mailer.subject).to eq('The Odin Project Admin Invitation')
+      end
+    end
+
+    context 'when signed in as an admin and the team member does not exist' do
+      it 'does not reactivate the team member' do
+        admin = create(:admin_user)
+        sign_in(admin)
+
+        put admin_v2_team_member_reactivation_path(team_member_id: 1002)
+
+        expect(response).to redirect_to(admin_v2_team_path)
+        expect(flash[:alert]).to eq('Team member not found')
+      end
+    end
+
+    context 'when not signed in as an admin' do
+      it 'redirects to the admin sign in page' do
+        user = create(:user)
+        admin = create(:admin_user)
+        sign_in(user)
+
+        expect do
+          put admin_v2_team_member_reactivation_path(team_member_id: admin.id)
+        end.not_to change { admin.reload.status }
+
+        expect(response).to redirect_to(new_admin_user_session_path)
+      end
+    end
+  end
+end

--- a/spec/system/admin_v2/deactivations_spec.rb
+++ b/spec/system/admin_v2/deactivations_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Admin V2 team members deactivations' do
   it 'deactivates a team member' do
     admin = create(:admin_user, status: :active)
-    other_admin = create(:admin_user, status: :active)
+    other_admin = create(:admin_user, status: :active, email: 'otheradmin@odin.com', password: 'password')
 
     sign_in(admin)
 
@@ -17,6 +17,17 @@ RSpec.describe 'Admin V2 team members deactivations' do
 
     within('#deactivated_members') do
       expect(page).to have_content(other_admin.name)
+    end
+
+    using_session('other_admin') do
+      visit new_admin_user_session_path
+
+      fill_in 'Email', with: other_admin.email
+      fill_in 'Password', with: other_admin.password
+      click_button 'Sign in'
+
+      expect(page).to have_current_path(new_admin_user_session_path)
+      expect(page).to have_content('Your account is deactivated')
     end
   end
 end

--- a/spec/system/admin_v2/reactivations_spec.rb
+++ b/spec/system/admin_v2/reactivations_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin V2 team members reactivations' do
+  it 'deactivates a team member' do
+    admin = create(:admin_user, status: :active)
+    deactivated_admin = create(:admin_user, status: :deactivated, email: 'deactivated@admin.com')
+
+    sign_in(admin)
+
+    visit admin_v2_team_path
+    sleep 0.1 # dropdown animations can be slow
+
+    within("#admin_user_#{deactivated_admin.id}") do
+      find(:test_id, 'dropdown-button').click
+      click_link('Reactivate')
+    end
+
+    within('#active_members') do
+      expect(page).to have_content(deactivated_admin.name)
+    end
+
+    using_session('deactivated_admin') do
+      open_email('deactivated@admin.com')
+      expect(current_email.subject).to match(/The Odin Project Admin Invitation/)
+      current_email.click_link('Accept invitation')
+
+      find(:test_id, 'password-field').fill_in(with: 'supersecretpassword')
+      find(:test_id, 'password-confirmation-field').fill_in(with: 'supersecretpassword')
+      click_button('Submit')
+
+      expect(page).to have_current_path(admin_v2_dashboard_path)
+    end
+  end
+end


### PR DESCRIPTION
Because:
- When an old team member returns to the team, I want to reactivate them as an admin, so they can regain access to the admin area.
- Closes: #4608 

This commit:
- Adds a "Reactivate" action to deactivated admin team members
- Reactivated team members are sent an invite email and can log in again.