### PR TITLE
fix: center h1 title on large screen(#4654)

### DIFF
--- a/app/views/lessons/_header.html.erb
+++ b/app/views/lessons/_header.html.erb
@@ -3,7 +3,7 @@
     <%= render Course::BadgeComponent.new(course: lesson.course, options: {show_badge: true }) %>
 
     <div class="text-center xl:text-left">
-      <div class="flex flex-col sm:flex-row items-center gap-0 sm:gap-3">
+      <div class="flex flex-col xl:flex-row items-center gap-0 sm:gap-3">
         <h1 class="text-2xl font-semibold text-gray-800 dark:text-gray-200" data-test-id="lesson-title-header">
           <%= lesson.display_title %>
         </h1>


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
The h1 heading in the Intermediate CSS Concepts section's Custom Properties lesson was not centered correctly.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- updates the class of the h1 container from `sm:flex-row` to `xl:flex-row`.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #4654

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
This issue was discussed in the [Odin Project Discord server](https://discord.com/channels/505093832157691914/700355756188368926) in the #contribution-opportunies channel.

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If applicable, this PR includes new or updated automated tests
