### PR TITLE
Feature: Admin V2 - role permissions

### DIFF
--- a/app/components/Ui/dropdown/component.rb
+++ b/app/components/Ui/dropdown/component.rb
@@ -1,4 +1,8 @@
 class Ui::Dropdown::Component < ApplicationComponent
   renders_one :trigger_button, 'Ui::Dropdown::TriggerComponent'
   renders_many :items
+
+  def render?
+    items.any?
+  end
 end

--- a/app/controllers/admin_v2/invitations_controller.rb
+++ b/app/controllers/admin_v2/invitations_controller.rb
@@ -1,4 +1,5 @@
 class AdminV2::InvitationsController < Devise::InvitationsController
+  before_action :authorize_admin, only: %i[new create] # rubocop:disable Rails/LexicallyScopedActionFilter
   before_action :configure_permitted_parameters
   after_action :create_invited_activity, only: :create
 
@@ -34,5 +35,11 @@ class AdminV2::InvitationsController < Devise::InvitationsController
       owner: current_admin_user,
       params: { name: @invited_admin_user.name }
     )
+  end
+
+  def authorize_admin
+    return if AdminUserPolicy.new(current_admin_user).invite?
+
+    redirect_to admin_v2_team_path, alert: 'You are not authorized to perform this action'
   end
 end

--- a/app/controllers/admin_v2/team_members/deactivation_controller.rb
+++ b/app/controllers/admin_v2/team_members/deactivation_controller.rb
@@ -1,5 +1,7 @@
 module AdminV2
   class TeamMembers::DeactivationController < AdminV2::BaseController
+    before_action :authorize_admin
+
     rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
     def update
@@ -13,6 +15,12 @@ module AdminV2
 
     def record_not_found
       redirect_to admin_v2_team_path, alert: 'Team member not found'
+    end
+
+    def authorize_admin
+      return if AdminUserPolicy.new(current_admin_user).deactivate?
+
+      redirect_to admin_v2_team_path, alert: 'You are not authorized to perform this action'
     end
   end
 end

--- a/app/controllers/admin_v2/team_members/reactivation_controller.rb
+++ b/app/controllers/admin_v2/team_members/reactivation_controller.rb
@@ -1,5 +1,6 @@
 module AdminV2
   class TeamMembers::ReactivationController < AdminV2::BaseController
+    before_action :authorize_admin
     rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
     def update
@@ -16,6 +17,12 @@ module AdminV2
 
     def record_not_found
       redirect_to admin_v2_team_path, alert: 'Team member not found'
+    end
+
+    def authorize_admin
+      return if AdminUserPolicy.new(current_admin_user).reactivate?
+
+      redirect_to admin_v2_team_path, alert: 'You are not authorized to perform this action'
     end
   end
 end

--- a/app/controllers/admin_v2/team_members/role_controller.rb
+++ b/app/controllers/admin_v2/team_members/role_controller.rb
@@ -1,5 +1,7 @@
 module AdminV2
   class TeamMembers::RoleController < AdminV2::BaseController
+    before_action :authorize_admin
+
     rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
     def edit
@@ -27,6 +29,12 @@ module AdminV2
 
     def record_not_found
       redirect_to admin_v2_team_path, alert: 'Team member not found'
+    end
+
+    def authorize_admin
+      return if AdminUserPolicy.new(current_admin_user).change_role?
+
+      redirect_to admin_v2_team_path, alert: 'You are not authorized to perform this action'
     end
   end
 end

--- a/app/controllers/admin_v2/team_members/two_factor_reset_controller.rb
+++ b/app/controllers/admin_v2/team_members/two_factor_reset_controller.rb
@@ -1,5 +1,6 @@
 module AdminV2
   class TeamMembers::TwoFactorResetController < AdminV2::BaseController
+    before_action :authorize_admin
     rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
     def update
@@ -15,6 +16,12 @@ module AdminV2
 
     def record_not_found
       redirect_to admin_v2_team_path, alert: 'Team member not found'
+    end
+
+    def authorize_admin
+      return if AdminUserPolicy.new(current_admin_user).reset_2fa?
+
+      redirect_to admin_v2_team_path, alert: 'You are not authorized to perform this action'
     end
   end
 end

