### PR TITLE
Feature: Change period filter buttons to a select field

### DIFF
--- a/app/builders/tailwind_form_builder.rb
+++ b/app/builders/tailwind_form_builder.rb
@@ -47,6 +47,12 @@ class TailwindFormBuilder < ActionView::Helpers::FormBuilder
     super(attribute, options.merge(default_opts), checked_value, unchecked_value)
   end
 
+  def select(attribute, choices, options = {}, html_options = {})
+    default_opts = { class: "#{@template.yass(select: :base)} #{html_options[:class]}" }
+
+    super(attribute, choices, options, html_options.merge(default_opts))
+  end
+
   private
 
   def classes_for(attribute, options)

--- a/app/controllers/admin_v2/reports/lesson_completions_controller.rb
+++ b/app/controllers/admin_v2/reports/lesson_completions_controller.rb
@@ -5,7 +5,7 @@ module AdminV2
     def show
       @lesson_completions_stats = ::Reports::AllLessonCompletionsDayStat
         .for_date_range(@start, @end)
-        .group_by_period(params.fetch(:period, 'day'))
+        .group_by_period(period.name)
     end
 
     private
@@ -23,11 +23,15 @@ module AdminV2
         'day' => 7.days.ago,
         'month' => 3.months.ago,
         'year' => 3.years.ago
-      }.fetch(params[:period], 7.days.ago).to_date.to_s
+      }.fetch(period.name).to_date.to_s
     end
 
     def default_end_date
       Time.zone.today.to_s
+    end
+
+    def period
+      @period ||= ::Reports::Period.find(params[:period]) || ::Reports::Period.new('day')
     end
   end
 end

--- a/app/controllers/admin_v2/reports/users_controller.rb
+++ b/app/controllers/admin_v2/reports/users_controller.rb
@@ -5,7 +5,7 @@ module AdminV2
     def index
       @sign_up_stats = ::Reports::UserSignUpsDayStat
         .for_date_range(@start, @end)
-        .group_by_period(params.fetch(:period, 'day'))
+        .group_by_period(period.name)
     end
 
     private
@@ -23,11 +23,15 @@ module AdminV2
         'day' => 7.days.ago,
         'month' => 3.months.ago,
         'year' => 3.years.ago
-      }.fetch(params[:period], 7.days.ago).to_date.to_s
+      }.fetch(period.name).to_date.to_s
     end
 
     def default_end_date
       Time.zone.today.to_s
+    end
+
+    def period
+      @period ||= ::Reports::Period.find(params[:period]) || ::Reports::Period.new('day')
     end
   end
 end

--- a/app/models/reports/period.rb
+++ b/app/models/reports/period.rb
@@ -1,0 +1,27 @@
+class Reports::Period
+  include Comparable
+
+  VALID_PERIODS = %w[day month year].freeze
+
+  attr_reader :name
+
+  def initialize(name)
+    @name = name
+  end
+
+  def self.all
+    VALID_PERIODS.map { |period| new(period) }
+  end
+
+  def self.find(value)
+    all.find { |period| period == new(value) }
+  end
+
+  def <=>(other)
+    name <=> other.name
+  end
+
+  def as_option
+    [name.capitalize, name]
+  end
+end

--- a/app/views/admin_v2/reports/_date_filters.html.erb
+++ b/app/views/admin_v2/reports/_date_filters.html.erb
@@ -1,0 +1,18 @@
+<div class="flex flex-col sm:flex-row justify-between mt-6 sm:items-center max-w-">
+  <%= form_with url:, method: :get, data: { controller: 'autosubmit', action: 'input->autosubmit#debouncedSubmit' } do |form| %>
+    <%= form.hidden_field :period, value: params[:period] if params[:period].present? %>
+
+    <div class="flex gap-x-2 items-center">
+      <%= render Forms::DatePickerComponent.new(name: :start, value: @start, min: @earliest, max: @end) %>
+      <span class="mt-2">-</span>
+      <%= render Forms::DatePickerComponent.new(name: :end, value: @end, min: @start, max: @latest) %>
+    </div>
+  <% end %>
+
+  <%= form_with url:, method: :get, html: {class: 'w-full max-w-40' }, builder: TailwindFormBuilder, data: { controller: 'autosubmit', action: 'input->autosubmit#debouncedSubmit' } do |form| %>
+    <%= form.hidden_field :start, value: params[:start] if params[:start].present? %>
+    <%= form.hidden_field :end, value: params[:end] if params[:end].present? %>
+
+    <%= form.select :period, options_for_select(Reports::Period.all.map(&:as_option), selected: params[:period]), {}, { class: 'text-sm' } %>
+  <% end %>
+</div>

