### PR TITLE
Chore: Silence Sidekiq logs in test output

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -5,3 +5,7 @@ end
 Sidekiq.configure_client do |config|
   config.redis = { url: ENV['REDIS_URL'], ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE } }
 end
+
+Sidekiq.configure_client do |config|
+  config.logger = Rails.logger if Rails.env.test?
+end


### PR DESCRIPTION
Because:
- We were getting "Sidekiq connecting to Redis" output in the test output
