### PR TITLE
Feature: Admin V2 - Path Analytics

### DIFF
--- a/app/components/charts/horizontal_bar_chart_component.html.erb
+++ b/app/components/charts/horizontal_bar_chart_component.html.erb
@@ -1,8 +1,8 @@
- <div class="w-full h-full">
+ <div class="w-full h-full relative p-0" style="height: <%= height %>px;">
     <canvas
       class="chart"
       data-controller="chart"
-      data-chart-type-value="line"
+      data-chart-type-value="bar"
       data-chart-data-value="<%= data.to_json %>"
       data-chart-options-value="<%= options.to_json %>">
     </canvas>

--- a/app/components/charts/horizontal_bar_chart_component.rb
+++ b/app/components/charts/horizontal_bar_chart_component.rb
@@ -1,0 +1,45 @@
+class Charts::HorizontalBarChartComponent < ApplicationComponent
+  NORMAL_BAR_THICKNESS = 25
+  SMALL_DATASET_BAR_THICKNESS = 40
+
+  def initialize(labels:, datasets:, options: {})
+    @labels = labels
+    @datasets = datasets
+    @options = options
+  end
+
+  def data
+    {
+      labels:,
+      datasets:
+    }
+  end
+
+  def height
+    return SMALL_DATASET_BAR_THICKNESS * labels.size if labels.size <= 5
+
+    NORMAL_BAR_THICKNESS * labels.size
+  end
+
+  def options # rubocop:disable Metrics/MethodLength
+    {
+      indexAxis: 'y',
+      scales: {
+        y: {
+          grid: { display: false },
+          ticks: {
+            crossAlign: 'far',
+          },
+        },
+        x: {
+          type: 'linear',
+          ticks: { precision: 0 },
+        }
+      },
+    }.merge(@options)
+  end
+
+  private
+
+  attr_reader :labels, :datasets
+end

--- a/app/components/charts/line_chart_component.rb
+++ b/app/components/charts/line_chart_component.rb
@@ -1,7 +1,8 @@
 class Charts::LineChartComponent < ApplicationComponent
-  def initialize(labels:, datasets:)
+  def initialize(labels:, datasets:, options: {})
     @labels = labels
     @datasets = datasets
+    @options = options
   end
 
   def data
@@ -9,6 +10,20 @@ class Charts::LineChartComponent < ApplicationComponent
       labels:,
       datasets:
     }
+  end
+
+  def options # rubocop:disable Metrics/MethodLength
+    {
+      scales: {
+        y: {
+          type: 'linear',
+          ticks: { precision: 0 },
+        },
+        x: {
+          grid: { display: false },
+        },
+      },
+    }.merge(@options)
   end
 
   private

--- a/app/controllers/admin_v2/reports/paths_controller.rb
+++ b/app/controllers/admin_v2/reports/paths_controller.rb
@@ -1,0 +1,32 @@
+module AdminV2
+  class Reports::PathsController < AdminV2::BaseController
+    before_action :set_date_range, only: :show
+
+    def show
+      @path = Path.find(params[:id])
+
+      @path_lesson_completions = @path.lesson_completion_stats
+        .filter_by_course(params[:course_id])
+        .for_date_range(@start, @end)
+        .group_by_lesson
+    end
+
+    private
+
+    def set_date_range
+      @earliest = ::Reports::PathLessonCompletionsDayStat.earliest_date
+      @latest = default_end_date
+
+      @start = Date.parse(params.fetch(:start, default_start_date))
+      @end = Date.parse(params.fetch(:end, default_end_date))
+    end
+
+    def default_start_date
+      1.month.ago.to_date.to_s
+    end
+
+    def default_end_date
+      Time.zone.today.to_s
+    end
+  end
+end

