### PR TITLE
Feature: Unify width of lesson content with submissions and buttons for wide viewport

### DIFF
--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -6,7 +6,7 @@
     <%= render 'lessons/header', lesson: @lesson %>
 
     <main class="grid grid-cols-12 gap-x-6" data-controller="lesson-toc" data-lesson-toc-item-classes-value="no-underline hover:text-gray-800 text-sm dark:hover:text-gray-300">
-      <article class="col-span-full xl:col-span-7 xl:col-start-2">
+      <article class="col-span-full xl:col-span-7 xl:col-start-2 xl:max-w-prose">
         <%= render ContentContainerComponent.new(classes: 'xl:mx-0 pb-6', data_attributes: { lesson_toc_target: 'lessonContent' }) do |component| %>
           <%= @lesson.body.html_safe %>
 


### PR DESCRIPTION
## Because

After the `xl` breakpoint, the lesson contents div and div housing course/lesson buttons and submissions are both left-aligned but different widths.

No changes needed below the `xl` breakpoint, as the lesson content is centred above the stretched buttons/submissions div.

## This PR

- Adds `xl:max-w-prose` to the parent `<article>`

## Issue

N/A

## Additional Information

Current:
![2024-07-11_06:20_screenshot](https://github.com/user-attachments/assets/9c6107ca-830f-4e65-9575-562468a80a22)

Unified:
![2024-07-11_06:19_screenshot](https://github.com/user-attachments/assets/0a925bcf-3045-4acf-875a-d51fee22ecf3)


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [ ] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If applicable, this PR includes new or updated automated tests
