### PR TITLE
Feature: Admin v2 - Users analytics

### DIFF
--- a/app/components/charts/line_chart_component.html.erb
+++ b/app/components/charts/line_chart_component.html.erb
@@ -1,9 +1,9 @@
  <div class="w-full h-full">
     <canvas
       class="chart"
-      data-controller="chart"
-      data-chart-type-value="line"
-      data-chart-data-value="<%= data.to_json %>"
-      data-chart-options-value="<%= options.to_json %>">
+      data-controller="chart-with-crosshair"
+      data-chart-with-crosshair-type-value="line"
+      data-chart-with-crosshair-data-value="<%= data.to_json %>"
+      data-chart-with-crosshair-options-value="<%= options.to_json %>">
     </canvas>
   </div>

--- a/app/components/charts/line_chart_component.rb
+++ b/app/components/charts/line_chart_component.rb
@@ -1,8 +1,9 @@
 class Charts::LineChartComponent < ApplicationComponent
-  def initialize(labels:, datasets:, options: {})
+  def initialize(labels:, datasets:, options: {}, display_x_labels: true)
     @labels = labels
     @datasets = datasets
     @options = options
+    @display_x_labels = ActiveModel::Type::Boolean.new.cast(display_x_labels)
   end
 
   def data
@@ -14,13 +15,16 @@ class Charts::LineChartComponent < ApplicationComponent
 
   def options # rubocop:disable Metrics/MethodLength
     {
+      hover: {
+        intersect: false
+      },
       scales: {
         y: {
           type: 'linear',
           ticks: { precision: 0 },
         },
         x: {
-          grid: { display: false },
+          display: display_x_labels,
         },
       },
     }.merge(@options)
@@ -28,5 +32,5 @@ class Charts::LineChartComponent < ApplicationComponent
 
   private
 
-  attr_reader :labels, :datasets
+  attr_reader :labels, :datasets, :display_x_labels
 end

--- a/app/controllers/admin_v2/reports/users_controller.rb
+++ b/app/controllers/admin_v2/reports/users_controller.rb
@@ -1,9 +1,9 @@
 module AdminV2
-  class Reports::LessonCompletionsController < AdminV2::BaseController
-    before_action :set_date_range, only: :show
+  class Reports::UsersController < AdminV2::BaseController
+    before_action :set_date_range, only: :index
 
-    def show
-      @lesson_completions_stats = ::Reports::AllLessonCompletionsDayStat
+    def index
+      @sign_up_stats = ::Reports::UserSignUpsDayStat
         .for_date_range(@start, @end)
         .group_by_period(params.fetch(:period, 'day'))
     end
@@ -11,7 +11,7 @@ module AdminV2
     private
 
     def set_date_range
-      @earliest = ::Reports::AllLessonCompletionsDayStat.earliest_date
+      @earliest = ::Reports::UserSignUpsDayStat.earliest_date
       @latest = default_end_date
 
       @start = Date.parse(params.fetch(:start, default_start_date))

--- a/app/javascript/controllers/chart_controller.js
+++ b/app/javascript/controllers/chart_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from '@hotwired/stimulus';
-import Chart from 'chart.js/auto';
+
+import { Chart } from 'chart.js/auto';
 import twColorsPlugin from 'chartjs-plugin-tailwindcss-colors';
 import twConfig from '../../../tailwind.config';
 