--- a/app/policies/admin_user_policy.rb
+++ b/app/policies/admin_user_policy.rb
@@ -1,0 +1,29 @@
+class AdminUserPolicy
+  def initialize(admin_user)
+    @admin_user = admin_user
+  end
+
+  def change_role?
+    admin_user.core?
+  end
+
+  def invite?
+    admin_user.core? || admin_user.maintainer?
+  end
+
+  def deactivate?
+    admin_user.core?
+  end
+
+  def reactivate?
+    admin_user.core? || admin_user.maintainer?
+  end
+
+  def reset_2fa?
+    admin_user.core?
+  end
+
+  private
+
+  attr_reader :admin_user
+end

--- a/app/views/admin_v2/passwords/edit.html.erb
+++ b/app/views/admin_v2/passwords/edit.html.erb
@@ -4,7 +4,7 @@
   <div class="page-container">
     <h1 class="page-heading-title">Change admin password</h1>
 
-    <div class='max-w-xl mx-auto'>
+    <div class='max-w-lg mx-auto'>
       <%= render CardComponent.new do |card| %>
         <% card.with_body do %>
           <%= form_for resource, as: resource_name, url: password_path(resource_name), builder: TailwindFormBuilder, html: { method: :put, class: 'grid grid-cols-6 gap-6 grid-flow-row' } do |form| %>

--- a/app/views/admin_v2/team_members/_member.html.erb
+++ b/app/views/admin_v2/team_members/_member.html.erb
@@ -27,10 +27,12 @@
           <%= inline_svg_tag 'icons/ellipsis-horizontal.svg', class: 'h-6 w-6', aria: true %>
         <% end %>
 
-        <% dropdown.with_item do %>
-          <%= link_to edit_admin_v2_team_member_role_path(team_member), data: { turbo_frame: 'modal' }, class: 'text-gray-700 dark:text-gray-300 whitespace-nowrap group flex items-center px-3 py-2 text-sm' do %>
-            <%= inline_svg_tag 'icons/user-circle.svg', class: 'mr-3 h-5 w-5 text-gray-400 group-hover:text-gray-500 dark:text-gray-300 dark:group-hover:text-gray-400' %>
-            Change role
+        <% if AdminUserPolicy.new(current_admin_user).change_role? %>
+          <% dropdown.with_item do %>
+            <%= link_to edit_admin_v2_team_member_role_path(team_member), data: { turbo_frame: 'modal' }, class: 'text-gray-700 dark:text-gray-300 whitespace-nowrap group flex items-center px-3 py-2 text-sm' do %>
+              <%= inline_svg_tag 'icons/user-circle.svg', class: 'mr-3 h-5 w-5 text-gray-400 group-hover:text-gray-500 dark:text-gray-300 dark:group-hover:text-gray-400' %>
+              Change role
+            <% end %>
           <% end %>
         <% end %>
 
@@ -58,22 +60,27 @@
             <% end %>
           <% end %>
 
-          <% dropdown.with_item do %>
-            <%= link_to admin_v2_team_member_two_factor_reset_path(team_member), data: { turbo_method: :put, turbo_frame: '_top', turbo_confirm: 'Are you sure?' }, class: 'text-gray-700 dark:text-gray-300 whitespace-nowrap group flex items-center px-3 py-2 text-sm' do %>
-              <%= inline_svg_tag 'icons/arrow-path.svg', class: 'mr-3 h-5 w-5 text-gray-400 group-hover:text-gray-500 dark:text-gray-300 dark:group-hover:text-gray-400' %>
-              Reset 2FA
+          <% if AdminUserPolicy.new(current_admin_user).reset_2fa? %>
+            <% dropdown.with_item do %>
+              <%= link_to admin_v2_team_member_two_factor_reset_path(team_member), data: { turbo_method: :put, turbo_frame: '_top', turbo_confirm: 'Are you sure?' }, class: 'text-gray-700 dark:text-gray-300 whitespace-nowrap group flex items-center px-3 py-2 text-sm' do %>
+                <%= inline_svg_tag 'icons/arrow-path.svg', class: 'mr-3 h-5 w-5 text-gray-400 group-hover:text-gray-500 dark:text-gray-300 dark:group-hover:text-gray-400' %>
+                Reset 2FA
+              <% end %>
             <% end %>
           <% end %>
 
