### PR TITLE
Chore: handle accept_prompt warnings in specs

### DIFF
--- a/spec/system/admin_v2/deactivations_spec.rb
+++ b/spec/system/admin_v2/deactivations_spec.rb
@@ -12,7 +12,10 @@ RSpec.describe 'Admin V2 team member deactivation' do
 
     within("#admin_user_#{other_admin.id}") do
       find(:test_id, 'dropdown-button').click
-      click_link('Deactivate')
+
+      accept_confirm do
+        click_link('Deactivate')
+      end
     end
 
     within('#deactivated_team_members') do

--- a/spec/system/admin_v2/reactivations_spec.rb
+++ b/spec/system/admin_v2/reactivations_spec.rb
@@ -12,7 +12,10 @@ RSpec.describe 'Admin V2 team members reactivations' do
 
     within("#admin_user_#{deactivated_admin.id}") do
       find(:test_id, 'dropdown-button').click
-      click_link('Reactivate')
+
+      accept_confirm do
+        click_link('Reactivate')
+      end
     end
 
     within('#team_members') do


### PR DESCRIPTION
Because:
- We need to wrap any links that have a confirm alert in `accept_confirm do ...`
