### PR TITLE
Fix: Admin v2 - Resetting 2fa should set admin user to pending

### DIFF
--- a/app/controllers/admin_v2/team_members/two_factor_reset_controller.rb
+++ b/app/controllers/admin_v2/team_members/two_factor_reset_controller.rb
@@ -6,6 +6,7 @@ module AdminV2
       team_member = AdminUser.find(params[:team_member_id])
 
       team_member.reset_two_factor!
+      team_member.pending!
       team_member.create_activity(key: 'admin_user.two_factor_reset', owner: current_admin_user)
       redirect_to admin_v2_team_path, notice: "#{team_member.name} two factor reset"
     end

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -32,7 +32,7 @@ class AdminUser < ApplicationRecord
     end
 
     event :deactivate do
-      transitions from: %i[activated pending_reactivation], to: :deactivated
+      transitions from: %i[activated pending_reactivation pending], to: :deactivated
     end
 
     event :reactivate do
@@ -63,7 +63,7 @@ class AdminUser < ApplicationRecord
   def remove!
     return unless awaiting_activation?
 
-    if pending_reactivation?
+    if invitation_accepted?
       deactivate!
     else
       destroy!

--- a/spec/models/admin_user_spec.rb
+++ b/spec/models/admin_user_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe AdminUser do
       subject { create(:admin_user, :pending) }
 
       it { is_expected.to allow_transition_to(:activated) }
-      it { is_expected.not_to allow_transition_to(:deactivated) }
+      it { is_expected.to allow_transition_to(:deactivated) }
       it { is_expected.not_to allow_transition_to(:pending_reactivation) }
     end
 
@@ -190,14 +190,14 @@ RSpec.describe AdminUser do
       end
     end
 
-    context 'when the admin is pending reactivation' do
+    context 'when the admin has previously accepted an invite' do
       it 'deactivates the admin' do
-        admin = create(:admin_user, :pending_reactivation)
-        expect { admin.remove! }.to change { admin.reload.status }.from('pending_reactivation').to('deactivated')
+        admin = create(:admin_user, :pending, invitation_accepted_at: 10.days.ago)
+        expect { admin.remove! }.to change { admin.reload.status }.from('pending').to('deactivated')
       end
     end
 
-    context 'when the admin is not pending reactivation' do
+    context 'when the admin has not accepted their invite' do
       it 'destroys the admin' do
         admin = create(:admin_user, :pending)
 

--- a/spec/requests/admin_v2/team_members/two_factor_reset_spec.rb
+++ b/spec/requests/admin_v2/team_members/two_factor_reset_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'Team member two factor reset' do
         expect do
           put admin_v2_team_member_two_factor_reset_path(team_member_id: other_admin.id)
         end.to change { other_admin.reload.otp_secret }.to(nil)
+          .and change { other_admin.reload.status }.from('activated').to('pending')
 
         expect(response).to redirect_to(admin_v2_team_path)
       end


### PR DESCRIPTION
Because:
- Previously, the `reset_two_factor` method also set an admin to pending. But that was removed.

This commit:
- Explicitly resets the admin to pending when this controller action is triggered.
- More test coverage around the rest 2fa controller