### PR TITLE
Feature: Admin v2 - Team member roles

### DIFF
--- a/app/controllers/admin_v2/invitations_controller.rb
+++ b/app/controllers/admin_v2/invitations_controller.rb
@@ -23,7 +23,7 @@ class AdminV2::InvitationsController < Devise::InvitationsController
   end
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:invite, keys: %i[name email])
+    devise_parameter_sanitizer.permit(:invite, keys: %i[name email role])
   end
 
   def create_invited_activity

--- a/app/controllers/admin_v2/team_members/role_controller.rb
+++ b/app/controllers/admin_v2/team_members/role_controller.rb
@@ -1,0 +1,32 @@
+module AdminV2
+  class TeamMembers::RoleController < AdminV2::BaseController
+    rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+
+    def edit
+      @team_member = AdminUser.find(params[:team_member_id])
+    end
+
+    def update
+      @team_member = AdminUser.find(params[:team_member_id])
+
+      respond_to do |format|
+        if @team_member.update(admin_user_params)
+          flash.now[:notice] = "#{@team_member.name} role updated"
+          format.turbo_stream
+        else
+          format.html { render :edit, status: :unprocessable_entity }
+        end
+      end
+    end
+
+    private
+
+    def admin_user_params
+      params.require(:admin_user).permit(:role)
+    end
+
+    def record_not_found
+      redirect_to admin_v2_team_path, alert: 'Team member not found'
+    end
+  end
+end

--- a/app/views/admin_v2/invitations/new.html.erb
+++ b/app/views/admin_v2/invitations/new.html.erb
@@ -7,9 +7,15 @@
             <%= form.label :name %>
             <%= form.text_field :name, autofocus: true, required: true, class: 'text-sm', placeholder: 'name', data: { test_id: 'name-field' } %>
           </div>
+
           <div>
             <%= form.label :email, 'Email address' %>
-            <%= form.email_field :email, class: 'text-sm', placeholder: 'name@example.com', data: { test_id: 'email-address-field' } %>
+            <%= form.email_field :email, class: 'text-sm', required: true, placeholder: 'name@example.com', data: { test_id: 'email-address-field' } %>
+          </div>
+
+          <div>
+            <%= form.label :role, 'Role', class: 'mb-2' %>
+            <%= form.select :role, options_for_select(AdminUser.roles), { include_blank: 'Select Role' }, required: true, class: 'text-sm', data: { test_id: 'role-field' } %>
           </div>
         </div>
 

--- a/app/views/admin_v2/team_members/_member.html.erb
+++ b/app/views/admin_v2/team_members/_member.html.erb
@@ -4,8 +4,16 @@
   </div>
 
   <div class="min-w-0 w-full flex items-center justify-between">
-    <div class="flex items-center gap-x-2">
-      <p class="text-sm font-semibold leading-6 text-gray-800 dark:text-gray-300"><%= team_member.name %></p>
+    <div class="flex items-end gap-x-4">
+      <div class="flex flex-col">
+        <p class="text-sm font-semibold leading-6 text-gray-800 dark:text-gray-300"><%= team_member.name %></p>
+        <p class="text-xs pt-1 text-gray-600 dark:text-gray-400">
+          <%= team_member.email %>
+          &middot;
+          <%= team_member.role.capitalize %>
+        </p>
+      </div>
+
       <% if team_member.awaiting_activation? %>
         <%= render Ui::BadgeComponent.new(color: 'yellow') do %>
           Pending
@@ -19,8 +27,14 @@
           <%= inline_svg_tag 'icons/ellipsis-horizontal.svg', class: 'h-6 w-6', aria: true %>
         <% end %>
 
-        <% if team_member.awaiting_activation? %>
+        <% dropdown.with_item do %>
+          <%= link_to edit_admin_v2_team_member_role_path(team_member), data: { turbo_frame: 'modal' }, class: 'text-gray-700 dark:text-gray-300 whitespace-nowrap group flex items-center px-3 py-2 text-sm' do %>
+            <%= inline_svg_tag 'icons/user-circle.svg', class: 'mr-3 h-5 w-5 text-gray-400 group-hover:text-gray-500 dark:text-gray-300 dark:group-hover:text-gray-400' %>
+            Change role
+          <% end %>
+        <% end %>
 
