### PR TITLE
Chore: Wrap delete announcement action within a accept_confirm

### DIFF
--- a/spec/system/admin_v2/announcements_spec.rb
+++ b/spec/system/admin_v2/announcements_spec.rb
@@ -57,7 +57,10 @@ RSpec.describe 'Announcements' do
       expect(page).to have_content('Test Message')
 
       visit admin_v2_announcement_path(announcement)
-      click_link('Delete')
+
+      accept_confirm do
+        click_link('Delete')
+      end
 
       expect(page).to have_current_path(admin_v2_announcements_path)
       expect(page).not_to have_content('Test Message')


### PR DESCRIPTION
Because:
- We were getting a warning in the test output about it