### PR TITLE
Chore: Add Github namespace

### DIFF
--- a/app/controllers/github/webhooks_controller.rb
+++ b/app/controllers/github/webhooks_controller.rb
@@ -1,10 +1,10 @@
-class GithubWebhooksController < ApplicationController
+class Github::WebhooksController < ApplicationController
   include GithubWebhook::Processor
 
   skip_before_action :verify_authenticity_token
 
   def github_push(payload)
-    event = ::GithubPushEventAdaptor.new(payload)
+    event = ::Github::PushEvent.new(payload)
 
     Lessons::UpdateContentJob.perform_later(event.modified_urls) if event.merged_to_main?
   end

--- a/app/jobs/lessons/import_all_content_job.rb
+++ b/app/jobs/lessons/import_all_content_job.rb
@@ -1,7 +1,7 @@
 module Lessons
   class ImportAllContentJob < ApplicationJob
     def perform
-      LessonContentImporter.import_all
+      Github::LessonContentImporter.import_all
     end
   end
 end

--- a/app/models/github/lesson_content_importer.rb
+++ b/app/models/github/lesson_content_importer.rb
@@ -1,4 +1,4 @@
-class LessonContentImporter
+class Github::LessonContentImporter
   attr_reader :lesson, :content
   private :lesson, :content
 

--- a/app/models/github/push_event.rb
+++ b/app/models/github/push_event.rb
@@ -1,4 +1,4 @@
-class GithubPushEventAdaptor
+class Github::PushEvent
   def initialize(payload)
     @payload = payload
   end

--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -33,7 +33,7 @@ class Lesson < ApplicationRecord
   end
 
   def import_content_from_github
-    LessonContentImporter.for(self)
+    Github::LessonContentImporter.for(self)
   end
 
   def display_title

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,8 +18,6 @@ Rails.application.routes.draw do
     mount Lookbook::Engine, at: '/lookbook'
   end
 
-  resource :github_webhooks, only: :create, defaults: { formats: :json }
-
   unauthenticated do
     root 'static_pages#home'
   end
@@ -39,6 +37,10 @@ Rails.application.routes.draw do
     get '/sign_in' => 'users/sessions#new'
     delete '/sign_out' => 'users/sessions#destroy'
     get '/sign_up' => 'users/registrations#new'
+  end
+
+  namespace :github do
+    resource :webhooks, only: :create, defaults: { formats: :json }
   end
 
   namespace :api do

--- a/spec/jobs/lessons/import_all_content_job_spec.rb
+++ b/spec/jobs/lessons/import_all_content_job_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe Lessons::ImportAllContentJob do
 
   describe '#perform' do
     before do
-      allow(LessonContentImporter).to receive(:import_all)
+      allow(Github::LessonContentImporter).to receive(:import_all)
     end
 
     it 'delegates to the lesson content importer service' do
       job.perform
 
-      expect(LessonContentImporter).to have_received(:import_all)
+      expect(Github::LessonContentImporter).to have_received(:import_all)
     end
   end
 end

--- a/spec/models/github/lesson_content_importer_spec.rb
+++ b/spec/models/github/lesson_content_importer_spec.rb
@@ -1,11 +1,15 @@
 require 'rails_helper'
 
-RSpec.describe LessonContentImporter do
+RSpec.describe Github::LessonContentImporter do
   subject(:importer) { described_class.new(lesson) }
 
   let(:lesson) do
-    create(:lesson, title: 'Ruby Basics', github_path: '/ruby_basics/variables',
-                    content: create(:content, body: lesson_content))
+    create(
+      :lesson,
+      title: 'Ruby Basics',
+      github_path: '/ruby_basics/variables',
+      content: create(:content, body: lesson_content)
+    )
   end
 
   let(:lesson_content) { "<p>Hello World</p>\n" }

--- a/spec/models/github/push_event_spec.rb
+++ b/spec/models/github/push_event_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe GithubPushEventAdaptor do
-  subject(:adaptor) { described_class.new(payload) }
+RSpec.describe Github::PushEvent do
+  subject(:push_event) { described_class.new(payload) }
 
   let(:payload) do
     {
@@ -16,7 +16,7 @@ RSpec.describe GithubPushEventAdaptor do
   describe '#merged_to_main?' do
     context 'when the ref is main' do
       it 'returns true' do
-        expect(adaptor.merged_to_main?).to be(true)
+        expect(push_event.merged_to_main?).to be(true)
       end
     end
 
@@ -24,7 +24,7 @@ RSpec.describe GithubPushEventAdaptor do
       let(:ref) { 'some/other/branch' }
 
       it 'returns false' do
-        expect(adaptor.merged_to_main?).to be(false)
+        expect(push_event.merged_to_main?).to be(false)
       end
     end
   end
@@ -33,7 +33,7 @@ RSpec.describe GithubPushEventAdaptor do
     it 'returns the modified urls formatted correctly' do
       result = ['/url/one', '/url/two']
 
-      expect(adaptor.modified_urls).to eq(result)
+      expect(push_event.modified_urls).to eq(result)
     end
   end
 end

--- a/spec/models/lesson_spec.rb
+++ b/spec/models/lesson_spec.rb
@@ -156,11 +156,11 @@ RSpec.describe Lesson do
 
   describe '#import_content_from_github' do
     it 'uses the lesson content importer to get lesson content from github' do
-      allow(LessonContentImporter).to receive(:for)
+      allow(Github::LessonContentImporter).to receive(:for)
 
       lesson.import_content_from_github
 
-      expect(LessonContentImporter).to have_received(:for).with(lesson)
+      expect(Github::LessonContentImporter).to have_received(:for).with(lesson)
     end
   end
 


### PR DESCRIPTION
Because:
- We can put all our GitHub services and models together, making them easier to find.

This commit:
- Move lesson content importer into Github namespace in the models directory
- Move GitHub push event adapter into the Github namespace in the models directory
- Move GitHub webhooks controller into a Github namespace in the controllers directory
