### PR TITLE
Feature: Admin V2 - Delete pending team members

### DIFF
--- a/app/controllers/admin_v2/invitations_controller.rb
+++ b/app/controllers/admin_v2/invitations_controller.rb
@@ -29,6 +29,10 @@ class AdminV2::InvitationsController < Devise::InvitationsController
   def create_invited_activity
     return unless @invited_admin_user
 
-    @invited_admin_user.create_activity(key: 'admin_user.invited', owner: current_admin_user)
+    @invited_admin_user.create_activity(
+      key: 'admin_user.invited',
+      owner: current_admin_user,
+      params: { name: @invited_admin_user.name }
+    )
   end
 end

--- a/app/controllers/admin_v2/team_members_controller.rb
+++ b/app/controllers/admin_v2/team_members_controller.rb
@@ -1,0 +1,20 @@
+module AdminV2
+  class TeamMembersController < AdminV2::BaseController
+    def destroy # rubocop:disable Metrics/MethodLength
+      team_member = AdminUser.find(params[:id])
+
+      if team_member.pending?
+        team_member.create_activity(
+          key: 'admin_user.removed',
+          owner: current_admin_user,
+          params: { name: team_member.name }
+        )
+
+        team_member.remove!
+        redirect_to admin_v2_team_path, notice: "#{team_member.name} removed from the team"
+      else
+        redirect_to admin_v2_team_path, alert: 'Only pending team members can be removed'
+      end
+    end
+  end
+end

--- a/app/views/admin_v2/team/_member.html.erb
+++ b/app/views/admin_v2/team/_member.html.erb
@@ -8,7 +8,7 @@
       <p class="text-sm font-semibold leading-6 text-gray-800 dark:text-gray-300"><%= team_member.name %></p>
       <% if team_member.pending? %>
         <%= render Ui::BadgeComponent.new(color: 'yellow') do %>
-            Pending
+          Pending
         <% end %>
       <% end %>
     </div>
@@ -20,10 +20,18 @@
         <% end %>
 
         <% if team_member.pending? %>
+
          <% dropdown.with_item do %>
             <%= link_to admin_v2_team_member_resend_invitation_path(team_member), data: { turbo_method: :post }, class: 'text-gray-700 dark:text-gray-300 whitespace-nowrap group flex items-center px-3 py-2 text-sm' do %>
               <%= inline_svg_tag 'icons/envelope.svg', class: 'mr-3 h-5 w-5 text-gray-400 group-hover:text-gray-500 dark:text-gray-300 dark:group-hover:text-gray-400' %>
               Resend invite
+            <% end %>
+          <% end %>
+
+          <% dropdown.with_item do %>
+            <%= link_to admin_v2_team_member_path(team_member), data: { turbo_method: :delete, turbo_frame: '_top', turbo_confirm: 'Are you sure?' }, class: 'text-red-700 dark:text-red-300 whitespace-nowrap group flex items-center px-3 py-2 text-sm' do %>
+              <%= inline_svg_tag 'icons/trash.svg', class: 'mr-3 h-5 w-5 text-red-700 group-hover:text-red-600 dark:text-red-300 dark:group-hover:text-red-400' %>
+              Remove
             <% end %>
           <% end %>
         <% end %>

--- a/app/views/public_activity/admin_user/_invited.html.erb
+++ b/app/views/public_activity/admin_user/_invited.html.erb
@@ -1,1 +1,1 @@
-<%= activity.owner.name %> invited <strong class="font-semibold"><%= activity.trackable.name %></strong>
+<%= activity.owner.name %> invited <strong class="font-semibold"><%= activity.parameters.fetch('name') %></strong>

--- a/app/views/public_activity/admin_user/_removed.html.erb
+++ b/app/views/public_activity/admin_user/_removed.html.erb
@@ -1,0 +1,1 @@
+<%= activity.owner.name %> removed <strong class="font-semibold"><%= activity.parameters.fetch('name') %></strong>

--- a/spec/models/admin_user_spec.rb
+++ b/spec/models/admin_user_spec.rb
@@ -72,21 +72,43 @@ RSpec.describe AdminUser do
   end
 
   describe '#deactivate!' do
