### PR TITLE
Chore: Use state machine with admin user

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 
 gem 'rails', '7.0.8.1'
 
+gem 'aasm', '~> 5.3'
 gem 'activeadmin', '~> 3.2'
 gem 'activeadmin_addons', '~> 1.10'
 gem 'active_material', '~> 1.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    aasm (5.5.0)
+      concurrent-ruby (~> 1.0)
     actioncable (7.0.8.1)
       actionpack (= 7.0.8.1)
       activesupport (= 7.0.8.1)
@@ -637,6 +639,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aasm (~> 5.3)
   active_material (~> 1.5)
   activeadmin (~> 3.2)
   activeadmin_addons (~> 1.10)

--- a/app/controllers/admin_v2/base_controller.rb
+++ b/app/controllers/admin_v2/base_controller.rb
@@ -7,6 +7,7 @@ module AdminV2
 
     before_action :authenticate_admin_user!
     before_action :ensure_two_factor_enabled, if: :current_admin_user
+    before_action :set_current_admin_user
 
     private
 
@@ -20,7 +21,11 @@ module AdminV2
     end
 
     def two_factor_setup_required?
-      current_admin_user.pending? && !current_admin_user.two_factor_enabled?
+      current_admin_user.awaiting_activation? && !current_admin_user.two_factor_enabled?
+    end
+
+    def set_current_admin_user
+      Current.admin_user = current_admin_user
     end
   end
 end

--- a/app/controllers/admin_v2/team_members/deactivation_controller.rb
+++ b/app/controllers/admin_v2/team_members/deactivation_controller.rb
@@ -5,7 +5,6 @@ module AdminV2
     def update
       team_member = AdminUser.find(params[:team_member_id])
       team_member.deactivate!
-      team_member.create_activity(key: 'admin_user.deactivated', owner: current_admin_user)
 
       redirect_to admin_v2_team_path, notice: "#{team_member.name} deactivated"
     end

--- a/app/controllers/admin_v2/team_members/reactivation_controller.rb
+++ b/app/controllers/admin_v2/team_members/reactivation_controller.rb
@@ -5,7 +5,7 @@ module AdminV2
     def update
       team_member = AdminUser.find(params[:team_member_id])
 
-      team_member.reactivate!(activator: current_admin_user)
+      team_member.reactivate!
       team_member.reset_two_factor!
       team_member.invite!(current_admin_user)
 

--- a/app/controllers/admin_v2/team_members/resend_invitation_controller.rb
+++ b/app/controllers/admin_v2/team_members/resend_invitation_controller.rb
@@ -5,7 +5,7 @@ module AdminV2
     def create
       team_member = AdminUser.find(params[:team_member_id])
 
-      if team_member.pending?
+      if team_member.awaiting_activation?
         team_member.invite!(current_admin_user)
         redirect_to admin_v2_team_path, notice: "Invite sent to #{team_member.name}"
       else

--- a/app/controllers/admin_v2/team_members_controller.rb
+++ b/app/controllers/admin_v2/team_members_controller.rb
@@ -1,15 +1,15 @@
 module AdminV2
   class TeamMembersController < AdminV2::BaseController
     def index
-      @pending_team_members = AdminUser.pending.ordered
-      @active_team_members = AdminUser.active.ordered
+      @pending_team_members = AdminUser.awaiting_activation.ordered
+      @active_team_members = AdminUser.activated.ordered
       @deactivated_team_members = AdminUser.deactivated.ordered
     end
 
     def destroy # rubocop:disable Metrics/MethodLength
       team_member = AdminUser.find(params[:id])
 
-      if team_member.pending?
+      if team_member.awaiting_activation?
         team_member.create_activity(
           key: 'admin_user.removed',
           owner: current_admin_user,
@@ -17,7 +17,7 @@ module AdminV2
         )
 
         team_member.remove!
-        redirect_to admin_v2_team_path, notice: "#{team_member.name} removed from the team"
+        redirect_to admin_v2_team_path, notice: "Removed #{team_member.name} from the team"
       else
         redirect_to admin_v2_team_path, alert: 'Only pending team members can be removed'
       end

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -1,6 +1,7 @@
 class AdminUser < ApplicationRecord
   include TwoFactorAuthenticatable
   include PublicActivity::Common
