### PR TITLE
Feature: Admin V2 - Begin line graphs at zero

### DIFF
--- a/app/components/charts/line_chart_component.rb
+++ b/app/components/charts/line_chart_component.rb
@@ -21,6 +21,7 @@ class Charts::LineChartComponent < ApplicationComponent
       scales: {
         y: {
           type: 'linear',
+          beginAtZero: true,
           ticks: { precision: 0 },
         },
         x: {


### PR DESCRIPTION
Because:
- The y-axis was starting at the datasets smallest value