### PR TITLE
Chore: Add Admin User Foreign Key to Flags

### DIFF
--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -8,6 +8,7 @@ class AdminUser < ApplicationRecord
          password_length: 8..128
 
   belongs_to :reactivated_by, class_name: 'AdminUser', optional: true
+  has_many :flags, dependent: :nullify
 
   validates :name, presence: true, uniqueness: true
 

--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -11,6 +11,7 @@ class Flag < ApplicationRecord
 
   belongs_to :flagger, class_name: 'User'
   belongs_to :project_submission
+  belongs_to :admin_user, optional: true
 
   validates :reason, presence: true
   validates :extra, presence: true, if: -> { reason == 'other' }
@@ -23,6 +24,12 @@ class Flag < ApplicationRecord
   scope :count_for, ->(status) { by_status(status).count }
   scope :ordered_by_most_recent, -> { order(created_at: :desc) }
 
+  def admin_user
+    return Null::AdminUser.new if resolved? && super.nil?
+
+    super
+  end
+
   def project_submission_owner
     project_submission.user
   end
@@ -31,7 +38,7 @@ class Flag < ApplicationRecord
     update(
       status: :resolved,
       taken_action: action_taken,
-      resolved_by_id: resolved_by.id
+      admin_user: resolved_by
     )
   end
 

--- a/app/models/null/admin_user.rb
+++ b/app/models/null/admin_user.rb
@@ -1,0 +1,5 @@
+class Null::AdminUser
+  def name
+    'Deleted Admin User'
+  end
+end

--- a/app/views/admin_v2/flags/index.html.erb
+++ b/app/views/admin_v2/flags/index.html.erb
@@ -35,6 +35,7 @@
                 <% if params[:status] == "resolved" %>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold">Action taken</th>
                 <% end %>
+                <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold">Resolved by</th>
                 <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-0">
                   <span class="sr-only">View</span>
                 </th>
@@ -71,6 +72,11 @@
                   <% if params[:status] == "resolved" %>
                     <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-gray-300"><%= flag.action_taken.past_tense %></td>
                   <% end %>
+
+                  <% if flag.resolved? %>
+                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-gray-300"><%= flag.admin_user.name %></td>
+                  <% end %>
+
                   <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-0">
                     <%= link_to 'View', admin_v2_flag_path(flag), class: 'underline text-gray-800 hover:text-gray-900 hover:no-underline dark:text-gray-300 dark:hover:text-gray-200' %>
                   </td>

--- a/app/views/admin_v2/flags/show.html.erb
+++ b/app/views/admin_v2/flags/show.html.erb
@@ -22,7 +22,7 @@
 
   <div>
     <div class="mt-6 border-t border-gray-100 dark:border-gray-800">
-      <dl class="divide-y divide-gray-100 dark:divide-gray-800">
+      <div class="divide-y divide-gray-100 dark:divide-gray-800">
         <div class="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
           <dt class="text-sm font-medium leading-6 text-gray-800 dark:text-gray-300">Reason</dt>
           <dd class="mt-1 text-sm leading-6 text-gray-700 dark:text-gray-300 sm:col-span-2 sm:mt-0"><%= Flag::REASONS.find { |reason| reason.name.to_s == @flag.reason }&.description %></dd>
@@ -61,6 +61,13 @@
           <dt class="text-sm font-medium leading-6 text-gray-800 dark:text-gray-300">Who created the flag?</dt>
           <dd class="mt-1 text-sm leading-6 text-gray-700 dark:text-gray-300 sm:col-span-2 sm:mt-0"><%= @flag.flagger.username %></dd>
         </div>
+
+        <% if @flag.resolved? %>
+          <div class="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
+            <dt class="text-sm font-medium leading-6 text-gray-800 dark:text-gray-300">Who resolved the flag?</dt>
+            <dd class="mt-1 text-sm leading-6 text-gray-700 dark:text-gray-300 sm:col-span-2 sm:mt-0"><%= @flag.admin_user.name %></dd>
+          </div>
+        <% end %>
       </dl>
     </div>
   </div>

--- a/app/views/admin_v2/invitations/new.html.erb
+++ b/app/views/admin_v2/invitations/new.html.erb
@@ -9,7 +9,7 @@
           </div>
           <div>
             <%= form.label :email, 'Email address' %>
-            <%= form.text_field :email, class: 'text-sm', placeholder: 'name@example.com', data: { test_id: 'email-address-field' } %>
+            <%= form.email_field :email, class: 'text-sm', placeholder: 'name@example.com', data: { test_id: 'email-address-field' } %>
           </div>
         </div>
 

--- a/db/migrate/20240729171320_add_admin_user_foreign_key_to_flags.rb
+++ b/db/migrate/20240729171320_add_admin_user_foreign_key_to_flags.rb
@@ -1,0 +1,5 @@
+class AddAdminUserForeignKeyToFlags < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :flags, :admin_user, foreign_key: true, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_26_181456) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_29_171320) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -135,6 +135,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_26_181456) do
     t.datetime "updated_at", null: false
     t.integer "resolved_by_id"
     t.integer "reason", default: 4, null: false
+    t.bigint "admin_user_id"
+    t.index ["admin_user_id"], name: "index_flags_on_admin_user_id"
     t.index ["flagger_id"], name: "index_flags_on_flagger_id"
     t.index ["project_submission_id"], name: "index_flags_on_project_submission_id"
   end
@@ -349,6 +351,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_26_181456) do
   add_foreign_key "admin_users", "admin_users", column: "reactivated_by_id"
   add_foreign_key "announcements", "users"
   add_foreign_key "contents", "lessons"
+  add_foreign_key "flags", "admin_users"
   add_foreign_key "flags", "project_submissions"
   add_foreign_key "flags", "users", column: "flagger_id"
   add_foreign_key "lesson_completions", "lessons", on_delete: :cascade

--- a/spec/models/admin_user_spec.rb
+++ b/spec/models/admin_user_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe AdminUser do
   it_behaves_like 'authenticatable_with_two_factor', :admin_user
   it_behaves_like 'two_factor_authenticatable'
 
+  it { is_expected.to have_many(:flags).dependent(:nullify) }
+
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_uniqueness_of(:name) }
   it { is_expected.to validate_presence_of(:email) }


### PR DESCRIPTION
Because
- We need to know who resolved a flag on Admin v2

This commit:
- Adds an admin_user foreign key to flags
- Adds a null admin user object to populate the name of flags handled by admins who have been deleted
- Adds resolved by column to the flags index table
- Adds a resolved by detail to the flag show page