+  include AASM
 
   devise :two_factor_authenticatable
   devise :invitable, :recoverable, :trackable, :timeoutable, :validatable,
@@ -10,9 +11,38 @@ class AdminUser < ApplicationRecord
 
   validates :name, presence: true, uniqueness: true
 
-  enum status: { pending: 'pending', active: 'active', deactivated: 'deactivated' }
-
   scope :ordered, -> { order(created_at: :desc) }
+  scope :awaiting_activation, -> { pending.or(pending_reactivation) }
+
+  enum status: {
+    pending: 'pending',
+    activated: 'activated',
+    deactivated: 'deactivated',
+    pending_reactivation: 'pending_reactivation'
+  }
+
+  aasm column: :status, enum: true, timestamps: true do
+    state :pending, initial: true
+    state :activated, :deactivated, :pending_reactivation
+
+    after_all_transitions :log_status_change
+
+    event :activate do
+      transitions from: %i[pending pending_reactivation], to: :activated
+    end
+
+    event :deactivate do
+      transitions from: %i[activated pending_reactivation], to: :deactivated
+    end
+
+    event :reactivate do
+      transitions from: :deactivated, to: :pending_reactivation, after: :set_reactivated_at!
+    end
+  end
+
+  def awaiting_activation?
+    pending? || pending_reactivation?
+  end
 
   def initials
     name.split.map(&:first).join
@@ -26,49 +56,27 @@ class AdminUser < ApplicationRecord
     deactivated? ? :deactivated : super
   end
 
-  def activate!
-    update!(status: :active)
-  end
-
-  def deactivate!
-    return unless active? || reactivated?
-
-    update!(status: :deactivated, deactivated_at: Time.current)
-  end
-
-  def reactivate!(activator:)
-    return unless deactivated?
-
-    update!(status: :pending, reactivated_by: activator, reactivated_at: Time.current)
-  end
-
   def enable_two_factor!
     super && activate!
   end
 
-  def reset_two_factor!
-    super && pending!
-  end
-
   def remove!
-    return unless pending?
+    return unless awaiting_activation?
 
-    if reactivated?
+    if pending_reactivation?
       deactivate!
     else
-      destroy
+      destroy!
     end
   end
 
   private
 
-  def reactivated?
-    reactivated_at.present?
+  def log_status_change
+    create_activity(key: "admin_user.#{aasm.to_state}", owner: Current.admin_user)
   end
 
-  def pending!
-    return if pending?
-
-    update!(status: :pending)
+  def set_reactivated_at!
+    update!(reactivated_at: Time.current)
   end
 end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,3 @@
+class Current < ActiveSupport::CurrentAttributes
+  attribute :admin_user
+end

--- a/app/views/admin_v2/team_members/_member.html.erb
+++ b/app/views/admin_v2/team_members/_member.html.erb
@@ -6,7 +6,7 @@
   <div class="min-w-0 w-full flex items-center justify-between">
     <div class="flex items-center gap-x-2">
       <p class="text-sm font-semibold leading-6 text-gray-800 dark:text-gray-300"><%= team_member.name %></p>
-      <% if team_member.pending? %>
+      <% if team_member.awaiting_activation? %>
         <%= render Ui::BadgeComponent.new(color: 'yellow') do %>
           Pending
         <% end %>
@@ -19,9 +19,9 @@
           <%= inline_svg_tag 'icons/ellipsis-horizontal.svg', class: 'h-6 w-6', aria: true %>
         <% end %>
 
-        <% if team_member.pending? %>
+        <% if team_member.awaiting_activation? %>
 
-         <% dropdown.with_item do %>
+          <% dropdown.with_item do %>
             <%= link_to admin_v2_team_member_resend_invitation_path(team_member), data: { turbo_method: :post, turbo_confirm: 'Are you sure?' }, class: 'text-gray-700 dark:text-gray-300 whitespace-nowrap group flex items-center px-3 py-2 text-sm' do %>
               <%= inline_svg_tag 'icons/envelope.svg', class: 'mr-3 h-5 w-5 text-gray-400 group-hover:text-gray-500 dark:text-gray-300 dark:group-hover:text-gray-400' %>
               Resend invite
