### PR TITLE
Feature: Admin v2 - Resend Invite

### DIFF
--- a/app/controllers/admin_v2/team_members/resend_invitation_controller.rb
+++ b/app/controllers/admin_v2/team_members/resend_invitation_controller.rb
@@ -1,0 +1,22 @@
+module AdminV2
+  class TeamMembers::ResendInvitationController < AdminV2::BaseController
+    rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+
+    def create
+      team_member = AdminUser.find(params[:team_member_id])
+
+      if team_member.pending?
+        team_member.invite!(current_admin_user)
+        redirect_to admin_v2_team_path, notice: "Invite sent to #{team_member.name}"
+      else
+        redirect_to admin_v2_team_path, alert: "#{team_member.name} has already accepted the invitation"
+      end
+    end
+
+    private
+
+    def record_not_found
+      redirect_to admin_v2_team_path, alert: 'Team member not found'
+    end
+  end
+end

--- a/app/views/admin_v2/team/_member.html.erb
+++ b/app/views/admin_v2/team/_member.html.erb
@@ -19,6 +19,15 @@
           <%= inline_svg_tag 'icons/ellipsis-horizontal.svg', class: 'h-6 w-6', aria: true %>
         <% end %>
 
+        <% if team_member.pending? %>
+         <% dropdown.with_item do %>
+            <%= link_to admin_v2_team_member_resend_invitation_path(team_member), data: { turbo_method: :post, turbo_frame: '_top' }, class: 'text-gray-700 dark:text-gray-300 whitespace-nowrap group flex items-center px-3 py-2 text-sm' do %>
+              <%= inline_svg_tag 'icons/envelope.svg', class: 'mr-3 h-5 w-5 text-gray-400 group-hover:text-gray-500 dark:text-gray-300 dark:group-hover:text-gray-400' %>
+              Resend invite
+            <% end %>
+          <% end %>
+        <% end %>
+
         <% if team_member.active? %>
           <% dropdown.with_item do %>
             <%= link_to admin_v2_team_member_password_resets_path(team_member), data: { turbo_method: :post, turbo_frame: '_top' }, class: 'text-gray-700 dark:text-gray-300 whitespace-nowrap group flex items-center px-3 py-2 text-sm' do %>

--- a/config/routes/admin_v2.rb
+++ b/config/routes/admin_v2.rb
@@ -10,6 +10,7 @@ namespace :admin_v2 do
 
   resources :team_members do
     resources :password_resets, only: %i[create], controller: 'team_members/password_resets'
+    resource :resend_invitation, only: %i[create], controller: 'team_members/resend_invitation'
     resource :deactivation, only: %i[update], controller: 'team_members/deactivation'
     resource :reactivation, only: %i[update], controller: 'team_members/reactivation'
   end

--- a/spec/requests/admin_v2/team_members/resend_invitation_spec.rb
+++ b/spec/requests/admin_v2/team_members/resend_invitation_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe 'Resend team member invite' do
+  describe 'POST #create' do
+    context 'when signed in as an admin and the team member is pending' do
+      it 'sends another invitation email to the team member' do
+        admin = create(:admin_user)
+        pending_admin = create(:admin_user, status: :pending, email: 'pending@odin.com')
+        sign_in(admin)
+
+        expect do
+          post admin_v2_team_member_resend_invitation_path(team_member_id: pending_admin.id)
+        end.to change { ActionMailer::Base.deliveries.count }
+
+        mailer = ActionMailer::Base.deliveries.last
+
+        expect(mailer.to).to eq(['pending@odin.com'])
+        expect(mailer.subject).to eq('The Odin Project Admin Invitation')
+      end
+    end
+
+    context 'when signed in as an admin and the team member is not pending' do
+      it 'does not send the team member another invite' do
+        admin = create(:admin_user)
+        active_admin = create(:admin_user, status: :active, email: 'active@odin.com')
+
+        sign_in(admin)
+
+        expect do
+          post admin_v2_team_member_resend_invitation_path(team_member_id: active_admin.id)
+        end.not_to change { ActionMailer::Base.deliveries.count }
+      end
+    end
+
+    context "when signed in as an admin and the team member doesn't exist" do
+      it 'does not send an invitation email' do
+        admin = create(:admin_user)
+
+        sign_in(admin)
+
+        expect do
+          post admin_v2_team_member_resend_invitation_path(team_member_id: 1007)
+        end.not_to change { ActionMailer::Base.deliveries.count }
+
+        expect(response).to redirect_to(admin_v2_team_path)
+        expect(flash[:alert]).to eq('Team member not found')
+      end
+    end
+
+    context 'when not signed in as an admin' do
+      it 'redirects to the admin sign in page' do
+        user = create(:user)
+        admin = create(:admin_user)
+        sign_in(user)
+
+        expect do
+          post admin_v2_team_member_resend_invitation_path(team_member_id: admin.id)
+        end.not_to change { ActionMailer::Base.deliveries.count }
+
+        expect(response).to redirect_to(new_admin_user_session_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Because:
- When a pending team member did not receive their invite or cannot accept the initial invite, I want to send it again, so they can join the team.
- Closes: https://github.com/TheOdinProject/theodinproject/issues/4627

This commit:
- Adds a "Resend invite" option to pending team member drop downs.