### PR TITLE
Chore: Add null constraint to admin user role

### DIFF
--- a/db/migrate/20240802085933_add_null_constraint_to_admin_user_role.rb
+++ b/db/migrate/20240802085933_add_null_constraint_to_admin_user_role.rb
@@ -1,0 +1,5 @@
+class AddNullConstraintToAdminUserRole < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :admin_users, :role, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_01_070241) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_02_085933) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -79,7 +79,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_01_070241) do
     t.string "otp_secret"
     t.integer "consumed_timestep"
     t.boolean "otp_required_for_login", default: false
-    t.enum "role", enum_type: "admin_roles"
+    t.enum "role", null: false, enum_type: "admin_roles"
     t.index ["email"], name: "index_admin_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_admin_users_on_invitation_token", unique: true
     t.index ["invited_by_id"], name: "index_admin_users_on_invited_by_id"

--- a/spec/requests/admin_v2/invitations_spec.rb
+++ b/spec/requests/admin_v2/invitations_spec.rb
@@ -55,7 +55,11 @@ RSpec.describe 'Invitations' do
   describe 'GET #edit' do
     context 'with a valid invitation token' do
       it 'renders the accept invitation page' do
-        token = AdminUser.invite!(email: 'test@example.com', skip_invitation: true).raw_invitation_token
+        token = AdminUser.invite!(
+          email: 'test@example.com',
+          role: 'moderator',
+          skip_invitation: true
+        ).raw_invitation_token
 
         get accept_admin_user_invitation_path(invitation_token: token)
         expect(response).to have_http_status(:ok)
@@ -64,7 +68,11 @@ RSpec.describe 'Invitations' do
 
     context 'with an invalid invitation token' do
       it 'redirects to the sign in page' do
-        AdminUser.invite!(email: 'test@example.com', skip_invitation: true).raw_invitation_token
+        AdminUser.invite!(
+          email: 'test@example.com',
+          role: 'moderator',
+          skip_invitation: true
+        ).raw_invitation_token
 
         get accept_admin_user_invitation_path(invitation_token: '17282')
 
@@ -88,7 +96,11 @@ RSpec.describe 'Invitations' do
 
     context 'when the invitation token is not valid' do
       it 'returns an unprocessable entity response' do
-        AdminUser.invite!(email: 'test@example.com', name: 'test').raw_invitation_token
+        AdminUser.invite!(
+          email: 'test@example.com',
+          name: 'test',
+          role: 'maintainer',
+        ).raw_invitation_token
 
         put admin_user_invitation_path, params: {
           admin_user: { password: 'password', password_confirmation: 'password', invitation_token: '123' },


### PR DESCRIPTION
Because:
- Now that we have roles populated for existing admins, we can make sure this attribute is never null for future admins.