@@ -16,7 +17,7 @@ export default class ChartController extends Controller {
       {
         type: this.typeValue,
         data: this.dataValue,
-        plugins: [twColorsPlugin(twConfig)],
+        plugins: [twColorsPlugin(twConfig), ...this.chartTypePlugins()],
         options: {
           maintainAspectRatio: false,
           responsive: true,
@@ -24,6 +25,7 @@ export default class ChartController extends Controller {
             legend: {
               display: false,
             },
+            ...this.chartTypePluginOptions(),
           },
           ...this.optionsValue,
         },
@@ -33,5 +35,16 @@ export default class ChartController extends Controller {
 
   disconnect() {
     this.chart.destroy();
+  }
+
+  // private
+
+  /* eslint-disable class-methods-use-this */
+  chartTypePlugins() {
+    return [];
+  }
+
+  chartTypePluginOptions() {
+    return {};
   }
 }

--- a/app/javascript/controllers/chart_with_crosshair_controller.js
+++ b/app/javascript/controllers/chart_with_crosshair_controller.js
@@ -1,0 +1,41 @@
+/* eslint-disable class-methods-use-this */
+
+import { Interaction } from 'chart.js/auto';
+import { CrosshairPlugin, Interpolate } from 'chartjs-plugin-crosshair';
+import ChartController from './chart_controller';
+
+export default class ChartWithCrosshairController extends ChartController {
+  connect() {
+    Interaction.modes.interpolate = Interpolate;
+    super.connect();
+  }
+
+  chartTypePlugins() {
+    return [CrosshairPlugin, Interpolate];
+  }
+
+  chartTypePluginOptions() {
+    return {
+      tooltip: {
+        mode: 'index',
+        intersect: false,
+      },
+      crosshair: {
+        line: {
+          dashPattern: [5, 5],
+          color: '#9ca3af',
+          width: 1,
+        },
+        snap: {
+          enabled: true,
+        },
+        zoom: {
+          enabled: true,
+          zoomboxBackgroundColor: 'rgba(66,133,244,0.2)',
+          zoomboxBorderColor: '#48F',
+          zoomButtonClass: 'hidden',
+        },
+      },
+    };
+  }
+}

--- a/app/jobs/refresh_materialized_views_job.rb
+++ b/app/jobs/refresh_materialized_views_job.rb
@@ -4,7 +4,8 @@ class RefreshMaterializedViewsJob < ApplicationJob
   def perform
     [
       Reports::AllLessonCompletionsDayStat,
-      Reports::PathLessonCompletionsDayStat
+      Reports::PathLessonCompletionsDayStat,
+      Reports::UserSignUpsDayStat
     ].each(&:refresh)
   end
 end

--- a/app/models/reports/user_sign_ups_day_stat.rb
+++ b/app/models/reports/user_sign_ups_day_stat.rb
@@ -1,0 +1,19 @@
+class Reports::UserSignUpsDayStat < ApplicationRecord
+  include MaterializedView
+
+  scope :for_date_range, ->(start_date, end_date) { where(date: start_date..end_date) }
+
+  scope :group_by_period, lambda { |period|
+    group("DATE_TRUNC('#{period}', date)")
+      .order(Arel.sql("DATE_TRUNC('#{period}', date) ASC"))
+      .sum(:sign_ups_count)
+  }
+
+  def self.earliest_date
+    minimum(:date) || Time.zone.today
+  end
+
+  def self.latest_date
+    maximum(:date) || Time.zone.today
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,6 +22,7 @@ class User < ApplicationRecord
 
   scope :created_after, ->(date) { where(arel_table[:created_at].gt(date)) }
   scope :signed_up_on, ->(date) { where(created_at: date.all_day) }
+  scope :banned, -> { where(banned: true) }
 
   def progress_for(course)
     @progress ||= Hash.new { |hash, c| hash[c] = CourseProgress.new(c, self) }

--- a/app/views/admin_v2/dashboard/show.html.erb
+++ b/app/views/admin_v2/dashboard/show.html.erb
@@ -22,9 +22,16 @@
 
   <ul role="list" class="mt-5 grid grid-cols-1 gap-5 sm:grid-cols-4">
     <%= link_to admin_v2_reports_lesson_completions_path do %>
-      <li class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 px-4 py-5 hover:border-gray-300 border border-gray-200 dark:border-gray-700 dark:hover:border-gray-600 sm:p-6">
+      <li class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 px-4 py-5 hover:border-gray-300 border border-gray-200 dark:border-gray-700 h- dark:hover:border-gray-600 sm:p-6">
         <dt class="truncate text-sm font-medium text-gray-800 dark:text-gray-300">Lesson completions this week</dt>
-        <%= turbo_frame_tag 'lesson_completion_stats', src: admin_v2_reports_lesson_completions_path, lazy: true, class: 'block h-56' %>
+        <%= turbo_frame_tag 'lesson_completion_stats', src: admin_v2_reports_lesson_completions_path(display_x_labels: false), lazy: true, class: 'block h-36' %>
+      </li>
+    <% end %>
+
+    <%= link_to admin_v2_reports_users_path do %>
+      <li class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 px-4 py-5 hover:border-gray-300 border border-gray-200 dark:border-gray-700 dark:hover:border-gray-600 sm:p-6">
+        <dt class="truncate text-sm font-medium text-gray-800 dark:text-gray-300">Sign ups this week</dt>
+        <%= turbo_frame_tag 'sign_up_stats', src: admin_v2_reports_users_path(display_x_labels: false), lazy: true, class: 'block h-36' %>
       </li>
     <% end %>
 

--- a/app/views/admin_v2/reports/lesson_completions/show.html.erb
+++ b/app/views/admin_v2/reports/lesson_completions/show.html.erb
@@ -16,7 +16,7 @@
     <% end %>
 
     <span class="isolate inline-flex rounded-md space-x-2 mt-6 sm:mt-0">
-      <% %w[day month].each do |period| %>
+      <% %w[day month year].each do |period| %>
         <%= link_to(
               period.capitalize,
               request.params.merge(period:),
@@ -31,19 +31,15 @@
   <%= turbo_frame_tag 'lesson_completion_stats', class: 'block mt-4 h-80' do %>
     <%= render Charts::LineChartComponent.new(
           labels: @lesson_completions_stats.keys.map { |date| date.to_fs(:"graph_#{params.fetch(:period, 'day')}") },
+          display_x_labels: params.fetch('display_x_labels', true),
           datasets: [
             {
               label: 'Lesson completions',
               data: @lesson_completions_stats.values,
               fill: true,
-              backgroundColor: 'emerald-200',
-              borderColor: 'emerald-700',
-              borderWidth: '2',
-              radius: '3',
-              pointBorderColor: 'emerald-700',
-              pointBorderWidth: '2',
-              pointHoverRadius: '3',
-              pointHoverBackgroundColor: 'emerald-700'
+              backgroundColor: 'blue-200',
+              borderColor: 'blue-600',
+              borderWidth: 2
             }
           ],
         ) %>

--- a/app/views/admin_v2/reports/paths/show.html.erb
+++ b/app/views/admin_v2/reports/paths/show.html.erb
@@ -8,19 +8,19 @@
 
     <li class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 px-4 py-5 hover:border-gray-300 border border-gray-200 dark:border-gray-700 dark:hover:border-gray-600 sm:p-6">
       <dt class="truncate text-sm font-medium text-gray-500 dark:text-gray-300"><%= 'Enrolment'.pluralize(@path.users_count) %></dt>
-      <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-800 dark:text-gray-200"><%= number_with_delimiter(@path.users_count) %></dd>
+      <dd class="mt-1 text-2xl font-semibold tracking-tight text-gray-800 dark:text-gray-200"><%= number_with_delimiter(@path.users_count) %></dd>
     </li>
 
     <% if @path.courses.many? %>
       <li class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 px-4 py-5 hover:border-gray-300 border border-gray-200 dark:border-gray-700 dark:hover:border-gray-600 sm:p-6">
         <dt class="truncate text-sm font-medium text-gray-500 dark:text-gray-300"><%= 'Courses' %></dt>
-        <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-800 dark:text-gray-200"><%= @path.courses.count %></dd>
+        <dd class="mt-1 text-2xl font-semibold tracking-tight text-gray-800 dark:text-gray-200"><%= @path.courses.count %></dd>
       </li>
     <% end %>
 
     <li class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 px-4 py-5 hover:border-gray-300 border border-gray-200 dark:border-gray-700 dark:hover:border-gray-600 sm:p-6">
       <dt class="truncate text-sm font-medium text-gray-500 dark:text-gray-300"><%= 'Lesson'.pluralize(@path.lessons.count) %></dt>
-      <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-800 dark:text-gray-200"><%= @path.lessons.count %></dd>
+      <dd class="mt-1 text-2xl font-semibold tracking-tight text-gray-800 dark:text-gray-200"><%= @path.lessons.count %></dd>
     </li>
 
   </ul>
@@ -59,8 +59,10 @@
                 label: 'Lesson completions',
                 data: @path_lesson_completions.map(&:count),
                 borderColor: 'emerald-600',
-                backgroundColor: 'emerald-300',
+                backgroundColor: 'emerald-200',
                 borderWidth: 1,
+                barThickness: 20,
+                borderRadius: 4
               }
             ],
           ) %>