-    it 'deactivates the admin' do
-      admin = build(:admin_user, status: :active)
+    context 'when the admin is active' do
+      it 'deactivates the admin' do
+        admin = build(:admin_user, status: :active)
 
-      expect do
-        admin.deactivate!
-      end.to change { admin.status }.from('active').to('deactivated')
-    end
-
-    it 'sets the deactivated_at timestamp' do
-      admin = build(:admin_user, status: :active)
-
-      freeze_time do
         expect do
           admin.deactivate!
-        end.to change { admin.deactivated_at }.from(nil).to(Time.current)
+        end.to change { admin.status }.from('active').to('deactivated')
+      end
+
+      it 'sets the deactivated_at timestamp' do
+        admin = build(:admin_user, status: :active)
+
+        freeze_time do
+          expect do
+            admin.deactivate!
+          end.to change { admin.deactivated_at }.from(nil).to(Time.current)
+        end
+      end
+    end
+
+    context 'when the admin has been reactivated' do
+      it 'deactivates the admin' do
+        admin = build(:admin_user, status: :pending, reactivated_at: 1.day.ago)
+
+        expect do
+          admin.deactivate!
+        end.to change { admin.status }.from('pending').to('deactivated')
+      end
+
+      it 'sets the deactivated_at timestamp' do
+        admin = build(:admin_user, status: :pending, reactivated_at: 1.day.ago)
+
+        freeze_time do
+          expect do
+            admin.deactivate!
+          end.to change { admin.deactivated_at }.from(nil).to(Time.current)
+        end
       end
     end
 
@@ -156,6 +178,35 @@ RSpec.describe AdminUser do
       expect do
         admin.reset_two_factor!
       end.to change { admin.status }.from('active').to('pending')
+    end
+  end
+
+  describe '#remove!' do
+    context 'when the admin is not pending' do
+      it 'does not remove active admins' do
+        admin = build(:admin_user, status: :active)
+        expect { admin.remove! }.not_to change { admin.status }
+      end
+
+      it 'does not remove deactivated admins' do
+        admin = build(:admin_user, status: :deactivated)
+        expect { admin.remove! }.not_to change { admin.status }
+      end
+    end
+
+    context 'when the admin has been previously reactivated' do
+      it 'deactivates the admin' do
+        admin = create(:admin_user, status: :pending, reactivated_at: 1.day.ago)
+        expect { admin.remove! }.to change { admin.reload.status }.from('pending').to('deactivated')
+      end
+    end
+
+    context 'when the admin has not been previously reactivated' do
+      it 'destroys the admin' do
+        admin = create(:admin_user, status: :pending)
+
+        expect { admin.remove! }.to change { described_class.count }.by(-1)
+      end
     end
   end
 end

--- a/spec/requests/admin_v2/team_members_spec.rb
+++ b/spec/requests/admin_v2/team_members_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe 'Team members' do
+  describe 'DELETE #destroy' do
+    context 'when signed in as an admin and the team member is pending' do
+      it 'deletes the team member' do
+        pending_admin = create(:admin_user, status: :pending)
+
+        sign_in(create(:admin_user))
+
+        expect do
+          delete admin_v2_team_member_path(pending_admin)
+        end.to change { AdminUser.count }.by(-1)
+
+        expect(response).to redirect_to(admin_v2_team_path)
+      end
+    end
+
+    context 'when signed in as an admin and the team member is not pending' do
+      it 'does not delete the team member' do
+        active_admin = create(:admin_user, status: :active)
+
+        sign_in(create(:admin_user))
+
+        expect do
+          delete admin_v2_team_member_path(active_admin)
+        end.not_to change { AdminUser.count }
+
+        expect(response).to redirect_to(admin_v2_team_path)
+        expect(flash[:alert]).to eq('Only pending team members can be removed')
+      end
+    end
+
+    context 'when not signed in as an admin' do
+      it 'redirects to the admin sign in page' do
+        user = create(:user)
+        admin = create(:admin_user)
+        sign_in(user)
+
+        expect do
+          delete admin_v2_team_member_path(admin)
+        end.not_to change { AdminUser.count }
+
+        expect(response).to redirect_to(new_admin_user_session_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Because:
- When I accidentally add someone to the admin team, I want to be able to remove that team member immediately, so someone doesn't gain access to admin when they shouldn't.