+        <% if team_member.awaiting_activation? %>
           <% dropdown.with_item do %>
             <%= link_to admin_v2_team_member_resend_invitation_path(team_member), data: { turbo_method: :post, turbo_confirm: 'Are you sure?' }, class: 'text-gray-700 dark:text-gray-300 whitespace-nowrap group flex items-center px-3 py-2 text-sm' do %>
               <%= inline_svg_tag 'icons/envelope.svg', class: 'mr-3 h-5 w-5 text-gray-400 group-hover:text-gray-500 dark:text-gray-300 dark:group-hover:text-gray-400' %>
@@ -44,7 +58,7 @@
             <% end %>
           <% end %>
 
-           <% dropdown.with_item do %>
+          <% dropdown.with_item do %>
             <%= link_to admin_v2_team_member_two_factor_reset_path(team_member), data: { turbo_method: :put, turbo_frame: '_top', turbo_confirm: 'Are you sure?' }, class: 'text-gray-700 dark:text-gray-300 whitespace-nowrap group flex items-center px-3 py-2 text-sm' do %>
               <%= inline_svg_tag 'icons/arrow-path.svg', class: 'mr-3 h-5 w-5 text-gray-400 group-hover:text-gray-500 dark:text-gray-300 dark:group-hover:text-gray-400' %>
               Reset 2FA

--- a/app/views/admin_v2/team_members/role/edit.html.erb
+++ b/app/views/admin_v2/team_members/role/edit.html.erb
@@ -1,0 +1,19 @@
+<%= render ModalComponent.new(title: "Change role for #{@team_member.name}")  do %>
+  <%= turbo_frame_tag 'edit_role_form', class: 'w-full' do %>
+    <%= form_with model: @team_member, url: admin_v2_team_member_role_path(@team_member), builder: TailwindFormBuilder, class: 'w-full', html: { method: :put } do |form| %>
+      <div class='space-y-6'>
+        <div class="space-y-6 pt-4">
+          <div>
+            <%= form.label :role, 'Role', class: 'mb-2' %>
+            <%= form.select :role, options_for_select(AdminUser.roles.map { |key, value| [key.capitalize, value] }, selected: form.object.role), { prompt: 'Select Role' }, required: true, class: 'text-sm', data: { test_id: 'role-field' } %>
+          </div>
+        </div>
+
+        <div class="mt-5 sm:flex sm:flex-row-reverse pt-4">
+          <%= form.submit 'Change role', class: 'cursor-pointer inline-flex w-full justify-center rounded-md button--primary px-5 py-2 text-sm font-semibold text-white shadow-sm sm:ml-3 sm:w-auto', data: { test_id: 'submit-btn' } %>
+          <button type="button" data-action="click->modal#close" class="button--white mt-3 inline-flex w-full justify-center sm:mt-0 sm:w-auto">Cancel</button>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/admin_v2/team_members/role/update.turbo_stream.erb
+++ b/app/views/admin_v2/team_members/role/update.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%= turbo_stream.replace @team_member do %>
+  <%= render 'admin_v2/team_members/member', team_member: @team_member %>
+<% end %>
+
+<%= turbo_stream.update 'flash-messages', partial: 'shared/flash' %>

--- a/config/routes/admin_v2.rb
+++ b/config/routes/admin_v2.rb
@@ -21,6 +21,7 @@ namespace :admin_v2 do # rubocop:disable Metrics/BlockLength
     resource :resend_invitation, only: %i[create], controller: 'team_members/resend_invitation'
     resource :deactivation, only: %i[update], controller: 'team_members/deactivation'
     resource :reactivation, only: %i[update], controller: 'team_members/reactivation'