--- a/app/javascript/controllers/chart_controller.js
+++ b/app/javascript/controllers/chart_controller.js
@@ -7,36 +7,25 @@ export default class ChartController extends Controller {
   static values = {
     type: String,
     data: Object,
+    options: Object,
   };
 
   connect() {
     this.chart = new Chart(
       this.element,
       {
-        type: 'line',
+        type: this.typeValue,
         data: this.dataValue,
         plugins: [twColorsPlugin(twConfig)],
         options: {
           maintainAspectRatio: false,
           responsive: true,
-          scales: {
-            y: {
-              type: 'linear',
-              ticks: {
-                precision: 0,
-              },
-            },
-            x: {
-              grid: {
-                display: false,
-              },
-            },
-          },
           plugins: {
             legend: {
               display: false,
             },
           },
+          ...this.optionsValue,
         },
       },
     );

--- a/app/jobs/refresh_materialized_views_job.rb
+++ b/app/jobs/refresh_materialized_views_job.rb
@@ -3,7 +3,8 @@ class RefreshMaterializedViewsJob < ApplicationJob
 
   def perform
     [
-      Reports::AllLessonCompletionsDayStat
+      Reports::AllLessonCompletionsDayStat,
+      Reports::PathLessonCompletionsDayStat
     ].each(&:refresh)
   end
 end

--- a/app/models/concerns/materialized_view.rb
+++ b/app/models/concerns/materialized_view.rb
@@ -1,0 +1,12 @@
+module MaterializedView
+  extend ActiveSupport::Concern
+  class_methods do
+    def refresh
+      Scenic.database.refresh_materialized_view(table_name, concurrently: false, cascade: false)
+    end
+  end
+
+  def readonly?
+    true
+  end
+end

--- a/app/models/path.rb
+++ b/app/models/path.rb
@@ -5,14 +5,17 @@ class Path < ApplicationRecord
 
   has_many :users, dependent: :nullify
   has_many :courses, -> { order(:position) }, dependent: :destroy, inverse_of: :path
+  has_many :lessons, through: :courses
   has_many :path_prerequisites, dependent: :destroy
   has_many :prerequisites, through: :path_prerequisites, source: :prerequisite
+  has_many :lesson_completion_stats, class_name: 'Reports::PathLessonCompletionsDayStat', dependent: :destroy
 
   validates :title, presence: true
   validates :description, presence: true
   validates :position, presence: true
 
   scope :fullstack_paths, -> { where.not(default_path: true) }
+  scope :order_by_position, -> { order(:position) }
 
   def self.default_path
     find_by(default_path: true)

--- a/app/models/reports/all_lesson_completions_day_stat.rb
+++ b/app/models/reports/all_lesson_completions_day_stat.rb
@@ -1,4 +1,6 @@
 class Reports::AllLessonCompletionsDayStat < ApplicationRecord
+  include MaterializedView
+
   scope :for_date_range, ->(start_date, end_date) { where(date: start_date..end_date) }
 
   scope :group_by_period, lambda { |period|
@@ -7,19 +9,11 @@ class Reports::AllLessonCompletionsDayStat < ApplicationRecord
       .sum(:completions_count)
   }
 
-  def self.refresh
-    Scenic.database.refresh_materialized_view(table_name, concurrently: false, cascade: false)
-  end
-
   def self.earliest_date
     minimum(:date) || Time.zone.today
   end
 
   def self.latest_date
     maximum(:date) || Time.zone.today
-  end
-
-  def readonly?
-    true
   end
 end

--- a/app/models/reports/path_lesson_completions_day_stat.rb
+++ b/app/models/reports/path_lesson_completions_day_stat.rb
@@ -1,0 +1,38 @@
+class Reports::PathLessonCompletionsDayStat < ApplicationRecord
+  include MaterializedView
+
+  belongs_to :path
+  belongs_to :course
+
+  scope :for_date_range, ->(start_date, end_date) { where(date: start_date..end_date) }
+
+  scope :group_by_lesson, lambda {
+    group(:lesson_title, :lesson_id, :lesson_position, :course_position)
+      .order(course_position: :asc, lesson_position: :asc)
+      .sum(:completions_count)
+      .map { |(lesson_title), count| Stat.new(lesson_title, count) }
+  }
+
+  def self.filter_by_course(course_id)
+    return all if course_id.blank?
+
+    where(course_id:)
+  end
+
+  def self.earliest_date
+    minimum(:date) || Time.zone.today
+  end
+
+  def self.latest_date
+    maximum(:date) || Time.zone.today
+  end
+
+  class Stat
+    attr_reader :lesson_title, :count
+
+    def initialize(lesson_title, count)
+      @lesson_title = lesson_title
+      @count = count
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,8 @@ class User < ApplicationRecord
   has_many :notifications, as: :recipient, dependent: :destroy
   has_many :announcements, dependent: nil
   has_many :likes, dependent: :destroy
-  belongs_to :path, optional: true
+
+  belongs_to :path, optional: true, counter_cache: true
 
   scope :created_after, ->(date) { where(arel_table[:created_at].gt(date)) }
 

--- a/app/views/admin_v2/dashboard/show.html.erb
+++ b/app/views/admin_v2/dashboard/show.html.erb
@@ -16,7 +16,7 @@
 
   </ul>
 
-  <div class="border-b border-gray-200 pb-5 mt-6">
+  <div class="border-b border-gray-200 dark:border-gray-800 pb-5 mt-6">
     <h3 class="text-base font-semibold leading-6 text-gray-800 dark:text-gray-300">Reports</h3>
   </div>
 

--- a/app/views/admin_v2/reports/paths/show.html.erb
+++ b/app/views/admin_v2/reports/paths/show.html.erb
@@ -1,0 +1,70 @@
+<div class="max-w-5xl w-full mx-auto">
+  <div class="sm:flex-auto">
+    <h1 class="text-xl font-semibold leading-6 text-gray-800 dark:text-gray-300"><%= @path.title %> path</h1>
+    <p class="mt-2 text-sm text-gray-500 dark:text-gray-400 max-w-">Analytics for the <%= @path.title %> path</p>
+  </div>
+
+  <ul role="list" class="mt-5 grid grid-cols-1 gap-5 sm:grid-cols-4">
+
+    <li class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 px-4 py-5 hover:border-gray-300 border border-gray-200 dark:border-gray-700 dark:hover:border-gray-600 sm:p-6">
+      <dt class="truncate text-sm font-medium text-gray-500 dark:text-gray-300"><%= 'Enrolment'.pluralize(@path.users_count) %></dt>
+      <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-800 dark:text-gray-200"><%= number_with_delimiter(@path.users_count) %></dd>
+    </li>
+
+    <% if @path.courses.many? %>
+      <li class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 px-4 py-5 hover:border-gray-300 border border-gray-200 dark:border-gray-700 dark:hover:border-gray-600 sm:p-6">
+        <dt class="truncate text-sm font-medium text-gray-500 dark:text-gray-300"><%= 'Courses' %></dt>
+        <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-800 dark:text-gray-200"><%= @path.courses.count %></dd>
+      </li>
+    <% end %>
+
+    <li class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 px-4 py-5 hover:border-gray-300 border border-gray-200 dark:border-gray-700 dark:hover:border-gray-600 sm:p-6">
+      <dt class="truncate text-sm font-medium text-gray-500 dark:text-gray-300"><%= 'Lesson'.pluralize(@path.lessons.count) %></dt>
+      <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-800 dark:text-gray-200"><%= @path.lessons.count %></dd>
+    </li>
+
+  </ul>
+
+  <div class="border-b border-gray-200 dark:border-gray-800 pb-5 mt-6">
+    <h3 class="text-base font-semibold leading-6 text-gray-800 dark:text-gray-300">Lesson completions</h3>
+  </div>
+
+  <%= turbo_frame_tag 'path_lesson_completions' do %>
+    <div>
+      <%= form_with url: admin_v2_reports_path_path(@path), method: :get, data: { controller: 'autosubmit', action: 'input->autosubmit#debouncedSubmit' } do |form| %>
+        <div class="flex flex-col sm:flex-row justify-between mt-6 sm:items-center">
+          <div class="flex gap-x-2 items-center">
+            <%= render Forms::DatePickerComponent.new(name: :start, value: @start, min: @earliest, max: @end) %>
+            <span class="mt-2">-</span>
+            <%= render Forms::DatePickerComponent.new(name: :end, value: @end, min: @start, max: @latest) %>
+          </div>
+
+          <% if @path.courses.many? %>
+            <%= form.select :course_id, options_for_select(@path.courses.collect { |course| [course.title, course.id] }.prepend(['All courses', nil]), selected: params[:course_id]), {}, { class: 'block w-full mt-6 sm:mt-0 max-w-60 border rounded-md py-2 px-3 focus:outline-none dark:bg-gray-700/50 dark:border-gray-500 dark:text-gray-300 dark:placeholder-gray-400 dark:focus:ring-2 dark:focus:border-transparent border-gray-300 focus:ring-blue-600 focus:border-blue-600 dark:focus:ring-blue-400 text-sm' } %>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="'w-full flex mt-4 h-screen">
+      <%= render Charts::HorizontalBarChartComponent.new(
+            labels: @path_lesson_completions.map(&:lesson_title),
+            options: {
+              animation: {
+                duration: 0
+              }
+            },
+            datasets: [
+              {
+                label: 'Lesson completions',
+                data: @path_lesson_completions.map(&:count),
+                borderColor: 'emerald-600',
+                backgroundColor: 'emerald-300',
+                borderWidth: 1,
+              }
+            ],
+          ) %>
+
+    </div>
+  <% end %>
+</div>

--- a/app/views/layouts/admin_v2/_sidebar_nav.html.erb
+++ b/app/views/layouts/admin_v2/_sidebar_nav.html.erb
@@ -4,9 +4,11 @@ nav_links = [
   { name: 'Flags', path: admin_v2_flags_path, icon: 'flag-outline' },
   { name: 'Announcements', path: admin_v2_announcements_path, icon: 'megaphone' },
   { name: 'Team', path: admin_v2_team_path, icon: 'user-group' },
-  { name: 'Analytics', icon: 'chart-bar', nested_nav_links: [
-    { name: 'Lesson completions', path: admin_v2_reports_lesson_completions_path },
-  ]}
+  {
+    name: 'Analytics', icon: 'chart-bar', nested_nav_links: [
+      { name: 'Lesson completions', path: admin_v2_reports_lesson_completions_path },
+    ].concat(Path.order_by_position.flat_map { |path| { name: "#{path.title} path", path: admin_v2_reports_path_path(path) } })
+  }
 ]
 %>
 

--- a/config/routes/admin_v2.rb
+++ b/config/routes/admin_v2.rb
@@ -20,5 +20,6 @@ namespace :admin_v2 do
 
   namespace :reports do
     resource :lesson_completions, only: :show
+    resources :paths, only: :show
   end
 end

--- a/db/migrate/20240712073547_create_path_lesson_completions_day_stats.rb
+++ b/db/migrate/20240712073547_create_path_lesson_completions_day_stats.rb
@@ -1,0 +1,5 @@
+class CreatePathLessonCompletionsDayStats < ActiveRecord::Migration[7.0]
+  def change
+    create_view :path_lesson_completions_day_stats, materialized: true
+  end
+end

--- a/db/migrate/20240713134127_add_users_counter_to_paths.rb
+++ b/db/migrate/20240713134127_add_users_counter_to_paths.rb
@@ -1,0 +1,9 @@
+class AddUsersCounterToPaths < ActiveRecord::Migration[7.0]
+  def up
+    add_column :paths, :users_count, :integer, default: 0
+
+    Path.find_each do |path|
+      Path.reset_counters(path.id, :users)
+    end
+  end
+end

--- a/db/views/path_lesson_completions_day_stats_v01.sql
+++ b/db/views/path_lesson_completions_day_stats_v01.sql
@@ -1,0 +1,15 @@
+SELECT
+  ROW_NUMBER() OVER (ORDER BY lesson_completions.created_at::DATE DESC) as id,
+  lesson_completions.path_id,
+  lesson_id,
+  lesson_completions.course_id,
+  lessons.position as lesson_position,
+  courses.position as course_position,
+  lesson_completions.created_at::DATE as date,
+  lessons.title as lesson_title,
+  COUNT(*) AS completions_count
+FROM lesson_completions
+  JOIN lessons ON lesson_completions.lesson_id = lessons.id
+  JOIN courses ON lesson_completions.course_id = courses.id
+  GROUP BY lesson_completions.created_at::DATE, lesson_completions.path_id, lesson_id, lesson_title, lesson_completions.course_id, lesson_position, course_position
+  ORDER BY lesson_completions.created_at::DATE DESC

--- a/spec/components/charts/horizontal_bar_chart_component_spec.rb
+++ b/spec/components/charts/horizontal_bar_chart_component_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Charts::HorizontalBarChartComponent, type: :component do
+  context 'when the dataset is smaller than 5' do
+    it 'renders the chart with an appropiate height' do
+      component = described_class.new(labels: %w[A B], datasets: [1, 2])
+
+      render_inline(component)
+
+      expect(page).to have_css('div', style: 'height: 80px;')
+    end
+  end
+
+  context 'when the dataset is larger than 5' do
+    it 'renders the chart with an appropiate height' do
+      component = described_class.new(labels: %w[A B C D E F], datasets: [1, 2, 3, 4, 5, 6])
+
+      render_inline(component)
+
+      expect(page).to have_css('div', style: 'height: 150px;')
+    end
+  end
+end

--- a/spec/jobs/refresh_materialized_views_job_spec.rb
+++ b/spec/jobs/refresh_materialized_views_job_spec.rb
@@ -6,11 +6,17 @@ RSpec.describe RefreshMaterializedViewsJob do
   describe '#perform' do
     before do
       allow(Reports::AllLessonCompletionsDayStat).to receive(:refresh)
+      allow(Reports::PathLessonCompletionsDayStat).to receive(:refresh)
     end
 
     it 'refreshes all lesson completions day stats' do
       job.perform
       expect(Reports::AllLessonCompletionsDayStat).to have_received(:refresh)
+    end
+
+    it 'refreshes path lesson completions day stats' do
+      job.perform
+      expect(Reports::PathLessonCompletionsDayStat).to have_received(:refresh)
     end
   end
 end

--- a/spec/models/path_spec.rb
+++ b/spec/models/path_spec.rb
@@ -1,12 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe Path do
-  subject { described_class.new }
+  subject(:path) { described_class.new }
 
   it { is_expected.to have_many(:users) }
   it { is_expected.to have_many(:courses).order(:position) }
+  it { is_expected.to have_many(:lessons).through(:courses) }
   it { is_expected.to have_many(:path_prerequisites).dependent(:destroy) }
   it { is_expected.to have_many(:prerequisites).through(:path_prerequisites).source(:prerequisite) }
+
+  it do
+    expect(path).to have_many(:lesson_completion_stats).class_name('Reports::PathLessonCompletionsDayStat')
+      .dependent(:destroy)
+  end
 
   it { is_expected.to validate_presence_of(:title) }
   it { is_expected.to validate_presence_of(:description) }

--- a/spec/models/reports/all_lesson_completions_day_stat_spec.rb
+++ b/spec/models/reports/all_lesson_completions_day_stat_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Reports::AllLessonCompletionsDayStat do
   end
 
   describe '.earliest_date' do
-    it 'returns the earliest lesson completion month stat' do
+    it 'returns the earliest lesson completions day stat' do
       create(:lesson_completion, created_at: Time.utc(2022, 1, 1))
       create(:lesson_completion, created_at: Time.utc(2022, 2, 1))
       create(:lesson_completion, created_at: Time.utc(2022, 3, 1))
@@ -60,13 +60,14 @@ RSpec.describe Reports::AllLessonCompletionsDayStat do
 
     context 'when there are no lesson completions' do
       it 'defaults to today' do
+        described_class.refresh
         expect(described_class.earliest_date).to eq(Time.zone.today)
       end
     end
   end
 
   describe '.latest_date' do
-    it 'returns the earliest lesson completion month stat' do
+    it 'returns the earliest lesson completions day stat' do
       create(:lesson_completion, created_at: Time.utc(2022, 1, 1))
       create(:lesson_completion, created_at: Time.utc(2022, 2, 1))
       create(:lesson_completion, created_at: Time.utc(2022, 3, 1))
@@ -78,6 +79,7 @@ RSpec.describe Reports::AllLessonCompletionsDayStat do
 
     context 'when there are no lesson completions' do
       it 'defaults to today' do
+        described_class.refresh
         expect(described_class.latest_date).to eq(Time.zone.today)
       end
     end

--- a/spec/models/reports/path_lesson_completions_day_stat_spec.rb
+++ b/spec/models/reports/path_lesson_completions_day_stat_spec.rb
@@ -1,0 +1,129 @@
+require 'rails_helper'
+
+RSpec.describe Reports::PathLessonCompletionsDayStat do
+  it { is_expected.to belong_to(:path) }
+  it { is_expected.to belong_to(:course) }
+
+  describe '.for_date_range' do
+    it 'returns path lesson completion stats for the given date range' do
+      course = create(:course)
+      create(:lesson_completion, course:, created_at: Time.utc(2022, 1, 1))
+      create(:lesson_completion, course:, created_at: Time.utc(2022, 1, 2))
+      create(:lesson_completion, course:, created_at: Time.utc(2022, 1, 3))
+      create(:lesson_completion, course:, created_at: Time.utc(2022, 1, 4))
+
+      described_class.refresh
+
+      expect(described_class.for_date_range('2022-01-01', '2022-01-02').map(&:date))
+        .to contain_exactly(Time.utc(2022, 1, 1), Time.utc(2022, 1, 2))
+    end
+  end
+
+  describe '.group_by_lesson' do
+    it 'returns path lesson completion stats grouped by lesson' do
+      course = create(:course)
+      lesson_one = create(:lesson, title: 'Ruby basics', course:, position: 1)
+      lesson_two = create(:lesson, title: 'JS basics', course:, position: 2)
+
+      create(:lesson_completion, course:, lesson: lesson_one, created_at: Time.utc(2022, 1, 1))
+      create(:lesson_completion, course:, lesson: lesson_two, created_at: Time.utc(2022, 2, 2))
+      create(:lesson_completion, course:, lesson: lesson_one, created_at: Time.utc(2022, 1, 4))
+
+      described_class.refresh
+
+      expect(described_class.group_by_lesson).to contain_exactly(
+        have_attributes(lesson_title: 'Ruby basics', count: 2), have_attributes(lesson_title: 'JS basics', count: 1)
+      )
+    end
+
+    it 'orders the stats by course position first and then lesson position' do
+      path = create(:path)
+      first_course = create(:course, position: 1)
+      second_course = create(:course, position: 2)
+      lesson_one = create(:lesson, title: 'Ruby basics', position: 1)
+      lesson_two = create(:lesson, title: 'JS basics', position: 2)
+      lesson_three = create(:lesson, title: 'HTML basics', position: 10)
+
+      create(:lesson_completion, path:, course: first_course, lesson: lesson_two, created_at: Time.utc(2022, 1, 4))
+      create(:lesson_completion, path:, course: first_course, lesson: lesson_three, created_at: Time.utc(2022, 1, 4))
+      create(:lesson_completion, path:, course: second_course, lesson: lesson_one, created_at: Time.utc(2022, 1, 1))
+      create(:lesson_completion, path:, course: second_course, lesson: lesson_one, created_at: Time.utc(2022, 2, 2))
+
+      described_class.refresh
+
+      expect(described_class.group_by_lesson.map(&:lesson_title)).to eq(['JS basics', 'HTML basics', 'Ruby basics'])
+    end
+  end
+
+  describe '.filter_by_course' do
+    it 'returns all lesson completion stats for the given course' do
+      course = create(:course)
+      create(:lesson_completion, created_at: Time.utc(2022, 1, 1))
+      create(:lesson_completion, course:, created_at: Time.utc(2022, 1, 2))
+      create(:lesson_completion, course:, created_at: Time.utc(2022, 1, 3))
+      create(:lesson_completion, created_at: Time.utc(2022, 1, 4))
+
+      described_class.refresh
+
+      expect(described_class.filter_by_course(nil).map(&:date)).to eq(
+        [Time.utc(2022, 1, 3), Time.utc(2022, 1, 2)]
+      )
+    end
+
+    context 'when course_id is blank' do
+      it 'returns all lesson completion stats' do
+        course = create(:course)
+        create(:lesson_completion, course:, created_at: Time.utc(2022, 1, 1))
+        create(:lesson_completion, course:, created_at: Time.utc(2022, 1, 2))
+        create(:lesson_completion, course:, created_at: Time.utc(2022, 1, 3))
+        create(:lesson_completion, course:, created_at: Time.utc(2022, 1, 4))
+
+        described_class.refresh
+
+        expect(described_class.filter_by_course(nil).map(&:date)).to eq(
+          [Time.utc(2022, 1, 4), Time.utc(2022, 1, 3), Time.utc(2022, 1, 2), Time.utc(2022, 1, 1)]
+        )
+      end
+    end
+  end
+
+  describe '.earliest_date' do
+    it 'returns the earliest path lesson completions stat' do
+      course = create(:course)
+      create(:lesson_completion, course:, created_at: Time.utc(2022, 1, 1))
+      create(:lesson_completion, course:, created_at: Time.utc(2022, 2, 1))
+      create(:lesson_completion, course:, created_at: Time.utc(2022, 3, 1))
+
+      described_class.refresh
+
+      expect(described_class.earliest_date).to eq(Time.utc(2022, 1, 1))
+    end
+
+    context 'when there are no lesson completions' do
+      it 'defaults to today' do
+        described_class.refresh
+        expect(described_class.earliest_date).to eq(Time.zone.today)
+      end
+    end
+  end
+
+  describe '.latest_date' do
+    it 'returns the earliest path lesson completions stat' do
+      course = create(:course)
+      create(:lesson_completion, course:, created_at: Time.utc(2022, 1, 1))
+      create(:lesson_completion, course:, created_at: Time.utc(2022, 2, 1))
+      create(:lesson_completion, course:, created_at: Time.utc(2022, 3, 1))
+
+      described_class.refresh
+
+      expect(described_class.latest_date).to eq(Time.utc(2022, 3, 1))
+    end
+
+    context 'when there are no lesson completions' do
+      it 'defaults to today' do
+        described_class.refresh
+        expect(described_class.latest_date).to eq(Time.zone.today)
+      end
+    end
+  end
+end

--- a/spec/requests/admin_v2/reports/paths_spec.rb
+++ b/spec/requests/admin_v2/reports/paths_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe 'Reports - Path' do
+  describe 'GET #show' do
+    context 'when signed in as an admin' do
+      it 'renders the path report' do
+        admin = create(:admin_user)
+        path = create(:path)
+
+        sign_in(admin)
+        get admin_v2_reports_path_path(path)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when not signed in as an admin' do
+      it 'redirects to the sign in page' do
+        path = create(:path)
+
+        get admin_v2_reports_path_path(path)
+
+        expect(response).to redirect_to(new_admin_user_session_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Because:
- When I need to find something out about a path, I want to go to a path analytics page on admin that can tell me basic stats about the path.

This commit:
- Adds analytics report pages for all paths
- Displays the lesson, courses and enrolments count for the path in cards
- Displays lesson completions for each lesson in the path within a horizontal bar graph
- Allows admins to see path lesson completions in the graph over a period of time
- Allows admins to filter the path lesson completions by course


https://github.com/user-attachments/assets/a66c764f-2efa-4140-8b0c-a5d2b1cf8523