--- a/app/views/admin_v2/reports/users/index.html.erb
+++ b/app/views/admin_v2/reports/users/index.html.erb
@@ -1,0 +1,65 @@
+<div class="max-w-5xl w-full mx-auto">
+  <div class="sm:flex-auto">
+    <h1 class="text-xl font-semibold leading-6 text-gray-800 dark:text-gray-300">Users</h1>
+  </div>
+
+  <ul role="list" class="mt-5 grid grid-cols-1 gap-5 sm:grid-cols-4">
+
+    <li class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 px-4 py-5 hover:border-gray-300 border border-gray-200 dark:border-gray-700 dark:hover:border-gray-600 sm:p-6">
+      <dt class="truncate text-sm font-medium text-gray-500 dark:text-gray-300">Total users</dt>
+      <dd class="mt-1 text-2xl font-semibold tracking-tight text-gray-800 dark:text-gray-200"><%= number_with_delimiter(User.count) %></dd>
+    </li>
+
+    <li class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 px-4 py-5 hover:border-gray-300 border border-gray-200 dark:border-gray-700 dark:hover:border-gray-600 sm:p-6">
+      <dt class="truncate text-sm font-medium text-gray-500 dark:text-gray-300">Banned</dt>
+      <dd class="mt-1 text-2xl font-semibold tracking-tight text-gray-800 dark:text-gray-200"><%= number_with_delimiter(User.banned.count) %></dd>
+    </li>
+
+  </ul>
+
+  <div class="border-b border-gray-200 dark:border-gray-800 pb-5 mt-6">
+    <h3 class="text-base font-semibold leading-6 text-gray-800 dark:text-gray-300">User sign ups</h3>
+  </div>
+
+  <div class="flex flex-col sm:flex-row justify-between mt-6 sm:items-center">
+    <%= form_with url: admin_v2_reports_users_path, method: :get, data: { controller: 'autosubmit', action: 'input->autosubmit#debouncedSubmit' } do |form| %>
+      <%= form.hidden_field :period, value: params[:period] if params[:period].present? %>
+
+      <div class="flex gap-x-2 items-center">
+        <%= render Forms::DatePickerComponent.new(name: :start, value: @start, min: @earliest, max: @end) %>
+         <span class="mt-2">-</span>
+        <%= render Forms::DatePickerComponent.new(name: :end, value: @end, min: @start, max: @latest) %>
+      </div>
+    <% end %>
+
+    <span class="isolate inline-flex rounded-md space-x-2 mt-6 sm:mt-0">
+      <% %w[day month year].each do |period| %>
+        <%= link_to(
+              period.capitalize,
+              request.params.merge(period:),
+              class: [
+                'relative inline-flex items-center rounded-md px-3 py-1.5 text-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus:z-10 dark:text-gray-300 dark:ring-gray-700 dark:hover:bg-gray-700',
+                'text-gray-800 bg-gray-100 dark:text-gray-300 dark:bg-gray-700': params.fetch(:period, 'day') == period
+              ]
+            ) %>
+      <% end %>
+    </span>
+  </div>
+
+  <%= turbo_frame_tag 'sign_up_stats', class: 'block mt-4 h-80' do %>
+    <%= render Charts::LineChartComponent.new(
+          labels: @sign_up_stats.keys.map { |date| date.to_fs(:"graph_#{params.fetch(:period, 'day')}") },
+          display_x_labels: params.fetch('display_x_labels', true),
+          datasets: [
+            {
+              label: 'Sign ups',
+              data: @sign_up_stats.values,
+              fill: true,
+              backgroundColor: 'blue-200',
+              borderColor: 'blue-600',
+              borderWidth: 2,
+            }
+          ],
+        ) %>
+  <% end %>
+</div>