@@ -36,7 +36,7 @@
           <% end %>
         <% end %>
 
-        <% if team_member.active? %>
+        <% if team_member.activated? %>
           <% dropdown.with_item do %>
             <%= link_to admin_v2_team_member_password_resets_path(team_member), data: { turbo_method: :post, turbo_confirm: 'Are you sure?' }, class: 'text-gray-700 dark:text-gray-300 whitespace-nowrap group flex items-center px-3 py-2 text-sm' do %>
               <%= inline_svg_tag 'icons/envelope.svg', class: 'mr-3 h-5 w-5 text-gray-400 group-hover:text-gray-500 dark:text-gray-300 dark:group-hover:text-gray-400' %>

--- a/app/views/public_activity/admin_user/_activated.html.erb
+++ b/app/views/public_activity/admin_user/_activated.html.erb
@@ -1,0 +1,1 @@
+<strong class="font-semibold"><%= activity.trackable.name %></strong> activated their account

--- a/app/views/public_activity/admin_user/_pending_reactivation.html.erb
+++ b/app/views/public_activity/admin_user/_pending_reactivation.html.erb
@@ -1,0 +1,1 @@
+<%= activity.owner.name %> reactivated <strong class="font-semibold"><%= activity.trackable.name %></strong>

--- a/db/migrate/20240726181456_add_reactivated_to_admin_user.rb
+++ b/db/migrate/20240726181456_add_reactivated_to_admin_user.rb
@@ -1,0 +1,9 @@
+class AddReactivatedToAdminUser < ActiveRecord::Migration[7.0]
+  def change
+    execute <<-SQL.squish
+      ALTER TYPE status RENAME TO admin_user_status;
+      ALTER TYPE admin_user_status RENAME VALUE 'active' TO 'activated';
+      ALTER TYPE admin_user_status ADD VALUE 'pending_reactivation';
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_23_092601) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_26_181456) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
-  create_enum "status", ["pending", "active", "deactivated"]
+  create_enum "admin_user_status", ["pending", "activated", "deactivated", "pending_reactivation"]
 
   create_table "active_admin_comments", id: :serial, force: :cascade do |t|
     t.string "namespace"
@@ -72,7 +72,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_23_092601) do
     t.string "invited_by_type"
     t.bigint "invited_by_id"
     t.integer "invitations_count", default: 0
-    t.enum "status", default: "pending", null: false, enum_type: "status"
+    t.enum "status", default: "pending", null: false, enum_type: "admin_user_status"
     t.datetime "deactivated_at"
     t.datetime "reactivated_at"
     t.bigint "reactivated_by_id"

--- a/db/seeds/test_admins.rb
+++ b/db/seeds/test_admins.rb
@@ -12,6 +12,6 @@ if Rails.env.development? || ENV['STAGING']
   AdminUser.find_or_create_by!(email: 'admin@odin.com') do |admin_user|
     admin_user.name = 'admin'
     admin_user.password = 'password123'
-    admin_user.status = 'active'
+    admin_user.status = 'activated'
   end
 end

--- a/spec/factories/admin_users.rb
+++ b/spec/factories/admin_users.rb
@@ -3,11 +3,27 @@ FactoryBot.define do
     sequence(:name) { |n| "admin#{n}" }
     sequence(:email) { |n| "admin#{n}@odin.com" }
     password { 'password123' }
-    status { :active }
+    status { :activated }
 
     trait :with_otp do
       otp_secret { AdminUser.generate_otp_secret }
       otp_required_for_login { true }
+    end
+
+    trait :pending do
+      status { :pending }
+    end
+
+    trait :pending_reactivation do
+      status { :pending_reactivation }
+    end
+
+    trait :deactivated do
+      status { :deactivated }
+    end
+
+    trait :activated do
+      status { :activated }
     end
   end
 end

--- a/spec/models/admin_user_spec.rb
+++ b/spec/models/admin_user_spec.rb
@@ -22,6 +22,112 @@ RSpec.describe AdminUser do
     end
   end
 