+    resource :role, only: %i[edit update], controller: 'team_members/role'
     resource :two_factor_reset, only: %i[update], controller: 'team_members/two_factor_reset'
 
     collection do

--- a/db/migrate/20240801070241_add_roles_to_admin_users.rb
+++ b/db/migrate/20240801070241_add_roles_to_admin_users.rb
@@ -1,0 +1,7 @@
+class AddRolesToAdminUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_enum :admin_roles, %w[moderator maintainer core]
+
+    add_column :admin_users, :role, :enum, enum_type: :admin_roles
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_30_082143) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_01_070241) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
+  create_enum "admin_roles", ["moderator", "maintainer", "core"]
   create_enum "admin_user_status", ["pending", "activated", "deactivated", "pending_reactivation"]
 
   create_table "active_admin_comments", id: :serial, force: :cascade do |t|
@@ -78,6 +79,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_30_082143) do
     t.string "otp_secret"
     t.integer "consumed_timestep"
     t.boolean "otp_required_for_login", default: false
+    t.enum "role", enum_type: "admin_roles"
     t.index ["email"], name: "index_admin_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_admin_users_on_invitation_token", unique: true
     t.index ["invited_by_id"], name: "index_admin_users_on_invited_by_id"

--- a/db/seeds/test_admins.rb
+++ b/db/seeds/test_admins.rb
@@ -13,5 +13,6 @@ if Rails.env.development? || ENV['STAGING']
     admin_user.name = 'admin'
     admin_user.password = 'password123'
     admin_user.status = 'activated'
+    admin_user.role = 'core'
   end
 end

--- a/spec/factories/admin_users.rb
+++ b/spec/factories/admin_users.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     sequence(:email) { |n| "admin#{n}@odin.com" }
     password { 'password123' }
     status { :activated }
+    role { :core }
 
     trait :with_otp do
       otp_secret { AdminUser.generate_otp_secret }

--- a/spec/models/admin_user_spec.rb
+++ b/spec/models/admin_user_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe AdminUser do
-  subject { create(:admin_user) }
+  subject(:admin_user) { create(:admin_user) }
 
   it_behaves_like 'authenticatable_with_two_factor', :admin_user
   it_behaves_like 'two_factor_authenticatable'
@@ -10,9 +10,27 @@ RSpec.describe AdminUser do
 
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_uniqueness_of(:name) }
+  it { is_expected.to validate_presence_of(:role) }
   it { is_expected.to validate_presence_of(:email) }
   it { is_expected.to validate_uniqueness_of(:email).case_insensitive }
   it { is_expected.to validate_length_of(:password).is_at_least(8) }
+
+  it do
+    expect(admin_user).to define_enum_for(:status).with_values(
+      {
+        pending: 'pending',
+        activated: 'activated',
+        deactivated: 'deactivated',
+        pending_reactivation: 'pending_reactivation'
+      }
+    ).backed_by_column_of_type(:enum)
+  end
+
+  it do
+    expect(admin_user).to define_enum_for(:role).with_values(
+      { moderator: 'moderator', maintainer: 'maintainer', core: 'core' }
+    ).backed_by_column_of_type(:enum)
+  end
 
   describe '.ordered' do
     it 'orders the admin users by created_at descending' do

--- a/spec/requests/admin_v2/invitations_spec.rb
+++ b/spec/requests/admin_v2/invitations_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Invitations' do
 
         expect do
           post admin_user_invitation_path, params: {
-            admin_user: { email: 'test@example.com', name: 'Test' },
+            admin_user: { email: 'test@example.com', name: 'Test', role: 'maintainer' },
             format: :turbo_stream
           }
         end.to change { AdminUser.count }.by(1)
@@ -76,7 +76,7 @@ RSpec.describe 'Invitations' do
   describe 'PUT #update' do
     context 'when the invitation token is valid' do
       it 'signs the new admin in' do