--- a/app/views/layouts/admin_v2/_sidebar_nav.html.erb
+++ b/app/views/layouts/admin_v2/_sidebar_nav.html.erb
@@ -7,6 +7,7 @@ nav_links = [
   {
     name: 'Analytics', icon: 'chart-bar', nested_nav_links: [
       { name: 'Lesson completions', path: admin_v2_reports_lesson_completions_path },
+      { name: 'Users', path: admin_v2_reports_users_path },
     ].concat(Path.order_by_position.flat_map { |path| { name: "#{path.title} path", path: admin_v2_reports_path_path(path) } })
   }
 ]

--- a/config/initializers/date_time_formats.rb
+++ b/config/initializers/date_time_formats.rb
@@ -1,3 +1,6 @@
+# 2024
+Time::DATE_FORMATS[:graph_year] = '%Y'
+
 # Jun, 2024
 Time::DATE_FORMATS[:graph_month] = '%b %Y'
 

--- a/config/routes/admin_v2.rb
+++ b/config/routes/admin_v2.rb
@@ -21,5 +21,6 @@ namespace :admin_v2 do
   namespace :reports do
     resource :lesson_completions, only: :show
     resources :paths, only: :show
+    resources :users, only: :index
   end
 end

--- a/db/migrate/20240719045454_create_user_sign_ups_day_stats.rb
+++ b/db/migrate/20240719045454_create_user_sign_ups_day_stats.rb
@@ -1,0 +1,5 @@
+class CreateUserSignUpsDayStats < ActiveRecord::Migration[7.0]
+  def change
+    create_view :user_sign_ups_day_stats, materialized: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_13_134127) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_19_045454) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -363,5 +363,13 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_13_134127) do
        JOIN courses ON ((lesson_completions.course_id = courses.id)))
     GROUP BY ((lesson_completions.created_at)::date), lesson_completions.path_id, lesson_completions.lesson_id, lessons.title, lesson_completions.course_id, lessons."position", courses."position"
     ORDER BY ((lesson_completions.created_at)::date) DESC;