+  describe '.awaiting_activation' do
+    it 'returns admin users that are pending or pending reactivation' do
+      pending_admin = create(:admin_user, :pending)
+      pending_reactivation_admin = create(:admin_user, :pending_reactivation)
+      active_admin = create(:admin_user, :activated)
+
+      expect(described_class.awaiting_activation).to contain_exactly(
+        pending_admin,
+        pending_reactivation_admin
+      )
+    end
+  end
+
+  describe 'allowed status changes' do
+    context 'when the admin is pending' do
+      subject { create(:admin_user, :pending) }
+
+      it { is_expected.to allow_transition_to(:activated) }
+      it { is_expected.not_to allow_transition_to(:deactivated) }
+      it { is_expected.not_to allow_transition_to(:pending_reactivation) }
+    end
+
+    context 'when the admin is activated' do
+      subject { create(:admin_user, :activated) }
+
+      it { is_expected.to allow_transition_to(:deactivated) }
+      it { is_expected.not_to allow_transition_to(:pending) }
+      it { is_expected.not_to allow_transition_to(:pending_reactivation) }
+    end
+
+    context 'when the admin is pending reactivation' do
+      subject { create(:admin_user, :pending_reactivation) }
+
+      it { is_expected.to allow_transition_to(:deactivated) }
+      it { is_expected.to allow_transition_to(:activated) }
+      it { is_expected.not_to allow_transition_to(:pending) }
+    end
+  end
+
+  describe '#activate!' do
+    it 'transitions the admin to activated' do
+      admin = create(:admin_user, :pending)
+      expect { admin.activate! }.to change { admin.reload.status }.from('pending').to('activated')
+    end
+
+    it 'logs the status change' do
+      admin = create(:admin_user, :pending)
+
+      expect { admin.activate! }.to change { admin.activities.count }.by(1)
+    end
+  end
+
+  describe '#deactivate' do
+    it 'transitions the admin to deactivated' do
+      admin = create(:admin_user, :activated)
+      expect { admin.deactivate! }.to change { admin.reload.status }.from('activated').to('deactivated')
+    end
+
+    it 'logs the status change' do
+      admin = create(:admin_user, :activated)
+
+      expect { admin.deactivate! }.to change { admin.activities.count }.by(1)
+    end
+  end
+
+  describe '#reactivate!' do
+    it 'transitions the admin to pending reactivation' do
+      admin = create(:admin_user, :deactivated)
+      expect { admin.reactivate! }.to change { admin.reload.status }.from('deactivated').to('pending_reactivation')
+    end
+
+    it 'logs the status change' do
+      admin = create(:admin_user, :deactivated)
+
+      expect { admin.reactivate! }.to change { admin.activities.count }.by(1)
+    end
+
+    it 'sets the reactivated_at timestamp' do
+      admin = create(:admin_user, :deactivated)
+
+      freeze_time do
+        expect { admin.reactivate! }.to change { admin.reactivated_at }.from(nil).to(Time.current)
+      end
+    end
+  end
+
+  describe '#awaiting_activation?' do
+    context 'when the admin is pending' do
+      subject { build(:admin_user, :pending) }
+
+      it { is_expected.to be_awaiting_activation }
+    end
+
+    context 'when the admin is pending reactivation' do
+      subject { build(:admin_user, :pending_reactivation) }
+
+      it { is_expected.to be_awaiting_activation }
+    end
+
+    context 'when the admin is not pending or pending reactivation' do
+      subject { build(:admin_user, :activated) }
+
+      it { is_expected.not_to be_awaiting_activation }
+    end
+  end
+
   describe '#initials' do
     it 'returns the initials of the admin user' do
       admin_user = build(:admin_user, name: 'John Wick')
@@ -39,7 +145,7 @@ RSpec.describe AdminUser do
 
     context 'when admin has been deactivated' do
       it 'returns false' do
-        admin = create(:admin_user, status: :deactivated)
+        admin = create(:admin_user, :deactivated)
         expect(admin).not_to be_active_for_authentication
       end
     end
@@ -55,155 +161,45 @@ RSpec.describe AdminUser do
 
     context 'when admin has been deactivated' do
       it 'returns banned translation key' do
-        admin = create(:admin_user, status: :deactivated)
+        admin = create(:admin_user, :deactivated)
         expect(admin.inactive_message).to eq(:deactivated)
