### PR TITLE
Chore: Add admin user foreign key to announcements

### DIFF
--- a/app/controllers/admin_v2/announcements_controller.rb
+++ b/app/controllers/admin_v2/announcements_controller.rb
@@ -1,7 +1,9 @@
 module AdminV2
   class AnnouncementsController < AdminV2::BaseController
     def index
-      @pagy, @announcements = pagy(Announcement.for_status(params.fetch(:status, :active)).ordered_by_recent, items: 20)
+      @pagy, @announcements = pagy(Announcement
+        .for_status(params.fetch(:status, :active))
+        .ordered_by_recent, items: 20)
     end
 
     def show
@@ -17,7 +19,7 @@ module AdminV2
     end
 
     def create
-      @announcement = Announcement.new(announcement_params)
+      @announcement = Announcement.new(announcement_params.merge(admin_user: current_admin_user))
 
       if @announcement.save
         redirect_to admin_v2_announcement_path(@announcement)

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,5 +1,6 @@
 class Announcement < ApplicationRecord
   belongs_to :user, optional: true
+  belongs_to :admin_user, optional: true
 
   validates :message, presence: true
   validates :message, length: { maximum: 100 }
@@ -27,6 +28,10 @@ class Announcement < ApplicationRecord
 
   def active?
     status == :active
+  end
+
+  def created_by
+    admin_user || Null::AdminUser.new
   end
 
   private

--- a/app/views/admin_v2/announcements/index.html.erb
+++ b/app/views/admin_v2/announcements/index.html.erb
@@ -32,6 +32,7 @@
               <tr class="text-gray-800 dark:text-gray-300">
                 <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold sm:pl-0">Message</th>
                 <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold">Created</th>
+                <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold">Created by</th>
                 <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold">Expires</th>
                 <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-0"><span class="sr-only">Edit</span></th>
               </tr>
@@ -48,6 +49,10 @@
                     <span title="<%= announcement.created_at %>">
                       <%= time_ago_in_words(announcement.created_at) %> ago
                     </span>
+                  </td>
+
+                  <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-gray-400">
+                    <%= announcement.created_by.name %>
                   </td>
 
                   <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-gray-400">

--- a/app/views/admin_v2/announcements/show.html.erb
+++ b/app/views/admin_v2/announcements/show.html.erb
@@ -38,6 +38,11 @@
         </div>
 
         <div class="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
+          <dt class="text-sm font-medium leading-6 text-gray-800 dark:text-gray-200">Created by</dt>
+          <dd class="mt-1 text-sm leading-6 text-gray-700 dark:text-gray-300 sm:col-span-2 sm:mt-0"><%= @announcement.created_by.name %></dd>
+        </div>
+
+        <div class="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
           <dt class="text-sm font-medium leading-6 text-gray-800 dark:text-gray-200">Expires</dt>
           <dd class="mt-1 text-sm leading-6 text-gray-700 dark:text-gray-200 sm:col-span-2 sm:mt-0">
             <span title="<%= @announcement.expires_at %>">

--- a/db/migrate/20240730080010_add_admin_user_to_announcement.rb
+++ b/db/migrate/20240730080010_add_admin_user_to_announcement.rb
@@ -1,0 +1,5 @@
+class AddAdminUserToAnnouncement < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :announcements, :admin_user, foreign_key: true, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -93,6 +93,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_30_082143) do
     t.datetime "expires_at", precision: nil, null: false
     t.bigint "user_id"
     t.string "learn_more_url"
+    t.bigint "admin_user_id"
+    t.index ["admin_user_id"], name: "index_announcements_on_admin_user_id"
     t.index ["expires_at"], name: "index_announcements_on_expires_at"
     t.index ["user_id"], name: "index_announcements_on_user_id"
   end
@@ -346,6 +348,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_30_082143) do
     t.index ["username"], name: "index_users_on_username"
   end
 
+  add_foreign_key "announcements", "admin_users"
   add_foreign_key "announcements", "users"
   add_foreign_key "contents", "lessons"
   add_foreign_key "flags", "admin_users"

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Announcement do
+  it { is_expected.to belong_to(:admin_user).optional }
   it { is_expected.to validate_presence_of(:message) }
   it { is_expected.to validate_length_of(:message).is_at_most(100) }
   it { is_expected.to validate_presence_of(:expires_at) }
@@ -107,6 +108,25 @@ RSpec.describe Announcement do
     context 'when the announcement is expired' do
       it 'returns false' do
         expect(build(:announcement, expires_at: 1.day.ago)).not_to be_active
+      end
+    end
+  end
+
+  describe '#created_by' do
+    context 'when the announcement was created by an admin user' do
+      it 'returns the admin user' do
+        admin_user = build_stubbed(:admin_user)
+        announcement = build_stubbed(:announcement, admin_user:)
+
+        expect(announcement.created_by).to eq(admin_user)
+      end
+    end
+
+    context 'when the announcement has no admin user' do
+      it 'returns a null admin user' do
+        announcement = build_stubbed(:announcement)
+
+        expect(announcement.created_by).to be_a(Null::AdminUser)
       end
     end
   end


### PR DESCRIPTION
Because:
- We need to know who created announcements

This commit:
- Adds a admin_user foreign key to announcements
- Returns a null admin user for older announcements created by admins that have since been deleted
- Displays the admin who created the announcement on the announcement index and show pages.