-          <% dropdown.with_item do %>
-            <%= link_to admin_v2_team_member_deactivation_path(team_member), data: { turbo_method: :put, turbo_confirm: 'Are you sure?' }, class: 'text-red-700 dark:text-red-300 whitespace-nowrap group flex items-center px-3 py-2 text-sm' do %>
-              <%= inline_svg_tag 'icons/user-minus.svg', class: 'mr-3 h-5 w-5 text-red-700 group-hover:text-red-600 dark:text-red-300 dark:group-hover:text-red-400' %>
-              Deactivate
+          <% if AdminUserPolicy.new(current_admin_user).deactivate? %>
+            <% dropdown.with_item do %>
+              <%= link_to admin_v2_team_member_deactivation_path(team_member), data: { turbo_method: :put, turbo_confirm: 'Are you sure?' }, class: 'text-red-700 dark:text-red-300 whitespace-nowrap group flex items-center px-3 py-2 text-sm' do %>
+                <%= inline_svg_tag 'icons/user-minus.svg', class: 'mr-3 h-5 w-5 text-red-700 group-hover:text-red-600 dark:text-red-300 dark:group-hover:text-red-400' %>
+                Deactivate
+              <% end %>
             <% end %>
           <% end %>
+
         <% end %>
 
-        <% if team_member.deactivated? %>
+        <% if team_member.deactivated? && AdminUserPolicy.new(current_admin_user).reactivate? %>
           <% dropdown.with_item do %>
             <%= link_to admin_v2_team_member_reactivation_path(team_member_id: team_member), data: { turbo_method: :put, turbo_confirm: 'Are you sure?' }, class: 'text-gray-700 dark:text-gray-300 whitespace-nowrap group flex items-center px-3 py-2 text-sm' do %>
               <%= inline_svg_tag 'icons/user-plus.svg', class: 'mr-3 h-5 w-5 text-gray-400 group-hover:text-gray-500 dark:text-gray-300 dark:group-hover:text-gray-400' %>

--- a/app/views/admin_v2/team_members/index.html.erb
+++ b/app/views/admin_v2/team_members/index.html.erb
@@ -8,7 +8,9 @@
       </div>
 
       <div class="flex items-center">
-        <%= link_to 'Invite new member', new_admin_user_invitation_path, class: 'button button--primary p-2', data: { turbo_frame: 'modal' } %>
+        <% if AdminUserPolicy.new(current_admin_user).invite? %>
+          <%= link_to 'Invite new member', new_admin_user_invitation_path, class: 'button button--primary p-2', data: { turbo_frame: 'modal' } %>
+        <% end %>
 
         <%= render Ui::Dropdown::Component.new do |dropdown| %>
           <% dropdown.with_trigger_button do %>

--- a/spec/policies/admin_user_policy_spec.rb
+++ b/spec/policies/admin_user_policy_spec.rb
@@ -1,0 +1,113 @@
+require 'rails_helper'
+
+RSpec.describe AdminUserPolicy do
+  describe '#change_role?' do
+    subject(:policy) { described_class.new(admin_user).change_role? }
+
+    context 'when the admin user has the core role' do
+      let(:admin_user) { create(:admin_user, role: 'core') }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when the admin user has the maintainer role' do
+      let(:admin_user) { create(:admin_user, role: 'maintainer') }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'when the admin user has the moderator role' do
+      let(:admin_user) { create(:admin_user, role: 'moderator') }
+
+      it { is_expected.to be(false) }
+    end
+  end
+
+  describe '#invite?' do
+    subject(:policy) { described_class.new(admin_user).invite? }
+
+    context 'when the admin user has the core role' do
+      let(:admin_user) { create(:admin_user, role: 'core') }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when the admin user has the maintainer role' do
+      let(:admin_user) { create(:admin_user, role: 'maintainer') }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when the admin user has the moderator role' do
+      let(:admin_user) { create(:admin_user, role: 'moderator') }
+
+      it { is_expected.to be(false) }
+    end
+  end
+
+  describe '#deactivate?' do
+    subject(:policy) { described_class.new(admin_user).deactivate? }
+
+    context 'when the admin user has the core role' do
+      let(:admin_user) { create(:admin_user, role: 'core') }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when the admin user has the maintainer role' do
+      let(:admin_user) { create(:admin_user, role: 'maintainer') }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'when the admin user has the moderator role' do
+      let(:admin_user) { create(:admin_user, role: 'moderator') }
+
+      it { is_expected.to be(false) }
+    end
+  end
+
+  describe '#reactivate?' do
+    subject(:policy) { described_class.new(admin_user).reactivate? }
+
+    context 'when the admin user has the core role' do
+      let(:admin_user) { create(:admin_user, role: 'core') }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when the admin user has the maintainer role' do
+      let(:admin_user) { create(:admin_user, role: 'maintainer') }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when the admin user has the moderator role' do
+      let(:admin_user) { create(:admin_user, role: 'moderator') }
+
+      it { is_expected.to be(false) }
+    end
+  end
+
+  describe '#reset_2fa?' do
+    subject(:policy) { described_class.new(admin_user).reset_2fa? }
+
+    context 'when the admin user has the core role' do
+      let(:admin_user) { create(:admin_user, role: 'core') }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'when the admin user has the maintainer role' do
+      let(:admin_user) { create(:admin_user, role: 'maintainer') }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'when the admin user has the moderator role' do
+      let(:admin_user) { create(:admin_user, role: 'moderator') }
+
+      it { is_expected.to be(false) }
+    end
+  end
+end