-      end
-    end
-  end
-
-  describe '#activate!' do
-    it 'activates the admin' do
-      admin = build(:admin_user, status: :pending)
-
-      expect do
-        admin.activate!
-      end.to change { admin.status }.from('pending').to('active')
-    end
-  end
-
-  describe '#deactivate!' do
-    context 'when the admin is active' do
-      it 'deactivates the admin' do
-        admin = build(:admin_user, status: :active)
-
-        expect do
-          admin.deactivate!
-        end.to change { admin.status }.from('active').to('deactivated')
-      end
-
-      it 'sets the deactivated_at timestamp' do
-        admin = build(:admin_user, status: :active)
-
-        freeze_time do
-          expect do
-            admin.deactivate!
-          end.to change { admin.deactivated_at }.from(nil).to(Time.current)
-        end
-      end
-    end
-
-    context 'when the admin has been reactivated' do
-      it 'deactivates the admin' do
-        admin = build(:admin_user, status: :pending, reactivated_at: 1.day.ago)
-
-        expect do
-          admin.deactivate!
-        end.to change { admin.status }.from('pending').to('deactivated')
-      end
-
-      it 'sets the deactivated_at timestamp' do
-        admin = build(:admin_user, status: :pending, reactivated_at: 1.day.ago)
-
-        freeze_time do
-          expect do
-            admin.deactivate!
-          end.to change { admin.deactivated_at }.from(nil).to(Time.current)
-        end
-      end
-    end
-
-    context 'when the admin is already deactivated' do
-      it 'does not deactivate the admin' do
-        admin = build(:admin_user, status: :deactivated)
-
-        expect { admin.deactivate! }.not_to change { admin.status }
-      end
-    end
-  end
-
-  describe '#reactivate!' do
-    it 'reactivates the admin' do
-      admin = build(:admin_user, status: :deactivated)
-      activator = build(:admin_user)
-
-      expect do
-        admin.reactivate!(activator:)
-      end.to change { admin.status }.from('deactivated').to('pending')
-    end
-
-    it 'sets the reactivator' do
-      admin = build(:admin_user, status: :deactivated)
-      activator = build(:admin_user)
-
-      expect do
-        admin.reactivate!(activator:)
-      end.to change { admin.reactivated_by }.from(nil).to(activator)
-    end
-
-    it 'sets the reactivated_at timestamp' do
-      admin = build(:admin_user, status: :deactivated)
-      activator = build(:admin_user)
-
-      freeze_time do
-        expect do
-          admin.reactivate!(activator:)
-        end.to change { admin.reactivated_at }.from(nil).to(Time.current)
-      end
-    end
-
-    context 'when the admin is already active' do
-      it 'does not reactivate the admin' do
-        admin = build(:admin_user, status: :active)
-        activator = build(:admin_user)
-
-        expect { admin.reactivate!(activator:) }.not_to change { admin.status }
       end
     end
   end
 
   describe '#enable_two_factor!' do
     it 'activates the admin' do
-      admin = build(:admin_user, status: :pending)
+      admin = build(:admin_user, :pending)
 
       expect do
         admin.enable_two_factor!
-      end.to change { admin.status }.from('pending').to('active')
-    end
-  end
-
-  describe '#reset_two_factor!' do
-    it 'sets the admin to pending' do
-      admin = build(:admin_user, status: :active)
-
-      expect do
-        admin.reset_two_factor!
-      end.to change { admin.status }.from('active').to('pending')
+      end.to change { admin.status }.from('pending').to('activated')
     end
   end
 
   describe '#remove!' do
-    context 'when the admin is not pending' do
-      it 'does not remove active admins' do
-        admin = build(:admin_user, status: :active)
+    context 'when the admin is not awaiting activation' do
+      it 'does not remove activated admins' do
+        admin = build(:admin_user, :activated)
         expect { admin.remove! }.not_to change { admin.status }
       end
 
       it 'does not remove deactivated admins' do
-        admin = build(:admin_user, status: :deactivated)
+        admin = build(:admin_user, :deactivated)
         expect { admin.remove! }.not_to change { admin.status }
       end
     end
 
-    context 'when the admin has been previously reactivated' do
+    context 'when the admin is pending reactivation' do
       it 'deactivates the admin' do
