### PR TITLE
Feature: Admin V2 - Nav links for Sidekiq and feature flags

### DIFF
--- a/app/views/layouts/admin_v2/_sidebar_nav.html.erb
+++ b/app/views/layouts/admin_v2/_sidebar_nav.html.erb
@@ -9,6 +9,12 @@ nav_links = [
       { name: 'Lesson completions', path: admin_v2_reports_lesson_completions_path },
       { name: 'Users', path: admin_v2_reports_users_path },
     ].concat(Path.order_by_position.flat_map { |path| { name: "#{path.title} path", path: admin_v2_reports_path_path(path) } })
+  },
+  {
+    name: 'Tools', icon: 'wrench-screwdriver', nested_nav_links: [
+      { name: 'Sidekiq', path: admin_v2_sidekiq_web_path },
+      { name: 'Feature flags', path: admin_v2_feature_flags_path },
+    ]
   }
 ]
 %>

--- a/config/routes/admin_v2.rb
+++ b/config/routes/admin_v2.rb
@@ -1,8 +1,16 @@
+require 'sidekiq/web'
+require 'sidekiq/cron/web'
+
 devise_for :admin_users, path: :admin_v2, module: :admin_v2
 
-namespace :admin_v2 do
+namespace :admin_v2 do # rubocop:disable Metrics/BlockLength
   root to: 'dashboard#show'
   resource :dashboard, only: :show, controller: :dashboard
+
+  authenticate :admin_user do
+    mount Sidekiq::Web => '/sidekiq'
+    mount Flipper::UI.app(Flipper) => '/feature_flags', as: :feature_flags
+  end
 
   resources :flags, only: %i[index show update]
   resources :announcements


### PR DESCRIPTION
Because:
- When I want to view Sidekiq or feature flags, I want an easy way to get to them, so I don't need to memorise the URLs.
- Closes: https://github.com/TheOdinProject/theodinproject/issues/4659