--- a/spec/requests/admin_v2/invitations_spec.rb
+++ b/spec/requests/admin_v2/invitations_spec.rb
@@ -20,6 +20,19 @@ RSpec.describe 'Invitations' do
         expect(response).to redirect_to(new_admin_user_session_path)
       end
     end
+
+    context 'when the admin is not authorized to invite other team members' do
+      it 'redirects to the team page' do
+        admin = create(:admin_user, role: 'moderator')
+
+        sign_in(admin)
+
+        get new_admin_user_invitation_path
+
+        expect(response).to redirect_to(admin_v2_team_path)
+        expect(flash[:alert]).to eq('You are not authorized to perform this action')
+      end
+    end
   end
 
   describe 'POST #create' do
@@ -48,6 +61,21 @@ RSpec.describe 'Invitations' do
         end.not_to change { AdminUser.count }
 
         expect(response).to redirect_to(new_admin_user_session_path)
+      end
+    end
+
+    context 'when the admin is not authorized to invite other team members' do
+      it 'redirects to the team page' do
+        admin = create(:admin_user, role: 'moderator')
+
+        sign_in(admin)
+
+        post admin_user_invitation_path, params: {
+          admin_user: { email: 'test@example.com', name: 'Test' },
+        }
+
+        expect(response).to redirect_to(admin_v2_team_path)
+        expect(flash[:alert]).to eq('You are not authorized to perform this action')
       end
     end
   end

--- a/spec/requests/admin_v2/team_members/deactivation_spec.rb
+++ b/spec/requests/admin_v2/team_members/deactivation_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Team member deactivation' do
         sign_in(admin)
 
         expect do
-          put admin_v2_team_member_deactivation_path(team_member_id: active_admin.id)
+          put admin_v2_team_member_deactivation_path(active_admin)
         end.to change { active_admin.reload.status }.from('activated').to('deactivated')
 
         expect(response).to redirect_to(admin_v2_team_path)
@@ -29,6 +29,21 @@ RSpec.describe 'Team member deactivation' do
       end
     end
 
+    context 'when the admin is not authorized to deactivate other team members' do
+      it 'redirects to the team page' do
+        admin = create(:admin_user, role: 'maintainer')
+        active_admin = create(:admin_user, :activated)
+        sign_in(admin)
+
+        expect do
+          put admin_v2_team_member_deactivation_path(active_admin)
+        end.not_to change { active_admin.reload.status }
+
+        expect(response).to redirect_to(admin_v2_team_path)
+        expect(flash[:alert]).to eq('You are not authorized to perform this action')
+      end
+    end
+
     context 'when not signed in as an admin' do
       it 'redirects to the admin sign in page' do
         user = create(:user)
@@ -36,7 +51,7 @@ RSpec.describe 'Team member deactivation' do
         sign_in(user)
 
         expect do
-          put admin_v2_team_member_deactivation_path(team_member_id: admin.id)
+          put admin_v2_team_member_deactivation_path(admin)
         end.not_to change { admin.reload.status }
 
         expect(response).to redirect_to(new_admin_user_session_path)

--- a/spec/requests/admin_v2/team_members/reactivation_spec.rb
+++ b/spec/requests/admin_v2/team_members/reactivation_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Team member reactivation' do
         sign_in(admin)
 
         expect do
-          put admin_v2_team_member_reactivation_path(team_member_id: deactivated_admin.id)
+          put admin_v2_team_member_reactivation_path(deactivated_admin)
         end.to change { deactivated_admin.reload.status }.from('deactivated').to('pending_reactivation')
 
         expect(response).to redirect_to(admin_v2_team_path)
@@ -22,7 +22,7 @@ RSpec.describe 'Team member reactivation' do
         sign_in(admin)
 
         expect do
-          put admin_v2_team_member_reactivation_path(team_member_id: deactivated_admin.id)
+          put admin_v2_team_member_reactivation_path(deactivated_admin)
         end.to change { deactivated_admin.reload.otp_secret }
       end
 