-        admin = create(:admin_user, status: :pending, reactivated_at: 1.day.ago)
-        expect { admin.remove! }.to change { admin.reload.status }.from('pending').to('deactivated')
+        admin = create(:admin_user, :pending_reactivation)
+        expect { admin.remove! }.to change { admin.reload.status }.from('pending_reactivation').to('deactivated')
       end
     end
 
-    context 'when the admin has not been previously reactivated' do
+    context 'when the admin is not pending reactivation' do
       it 'destroys the admin' do
-        admin = create(:admin_user, status: :pending)
+        admin = create(:admin_user, :pending)
 
         expect { admin.remove! }.to change { described_class.count }.by(-1)
       end

--- a/spec/requests/admin_v2/team_members/deactivation_spec.rb
+++ b/spec/requests/admin_v2/team_members/deactivation_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe 'Team member deactivation' do
     context 'when signed in as an admin and the team member exists' do
       it 'deactivates the team member' do
         admin = create(:admin_user)
-        active_admin = create(:admin_user, status: :active)
+        active_admin = create(:admin_user, :activated)
 
         sign_in(admin)
 
         expect do
           put admin_v2_team_member_deactivation_path(team_member_id: active_admin.id)
-        end.to change { active_admin.reload.status }.from('active').to('deactivated')
+        end.to change { active_admin.reload.status }.from('activated').to('deactivated')
 
         expect(response).to redirect_to(admin_v2_team_path)
       end

--- a/spec/requests/admin_v2/team_members/reactivation_spec.rb
+++ b/spec/requests/admin_v2/team_members/reactivation_spec.rb
@@ -5,20 +5,20 @@ RSpec.describe 'Team member reactivation' do
     context 'when signed in as an admin and the team member exists' do
       it 'reactivates the team member' do
         admin = create(:admin_user)
-        deactivated_admin = create(:admin_user, status: :deactivated)
+        deactivated_admin = create(:admin_user, :deactivated)
 
         sign_in(admin)
 
         expect do
           put admin_v2_team_member_reactivation_path(team_member_id: deactivated_admin.id)
-        end.to change { deactivated_admin.reload.status }.from('deactivated').to('pending')
+        end.to change { deactivated_admin.reload.status }.from('deactivated').to('pending_reactivation')
 
         expect(response).to redirect_to(admin_v2_team_path)
       end
 
       it 'resets the admins two factor credentials' do
         admin = create(:admin_user)
-        deactivated_admin = create(:admin_user, status: :deactivated, otp_secret: 'secret')
+        deactivated_admin = create(:admin_user, :deactivated, otp_secret: 'secret')
         sign_in(admin)
 
         expect do
@@ -28,7 +28,7 @@ RSpec.describe 'Team member reactivation' do
 
       it 'sends an invitation email to the team member' do
         admin = create(:admin_user)
-        deactivated_admin = create(:admin_user, status: :deactivated, email: 'deactivated@odin.com')
+        deactivated_admin = create(:admin_user, :deactivated, email: 'deactivated@odin.com')
         sign_in(admin)
 
         expect do

--- a/spec/requests/admin_v2/team_members/resend_invitation_spec.rb
+++ b/spec/requests/admin_v2/team_members/resend_invitation_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Resend team member invite' do
     context 'when signed in as an admin and the team member is pending' do
       it 'sends another invitation email to the team member' do
         admin = create(:admin_user)
-        pending_admin = create(:admin_user, status: :pending, email: 'pending@odin.com')
+        pending_admin = create(:admin_user, :pending, email: 'pending@odin.com')
         sign_in(admin)
 
         expect do
@@ -22,7 +22,7 @@ RSpec.describe 'Resend team member invite' do
     context 'when signed in as an admin and the team member is not pending' do
       it 'does not send the team member another invite' do
         admin = create(:admin_user)
-        active_admin = create(:admin_user, status: :active, email: 'active@odin.com')
+        active_admin = create(:admin_user, :activated, email: 'active@odin.com')
 
         sign_in(admin)
 

--- a/spec/requests/admin_v2/team_members_spec.rb
+++ b/spec/requests/admin_v2/team_members_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Team members' do
   describe 'DELETE #destroy' do
     context 'when signed in as an admin and the team member is pending' do
       it 'deletes the team member' do
