### PR TITLE
Feature: Admin V2 - Create activity when password reset email is sent

### DIFF
--- a/app/controllers/admin_v2/team_members/password_resets_controller.rb
+++ b/app/controllers/admin_v2/team_members/password_resets_controller.rb
@@ -6,6 +6,7 @@ module AdminV2
       team_member = AdminUser.find(params[:team_member_id])
 
       team_member.send_reset_password_instructions
+      team_member.create_activity(key: 'admin_user.password_reset', owner: current_admin_user)
       redirect_to admin_v2_team_path, notice: 'Reset password instructions sent'
     end
 

--- a/app/views/public_activity/admin_user/_password_reset.html.erb
+++ b/app/views/public_activity/admin_user/_password_reset.html.erb
@@ -1,0 +1,1 @@
+<%= activity.owner.name %> sent a password reset email to <strong class="font-semibold"><%= activity.trackable.name %></strong>


### PR DESCRIPTION
Because:
- When I reset an admin team members password, I want an activity to be created, so it is auditable.
- Closes: https://github.com/TheOdinProject/theodinproject/issues/4661
