### PR TITLE
Chore: Migrate old flag resolvers to admin users

### DIFF
--- a/lib/tasks/data_migrations/populate_flag_resolvers.rake
+++ b/lib/tasks/data_migrations/populate_flag_resolvers.rake
@@ -1,0 +1,32 @@
+# rubocop:disable all
+namespace :data_migrations do
+  desc 'populate flag resolvers'
+  task populate_flag_resolvers: :environment do
+    puts "Populating resolvers for #{Flag.count} flags"
+
+    resolvers = {
+      19863 => 'Timato',
+      260969 => 'Mfrnk',
+      212391 => 'Sully',
+      207444 => 'Rachel',
+      1018843 => 'Kevin',
+      421591 => 'Kevin',
+      932663 => 'Mao',
+    }
+
+    Flag.find_each do |flag|
+      next if flag.resolved_by_id.blank?
+
+      resolver = resolvers[flag.resolved_by_id]
+      next if resolver.blank?
+
+      admin_user = AdminUser.find_by(name: resolver)
+
+      puts "Set admin user on flag #{flag.id} to #{resolver}"
+      flag.update!(admin_user: admin_user)
+    end
+
+    puts 'Done!'
+  end
+end
+# rubocop:enable all

--- a/lib/tasks/data_migrations/update_legacy_flag_reasons.rake
+++ b/lib/tasks/data_migrations/update_legacy_flag_reasons.rake
@@ -1,0 +1,13 @@
+namespace :data_migrations do
+  desc 'Update legacy flag reasons'
+  task update_legacy_flag_reasons: :environment do
+    legacy_flags = Flag.where(reason: 4)
+    puts "Updating reasons for #{legacy_flags.count} legacy flags"
+
+    legacy_flags.each do |flag|
+      flag.update!(reason: 40)
+    end
+
+    puts 'Done!'
+  end
+end


### PR DESCRIPTION
Because:
- We want to keep an accurate record of who resolved flags

This commit:
- Adds a data migration to set legacy flags with a reason "4" to "40". These flags fail validation and can't be updated without this.
- Adds a data migration mapping old user resolvers to admin users and sets the admin user foreign key for the appropriate flags
