### PR TITLE
Chore: Change deactivations controller to singular resource

### DIFF
--- a/app/controllers/admin_v2/team_members/deactivation_controller.rb
+++ b/app/controllers/admin_v2/team_members/deactivation_controller.rb
@@ -1,8 +1,8 @@
 module AdminV2
-  class TeamMembers::DeactivationsController < AdminV2::BaseController
+  class TeamMembers::DeactivationController < AdminV2::BaseController
     rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
-    def create
+    def update
       team_member = AdminUser.find(params[:team_member_id])
 
       team_member.deactivate!(deactivator: current_admin_user)

--- a/app/views/admin_v2/team/_member.html.erb
+++ b/app/views/admin_v2/team/_member.html.erb
@@ -28,7 +28,7 @@
           <% end %>
 
           <% dropdown.with_item do %>
-            <%= link_to admin_v2_team_member_deactivations_path(team_member), data: { turbo_method: :post, turbo_frame: '_top' }, class: 'text-red-700 dark:text-red-300 whitespace-nowrap group flex items-center px-3 py-2 text-sm' do %>
+            <%= link_to admin_v2_team_member_deactivation_path(team_member), data: { turbo_method: :put, turbo_frame: '_top' }, class: 'text-red-700 dark:text-red-300 whitespace-nowrap group flex items-center px-3 py-2 text-sm' do %>
               <%= inline_svg_tag 'icons/user-minus.svg', class: 'mr-3 h-5 w-5 text-red-700 group-hover:text-red-600 dark:text-red-300 dark:group-hover:text-red-400' %>
               Deactivate
             <% end %>

--- a/config/routes/admin_v2.rb
+++ b/config/routes/admin_v2.rb
@@ -10,7 +10,7 @@ namespace :admin_v2 do
 
   resources :team_members do
     resources :password_resets, only: %i[create], controller: 'team_members/password_resets'
-    resources :deactivations, only: %i[create], controller: 'team_members/deactivations'
+    resource :deactivation, only: %i[update], controller: 'team_members/deactivation'
     resource :reactivation, only: %i[update], controller: 'team_members/reactivation'
   end
 

--- a/spec/system/admin_v2/deactivations_spec.rb
+++ b/spec/system/admin_v2/deactivations_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Admin V2 team members deactivations' do
+RSpec.describe 'Admin V2 team member deactivation' do
   it 'deactivates a team member' do
     admin = create(:admin_user, status: :active)
     other_admin = create(:admin_user, status: :active, email: 'otheradmin@odin.com', password: 'password')


### PR DESCRIPTION
Because:
- It makes more sense for deactivation to be an update action instead of create.
- It can be changed to a singular resource because we can get the team member id through the parent route.