### PR TITLE
Chore: Move notifications into models directory

### DIFF
--- a/app/models/flags/actions/notify_user.rb
+++ b/app/models/flags/actions/notify_user.rb
@@ -16,7 +16,7 @@ class Flags::Actions::NotifyUser < Flags::Actions::Base
   private
 
   def send_notification
-    FlagNotification.with(
+    Notifications::FlagNotification.with(
       flag:,
       title: message.title,
       message: message.content,

--- a/app/models/notifications/flag_notification.rb
+++ b/app/models/notifications/flag_notification.rb
@@ -1,4 +1,4 @@
-class FlagNotification < Noticed::Base
+class Notifications::FlagNotification < Noticed::Base
   deliver_by :database, format: :to_database
 
   def to_database

--- a/app/services/admin/flags/notify_user.rb
+++ b/app/services/admin/flags/notify_user.rb
@@ -18,7 +18,7 @@ module Admin
           flag.resolved!
           flag.update!(resolved_by_id: admin.id)
 
-          FlagNotification
+          Notifications::FlagNotification
             .with(flag:, title: message.title, message: message.content, url: message.url)
             .deliver_later(flag.project_submission.user)
 

--- a/spec/models/flags/actions/notify_user_spec.rb
+++ b/spec/models/flags/actions/notify_user_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe Flags::Actions::NotifyUser do
 
       it 'creates a dead link notification' do
         deadlink_notification = Messages::DeadLink.new(flag)
-        allow(FlagNotification).to receive(:with).and_call_original
+        allow(Notifications::FlagNotification).to receive(:with).and_call_original
 
         described_class.perform(admin_user:, flag:)
 
-        expect(FlagNotification).to have_received(:with).with(
+        expect(Notifications::FlagNotification).to have_received(:with).with(
           flag:,
           title: deadlink_notification.title,
           message: deadlink_notification.content,

--- a/spec/models/notifications/flag_notification_spec.rb
+++ b/spec/models/notifications/flag_notification_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe FlagNotification do
+RSpec.describe Notifications::FlagNotification do
   subject(:flag_notification) { described_class }
 
   let(:flag) { create(:flag) }


### PR DESCRIPTION
Because:
- This is better suited as a model rather than a top level concept in the root of the app directory.