+  SQL
+  create_view "user_sign_ups_day_stats", materialized: true, sql_definition: <<-SQL
+      SELECT row_number() OVER (ORDER BY ((users.created_at)::date)) AS id,
+      (users.created_at)::date AS date,
+      count(*) AS sign_ups_count
+     FROM users
+    GROUP BY ((users.created_at)::date)
+    ORDER BY ((users.created_at)::date);
   SQL
 end

--- a/db/views/user_sign_ups_day_stats_v01.sql
+++ b/db/views/user_sign_ups_day_stats_v01.sql
@@ -1,0 +1,7 @@
+SELECT
+  ROW_NUMBER() OVER (ORDER BY created_at::DATE ASC) as id,
+  created_at::DATE as date,
+  COUNT(*) AS sign_ups_count
+FROM users
+  GROUP BY created_at::DATE
+  ORDER BY created_at::DATE ASC

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "babel-plugin-prismjs": "^2.1.0",
     "browserslist": "^4.22.2",
     "chart.js": "^4.4.3",
+    "chartjs-plugin-crosshair": "^2.0.0",
     "chartjs-plugin-tailwindcss-colors": "^0.2.2",
     "compression-webpack-plugin": "10",
     "core-js": "^3.37.0",

--- a/spec/jobs/refresh_materialized_views_job_spec.rb
+++ b/spec/jobs/refresh_materialized_views_job_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe RefreshMaterializedViewsJob do
     before do
       allow(Reports::AllLessonCompletionsDayStat).to receive(:refresh)
       allow(Reports::PathLessonCompletionsDayStat).to receive(:refresh)
+      allow(Reports::UserSignUpsDayStat).to receive(:refresh)
     end
 
     it 'refreshes all lesson completions day stats' do
@@ -17,6 +18,11 @@ RSpec.describe RefreshMaterializedViewsJob do
     it 'refreshes path lesson completions day stats' do
       job.perform
       expect(Reports::PathLessonCompletionsDayStat).to have_received(:refresh)
+    end
+
+    it 'refreshes user sign up day stats' do
+      job.perform
+      expect(Reports::UserSignUpsDayStat).to have_received(:refresh)
     end
   end
 end

