### PR TITLE
Chore: Add created and updated activities on announcements

### DIFF
--- a/app/controllers/admin_v2/announcements_controller.rb
+++ b/app/controllers/admin_v2/announcements_controller.rb
@@ -20,6 +20,7 @@ module AdminV2
       @announcement = Announcement.new(announcement_params)
 
       if @announcement.save
+        create_activity(@announcement, 'created')
         redirect_to admin_v2_announcement_path(@announcement)
       else
         render :new, status: :unprocessable_entity
@@ -30,6 +31,7 @@ module AdminV2
       @announcement = Announcement.find(params[:id])
 
       if @announcement.update(announcement_params)
+        create_activity(@announcement, 'updated')
         redirect_to admin_v2_announcement_path(@announcement), notice: 'Announcement updated.'
       else
         render :edit, status: :unprocessable_entity
@@ -48,6 +50,14 @@ module AdminV2
 
     def announcement_params
       params.require(:announcement).permit(:message, :expires_at, :learn_more_url)
+    end
+
+    def create_activity(announcement, key)
+      announcement.create_activity(
+        key: "announcement.#{key}",
+        owner: current_admin_user,
+        parameters: { params: announcement_params.to_h }
+      )
     end
   end
 end

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,4 +1,6 @@
 class Announcement < ApplicationRecord
+  include PublicActivity::Common
+
   belongs_to :user, optional: true
 
   validates :message, presence: true


### PR DESCRIPTION
Because:
- Announcements are seen by everyone and need to be auditable

This commit:
- Creates activities when an announcement is created and updated.
- We aren't exposing these activities in the UI yet, but may do in the future.