-        token = AdminUser.invite!(email: 'test@example.com', name: 'test').raw_invitation_token
+        token = AdminUser.invite!(email: 'test@example.com', name: 'test', role: 'maintainer').raw_invitation_token
 
         put admin_user_invitation_path, params: {
           admin_user: { password: 'password', password_confirmation: 'password', invitation_token: token },

--- a/spec/requests/admin_v2/team_members/role_spec.rb
+++ b/spec/requests/admin_v2/team_members/role_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.describe 'Team member role' do
+  describe 'GET #edit' do
+    context 'when signed in as an admin and the team member exists' do
+      it 'renders the edit template' do
+        admin = create(:admin_user)
+        team_member = create(:admin_user)
+
+        sign_in(admin)
+
+        get edit_admin_v2_team_member_role_path(team_member)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when signed in as an admin and the team member does not exist' do
+      it 'renders the edit template' do
+        admin = create(:admin_user)
+
+        sign_in(admin)
+
+        get edit_admin_v2_team_member_role_path(team_member_id: 1002)
+
+        expect(response).to redirect_to(admin_v2_team_path)
+        expect(flash[:alert]).to eq('Team member not found')
+      end
+    end
+
+    context 'when not signed in as an admin' do
+      it 'redirects to the admin sign in page' do
+        user = create(:user)
+        admin = create(:admin_user)
+        sign_in(user)
+
+        get edit_admin_v2_team_member_role_path(admin)
+
+        expect(response).to redirect_to(new_admin_user_session_path)
+      end
+    end
+  end
+
+  describe 'PUT #update' do
+    context 'when signed in as an admin and the team member exists' do
+      it 'changes the the team members role' do
+        admin = create(:admin_user)
+        other_admin = create(:admin_user, role: 'moderator')
+
+        sign_in(admin)
+
+        expect do
+          put admin_v2_team_member_role_path(other_admin), params: {
+            admin_user: { role: 'core' },
+            format: :turbo_stream
+          }
+        end.to change { other_admin.reload.role }.from('moderator').to('core')
+      end
+    end
+
+    context 'when signed in as an admin and the team member does not exist' do
+      it 'does not reactivate the team member' do
+        admin = create(:admin_user)
+        sign_in(admin)
+
+        put admin_v2_team_member_role_path(1002), params: {
+          admin_user: { role: 'core' },
+          format: :turbo_stream
+        }
+
+        expect(response).to redirect_to(admin_v2_team_path)
+        expect(flash[:alert]).to eq('Team member not found')
+      end
+    end
+
+    context 'when not signed in as an admin' do
+      it 'redirects to the admin sign in page' do
+        user = create(:user)
+        admin = create(:admin_user)
+        sign_in(user)
+
+        expect do
+          put admin_v2_team_member_role_path(admin), params: {
+            admin_user: { role: 'core' },
+            format: :turbo_stream
+          }
+        end.not_to change { admin.reload.role }
+
+        expect(response).to redirect_to(new_admin_user_session_path)
+      end
+    end
+  end
+end

--- a/spec/system/admin_v2/invitations_spec.rb
+++ b/spec/system/admin_v2/invitations_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'Admin v2 invitations' do
 
     fill_in('Name', with: 'John Doe')
     fill_in('Email', with: 'john@example.com')
+    select('core', from: 'Role')
     click_button('Send invite')
 
     expect(page).to have_content('Invitation sent to john@example.com')
@@ -50,6 +51,7 @@ RSpec.describe 'Admin v2 invitations' do
 
     fill_in('Name', with: 'John Doe')
     fill_in('Email', with: 'john@example.com')
+    select('core', from: 'Role')
     click_button('Send invite')
 
     expect(page).to have_content('Invitation sent to john@example.com')


### PR DESCRIPTION
Because:
- We will use roles for permissions

This commit:
- Adds role enum to admin user with  moderator, maintainer and core as the possible values
- Allows role to be selected when inviting a new team member
- Adds a new team member option for changing a role.
- Display the team member role and email address on their team member item so an inviter can come back later and check they entered the correct information