--- a/app/views/admin_v2/reports/lesson_completions/show.html.erb
+++ b/app/views/admin_v2/reports/lesson_completions/show.html.erb
@@ -4,30 +4,8 @@
     <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">Total lesson completions for all lessons.</p>
   </div>
 
-  <div class="flex flex-col sm:flex-row justify-between mt-6 sm:items-center">
-    <%= form_with url: admin_v2_reports_lesson_completions_path, method: :get, data: { controller: 'autosubmit', action: 'input->autosubmit#debouncedSubmit' } do |form| %>
-      <%= form.hidden_field :period, value: params[:period] if params[:period].present? %>
+  <%= render 'admin_v2/reports/date_filters', url: admin_v2_reports_lesson_completions_path %>
 
-      <div class="flex gap-x-2 items-center">
-        <%= render Forms::DatePickerComponent.new(name: :start, value: @start, min: @earliest, max: @end) %>
-         <span class="mt-2">-</span>
-        <%= render Forms::DatePickerComponent.new(name: :end, value: @end, min: @start, max: @latest) %>
-      </div>
-    <% end %>
-
-    <span class="isolate inline-flex rounded-md space-x-2 mt-6 sm:mt-0">
-      <% %w[day month year].each do |period| %>
-        <%= link_to(
-              period.capitalize,
-              request.params.merge(period:),
-              class: [
-                'relative inline-flex items-center rounded-md px-3 py-1.5 text-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus:z-10 dark:text-gray-300 dark:ring-gray-700 dark:hover:bg-gray-700',
-                'text-gray-800 bg-gray-100 dark:text-gray-300 dark:bg-gray-700': params.fetch(:period, 'day') == period
-              ]
-            ) %>
-      <% end %>
-    </span>
-  </div>
   <%= turbo_frame_tag 'lesson_completion_stats', class: 'block mt-4 h-80' do %>
     <%= render Charts::LineChartComponent.new(
           labels: @lesson_completions_stats.keys.map { |date| date.to_fs(:"graph_#{params.fetch(:period, 'day')}") },

--- a/app/views/admin_v2/reports/users/index.html.erb
+++ b/app/views/admin_v2/reports/users/index.html.erb
@@ -21,30 +21,7 @@
     <h3 class="text-base font-semibold leading-6 text-gray-800 dark:text-gray-300">User sign ups</h3>
   </div>
 
-  <div class="flex flex-col sm:flex-row justify-between mt-6 sm:items-center">
-    <%= form_with url: admin_v2_reports_users_path, method: :get, data: { controller: 'autosubmit', action: 'input->autosubmit#debouncedSubmit' } do |form| %>
-      <%= form.hidden_field :period, value: params[:period] if params[:period].present? %>
-
-      <div class="flex gap-x-2 items-center">
-        <%= render Forms::DatePickerComponent.new(name: :start, value: @start, min: @earliest, max: @end) %>
-         <span class="mt-2">-</span>
-        <%= render Forms::DatePickerComponent.new(name: :end, value: @end, min: @start, max: @latest) %>
-      </div>
-    <% end %>
-
-    <span class="isolate inline-flex rounded-md space-x-2 mt-6 sm:mt-0">
-      <% %w[day month year].each do |period| %>
-        <%= link_to(
-              period.capitalize,
-              request.params.merge(period:),
-              class: [
-                'relative inline-flex items-center rounded-md px-3 py-1.5 text-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus:z-10 dark:text-gray-300 dark:ring-gray-700 dark:hover:bg-gray-700',
-                'text-gray-800 bg-gray-100 dark:text-gray-300 dark:bg-gray-700': params.fetch(:period, 'day') == period
-              ]
-            ) %>
-      <% end %>
-    </span>
-  </div>
+  <%= render 'admin_v2/reports/date_filters', url: admin_v2_reports_users_path %>
 
   <%= turbo_frame_tag 'sign_up_stats', class: 'block mt-4 h-80' do %>
     <%= render Charts::LineChartComponent.new(

--- a/config/utility_classes.yml
+++ b/config/utility_classes.yml
@@ -4,6 +4,8 @@ text_field:
   invalid: "pr-10 border-red-300 text-red-900 placeholder-red-300 focus:ring-red-500 focus:border-red-500"
 label:
   base: "block text-sm font-medium text-gray-700 dark:text-gray-200"
+select:
+  base: "block w-full mt-6 sm:mt-0 border rounded-md py-2 px-3 focus:outline-none dark:bg-gray-700/50 dark:border-gray-500 dark:text-gray-300 dark:placeholder-gray-400 dark:focus:ring-2 dark:focus:border-transparent border-gray-300 focus:ring-blue-600 focus:border-blue-600 dark:focus:ring-blue-400"
 error_field:
   base: "mt-2 text-sm text-red-600 dark:text-red-500"
   visible: ""

--- a/spec/builders/__snapshots__/tailwind_form_builder/select.snap
+++ b/spec/builders/__snapshots__/tailwind_form_builder/select.snap
@@ -1,0 +1,2 @@
+<select class="block w-full mt-6 sm:mt-0 border rounded-md py-2 px-3 focus:outline-none dark:bg-gray-700/50 dark:border-gray-500 dark:text-gray-300 dark:placeholder-gray-400 dark:focus:ring-2 dark:focus:border-transparent border-gray-300 focus:ring-blue-600 focus:border-blue-600 dark:focus:ring-blue-400 text-sm" name="user[username]" id="user_username"><option value="a">choice one</option>
+<option value="b">choice two</option></select>

--- a/spec/builders/tailwind_form_builder_spec.rb
+++ b/spec/builders/tailwind_form_builder_spec.rb
@@ -151,4 +151,12 @@ RSpec.describe TailwindFormBuilder do
       expect(builder.check_box(:username)).to match_snapshot('tailwind_form_builder/check_box')
     end
   end
+
+  describe '#select' do
+    it 'returns a tailwind styled select' do
+      expect(
+        builder.select(:username, [['choice one', 'a'], ['choice two', 'b']], {}, { class: 'text-sm' })
+      ).to match_snapshot('tailwind_form_builder/select')
+    end
+  end
 end

--- a/spec/models/reports/period_spec.rb
+++ b/spec/models/reports/period_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe Reports::Period do
+  describe '.all' do
+    it 'returns all valid periods' do
+      periods = described_class.all
+
+      expect(periods.map(&:name)).to eq(%w[day month year])
+    end
+  end
+
+  describe '.find' do
+    context 'when period with the same name is found' do
+      it 'returns the period' do
+        expect(described_class.find('day')).to eq(described_class.new('day'))
+      end
+    end
+
+    context "when a period can't be found" do
+      it 'returns the period' do
+        expect(described_class.find('eon')).to be_nil
+      end
+    end
+  end
+
+  describe '#as_option' do
+    it 'returns the period in a format for rails select form fields' do
+      expect(described_class.new('day').as_option).to eq(%w[Day day])
+    end
+  end
+end


### PR DESCRIPTION
Because:
- Save space for more filters

This commit:
- Extracts date filters to a partial so they can be used in both lesson completions and user reports
- Adds a period value object to sanitise period input
- Adds select field styling to our tailwind form builder