### PR TITLE
Fix: Add Active Record Encryption keys to test enviroment

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -61,6 +61,12 @@ Rails.application.configure do
   # Tell Active Support which deprecation messages to disallow.
   config.active_support.disallowed_deprecation_warnings = []
 
+  config.active_record.encryption = {
+    primary_key: 'C697JaYLcwzaSkxtmnedQad2Tl369h4P',
+    deterministic_key: '7Db9oVtlyUn59MkoSnqnwBo17eJqqw7w',
+    key_derivation_salt: 'IlKDRto84iBwxg09w0nbBqlWBe8a2NWT'
+  }
+
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
- this is causing tests to fail (see e.g. https://github.com/TheOdinProject/theodinproject/pull/4677), including on a no op

## This PR
- Copies the active record keys from `development.rb` to `test.rb`

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.