-        pending_admin = create(:admin_user, status: :pending)
+        pending_admin = create(:admin_user, :pending)
 
         sign_in(create(:admin_user))
 
@@ -40,7 +40,7 @@ RSpec.describe 'Team members' do
 
     context 'when signed in as an admin and the team member is not pending' do
       it 'does not delete the team member' do
-        active_admin = create(:admin_user, status: :active)
+        active_admin = create(:admin_user, :activated)
 
         sign_in(create(:admin_user))
 

--- a/spec/requests/admin_v2/two_factor_authentication_spec.rb
+++ b/spec/requests/admin_v2/two_factor_authentication_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Two factor authentication' do
   describe 'POST #create' do
     context 'when the otp code is valid' do
       it 'enables two factor authentication for the admin' do
-        admin = create(:admin_user, otp_required_for_login: false)
+        admin = create(:admin_user, :pending, otp_required_for_login: false)
         allow(admin).to receive(:validate_and_consume_otp!).and_return(true)
 
         sign_in(admin)

--- a/spec/support/aasm.rb
+++ b/spec/support/aasm.rb
@@ -1,0 +1,1 @@
+require 'aasm/rspec'

--- a/spec/support/shared_examples/shared_examples_for_authenticatable_with_two_factor.rb
+++ b/spec/support/shared_examples/shared_examples_for_authenticatable_with_two_factor.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.shared_examples 'authenticatable_with_two_factor' do |factory|
-  let(:record) { create(factory) }
+  let(:record) { create(factory, :pending) }
 
   describe '#generate_two_factor_secret_if_missing!' do
     context 'when the otp secret is not present' do

--- a/spec/system/admin_v2/deactivations_spec.rb
+++ b/spec/system/admin_v2/deactivations_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe 'Admin V2 team member deactivation' do
   it 'deactivates a team member' do
-    admin = create(:admin_user, status: :active)
-    other_admin = create(:admin_user, status: :active, email: 'otheradmin@odin.com', password: 'password')
+    admin = create(:admin_user, :activated)
+    other_admin = create(:admin_user, :activated, email: 'otheradmin@odin.com', password: 'password')
 
     sign_in(admin)
 

--- a/spec/system/admin_v2/invitations_spec.rb
+++ b/spec/system/admin_v2/invitations_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe 'Admin v2 invitations' do
   end
 
   it 'does not allow access if two factor authentication is not enabled' do
-    sign_in(create(:admin_user, status: :active))
+    sign_in(create(:admin_user, :activated))
 
     # Create a new invitation
     visit admin_v2_team_path

--- a/spec/system/admin_v2/reactivations_spec.rb
+++ b/spec/system/admin_v2/reactivations_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe 'Admin V2 team members reactivations' do
   it 'deactivates a team member' do
-    admin = create(:admin_user, status: :active)
-    deactivated_admin = create(:admin_user, status: :deactivated, email: 'deactivated@admin.com')
+    admin = create(:admin_user, :activated)
+    deactivated_admin = create(:admin_user, :deactivated, email: 'deactivated@admin.com')
 
     sign_in(admin)
 

--- a/spec/system/admin_v2/sign_in_and_out_spec.rb
+++ b/spec/system/admin_v2/sign_in_and_out_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Admin V2 Sign in and sign out' do
 
     context 'when the admin is deactivated' do
       it 'does not sign the admin in' do
-        admin_user = create(:admin_user, status: :deactivated)
+        admin_user = create(:admin_user, :deactivated)
 
         visit admin_v2_root_path
 


### PR DESCRIPTION
Because:
- A state machine will make it easier to reason about state transitions and make sure the state change rules are enforced
- Closes: https://github.com/TheOdinProject/theodinproject/issues/4658

This commit:
- Adds AASM for the state machine DSL
- Renames admin user active status to "activated" to be more uniform with the other statuses
- Adds a new "pending reactivation" status to hold reactivated users until they set new password and 2fa credentials
- Creates activities automatically when an admin user status changes
- Adds status traits to admin user factory
- Adds current attributes to set the admin user so we can use the current admin user when creating an activity from a model.