--- a/spec/models/reports/user_sign_ups_day_stat_spec.rb
+++ b/spec/models/reports/user_sign_ups_day_stat_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.describe Reports::UserSignUpsDayStat do
+  describe '.for_date_range' do
+    it 'returns all user sign up stats for the given date range' do
+      create(:user, created_at: Time.utc(2022, 1, 1))
+      create(:user, created_at: Time.utc(2022, 1, 2))
+      create(:user, created_at: Time.utc(2022, 1, 3))
+      create(:user, created_at: Time.utc(2022, 1, 4))
+
+      described_class.refresh
+
+      expect(described_class.for_date_range('2022-01-01', '2022-01-02').map(&:date))
+        .to contain_exactly(Time.utc(2022, 1, 1), Time.utc(2022, 1, 2))
+    end
+  end
+
+  describe '.group_by_period' do
+    it 'returns all user sign up stats grouped by month' do
+      create(:user, created_at: Time.utc(2022, 1, 1))
+      create(:user, created_at: Time.utc(2022, 2, 2))
+      create(:user, created_at: Time.utc(2022, 1, 4))
+
+      described_class.refresh
+
+      expect(described_class.group_by_period('month')).to eq(
+        {
+          Time.utc(2022, 1, 1) => 2,
+          Time.utc(2022, 2, 1) => 1
+        }
+      )
+    end
+
+    it 'returns all user sign up stats grouped by day' do
+      create(:user, created_at: Time.utc(2022, 1, 1))
+      create(:user, created_at: Time.utc(2022, 1, 2))
+      create(:user, created_at: Time.utc(2022, 1, 2))
+
+      described_class.refresh
+
+      expect(described_class.group_by_period('day')).to eq(
+        {
+          Time.utc(2022, 1, 1) => 1,
+          Time.utc(2022, 1, 2) => 2
+        }
+      )
+    end
+  end
+
+  describe '.earliest_date' do
+    it 'returns the earliest user sign up day stat' do
+      create(:user, created_at: Time.utc(2022, 1, 1))
+      create(:user, created_at: Time.utc(2022, 2, 1))
+      create(:user, created_at: Time.utc(2022, 3, 1))
+
+      described_class.refresh
+
+      expect(described_class.earliest_date).to eq(Time.utc(2022, 1, 1))
+    end
+
+    context 'when there are no user sign ups' do
+      it 'defaults to today' do
+        described_class.refresh
+        expect(described_class.earliest_date).to eq(Time.zone.today)
+      end
+    end
+  end
+
+  describe '.latest_date' do
+    it 'returns the earliest user sign up day stat' do
+      create(:user, created_at: Time.utc(2022, 1, 1))
+      create(:user, created_at: Time.utc(2022, 2, 1))
+      create(:user, created_at: Time.utc(2022, 3, 1))
+
+      described_class.refresh
+
+      expect(described_class.latest_date).to eq(Time.utc(2022, 3, 1))
+    end
+
+    context 'when there are no user sign ups' do
+      it 'defaults to today' do
+        described_class.refresh
+        expect(described_class.latest_date).to eq(Time.zone.today)
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -38,6 +38,19 @@ RSpec.describe User do
     end
   end
 
+  describe '.banned' do
+    it 'returns banned users' do
+      first_banned_user = create(:user, banned: true)
+      second_banned_user = create(:user, banned: true)
+      create(:user, banned: false)
+      create(:user, banned: false)
+
+      expect(described_class.banned).to contain_exactly(
+        first_banned_user, second_banned_user
+      )
+    end
+  end
+
   describe '#progress_for' do
     let(:course) { build_stubbed(:course) }
     let(:course_progress) { instance_double(CourseProgress) }

--- a/spec/requests/admin_v2/reports/users_spec.rb
+++ b/spec/requests/admin_v2/reports/users_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe 'Reports - Users' do
+  describe 'GET #index' do
+    context 'when signed in as an admin' do
+      it 'renders the users report' do
+        admin = create(:admin_user)
+        sign_in(admin)
+
+        get admin_v2_reports_users_path
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when not signed in as an admin' do
+      it 'redirects to the sign in page' do
+        get admin_v2_reports_users_path
+
+        expect(response).to redirect_to(new_admin_user_session_path)
+      end
+    end
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -2651,6 +2651,11 @@ chart.js@^4.4.3:
   dependencies:
     "@kurkle/color" "^0.3.0"
 
+chartjs-plugin-crosshair@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chartjs-plugin-crosshair/-/chartjs-plugin-crosshair-2.0.0.tgz#17ba6b33b8123fc8a3ccb10c9e5069ec67fd255f"
+  integrity sha512-Vs6strRvYpzL92v40r/rAWhh+7au8VnfyC/m2ZHXcXeLEWeFjDgMvXjWdX+eARhbgHQo+uGIKyq9fmkS79GIyQ==
+
 chartjs-plugin-tailwindcss-colors@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/chartjs-plugin-tailwindcss-colors/-/chartjs-plugin-tailwindcss-colors-0.2.2.tgz#659132a5a97a80b3d25d227d375a42b100cb4902"


### PR DESCRIPTION
Because:
- When I want to see how many users have signed up in a given period of time, I want to view that data on a graph, so I can get and read the data easier.

This commit:
- Adds a user analytics page
- Adds a database view to cache the query for sign ups everyday
- Display sign ups in a line graph
- Includes many graph UI improvements
  - Adds a year option to line graph filters
  - Improved styling with graph colors
  - Use cross hairs for the points on line graphs - better UX, allows zooming into segments of the graph

<img width="1448" alt="Screenshot 2024-07-19 at 08 26 28" src="https://github.com/user-attachments/assets/013c1266-e8dc-45dd-bbc1-2c59b205246c">