@@ -54,6 +54,21 @@ RSpec.describe 'Team member reactivation' do
       end
     end
 
+    context 'when the admin is not authorized to reactivate other team members' do
+      it 'redirects to the team page' do
+        admin = create(:admin_user, role: 'moderator')
+        deactivated_admin = create(:admin_user, :deactivated)
+        sign_in(admin)
+
+        expect do
+          put admin_v2_team_member_reactivation_path(deactivated_admin)
+        end.not_to change { deactivated_admin.reload.status }
+
+        expect(response).to redirect_to(admin_v2_team_path)
+        expect(flash[:alert]).to eq('You are not authorized to perform this action')
+      end
+    end
+
     context 'when not signed in as an admin' do
       it 'redirects to the admin sign in page' do
         user = create(:user)
@@ -61,7 +76,7 @@ RSpec.describe 'Team member reactivation' do
         sign_in(user)
 
         expect do
-          put admin_v2_team_member_reactivation_path(team_member_id: admin.id)
+          put admin_v2_team_member_reactivation_path(admin)
         end.not_to change { admin.reload.status }
 
         expect(response).to redirect_to(new_admin_user_session_path)

--- a/spec/requests/admin_v2/team_members/resend_invitation_spec.rb
+++ b/spec/requests/admin_v2/team_members/resend_invitation_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Resend team member invite' do
         sign_in(admin)
 
         expect do
-          post admin_v2_team_member_resend_invitation_path(team_member_id: pending_admin.id)
+          post admin_v2_team_member_resend_invitation_path(pending_admin)
         end.to change { ActionMailer::Base.deliveries.count }
 
         mailer = ActionMailer::Base.deliveries.last
@@ -27,7 +27,7 @@ RSpec.describe 'Resend team member invite' do
         sign_in(admin)
 
         expect do
-          post admin_v2_team_member_resend_invitation_path(team_member_id: active_admin.id)
+          post admin_v2_team_member_resend_invitation_path(active_admin)
         end.not_to change { ActionMailer::Base.deliveries.count }
       end
     end
@@ -54,7 +54,7 @@ RSpec.describe 'Resend team member invite' do
         sign_in(user)
 
         expect do
-          post admin_v2_team_member_resend_invitation_path(team_member_id: admin.id)
+          post admin_v2_team_member_resend_invitation_path(admin)
         end.not_to change { ActionMailer::Base.deliveries.count }
 
         expect(response).to redirect_to(new_admin_user_session_path)

--- a/spec/requests/admin_v2/team_members/role_spec.rb
+++ b/spec/requests/admin_v2/team_members/role_spec.rb
@@ -15,6 +15,19 @@ RSpec.describe 'Team member role' do
       end
     end
 
+    context 'when the admin is not authorized to change roles' do
+      it 'redirects to the team page' do
+        admin = create(:admin_user, role: 'maintainer')
+        team_member = create(:admin_user)
+        sign_in(admin)
+
+        get edit_admin_v2_team_member_role_path(team_member)
+
+        expect(response).to redirect_to(admin_v2_team_path)
+        expect(flash[:alert]).to eq('You are not authorized to perform this action')
+      end
+    end
+
     context 'when signed in as an admin and the team member does not exist' do
       it 'renders the edit template' do
         admin = create(:admin_user)
@@ -70,6 +83,22 @@ RSpec.describe 'Team member role' do
 
         expect(response).to redirect_to(admin_v2_team_path)
         expect(flash[:alert]).to eq('Team member not found')
+      end
+    end
+
+    context 'when the admin is not authorized to change roles' do
+      it 'redirects to the team page' do
+        admin = create(:admin_user, role: 'maintainer')
+        other_admin = create(:admin_user)
+        sign_in(admin)
+
+        put admin_v2_team_member_role_path(other_admin), params: {
+          admin_user: { role: 'core' },
+          format: :turbo_stream
+        }
+
+        expect(response).to redirect_to(admin_v2_team_path)
+        expect(flash[:alert]).to eq('You are not authorized to perform this action')
       end
     end
 


### PR DESCRIPTION
Because:
- We'll be following principle of least privilege for security - users should only be able to perform actions they need to.

This commit:
- Adds a admin user policy to encapsulate admin user permissions.
- Wraps actions in the team page with conditionals to enable and disable sensitive actions
- Adds before actions to applicable controllers to check if admins are authorised to perform that action