### PR TITLE
Chore: Rename flag admin user association to resolved by

### DIFF
--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -10,7 +10,7 @@ class AdminUser < ApplicationRecord
   devise :invitable, :recoverable, :trackable, :timeoutable, :validatable,
          password_length: 8..128
 
-  has_many :flags, dependent: :nullify
+  has_many :flags, foreign_key: :resolved_by_id, dependent: :nullify, inverse_of: :resolved_by
 
   validates :name, presence: true, uniqueness: true
   validates :role, presence: true, inclusion: { in: roles.values }

--- a/app/views/admin/flags/index.html.erb
+++ b/app/views/admin/flags/index.html.erb
@@ -74,7 +74,7 @@
                   <% end %>
 
                   <% if flag.resolved? %>
-                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-gray-300"><%= flag.admin_user.name %></td>
+                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-gray-300"><%= flag.resolved_by.name %></td>
                   <% end %>
 
                   <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-0">

--- a/app/views/admin/flags/show.html.erb
+++ b/app/views/admin/flags/show.html.erb
@@ -65,7 +65,7 @@
         <% if @flag.resolved? %>
           <div class="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-0">
             <dt class="text-sm font-medium leading-6 text-gray-800 dark:text-gray-300">Who resolved the flag?</dt>
-            <dd class="mt-1 text-sm leading-6 text-gray-700 dark:text-gray-300 sm:col-span-2 sm:mt-0"><%= @flag.admin_user.name %></dd>
+            <dd class="mt-1 text-sm leading-6 text-gray-700 dark:text-gray-300 sm:col-span-2 sm:mt-0"><%= @flag.resolved_by.name %></dd>
           </div>
         <% end %>
       </dl>

--- a/db/migrate/20240805080849_rename_flag_admin_user_to_resolved_by.rb
+++ b/db/migrate/20240805080849_rename_flag_admin_user_to_resolved_by.rb
@@ -1,0 +1,6 @@
+class RenameFlagAdminUserToResolvedBy < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :flags, :resolved_by_id, :integer
+    rename_column :flags, :admin_user_id, :resolved_by_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_02_085933) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_05_080849) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -135,12 +135,11 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_02_085933) do
     t.integer "taken_action", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "resolved_by_id"
     t.integer "reason", default: 4, null: false
-    t.bigint "admin_user_id"
-    t.index ["admin_user_id"], name: "index_flags_on_admin_user_id"
+    t.bigint "resolved_by_id"
     t.index ["flagger_id"], name: "index_flags_on_flagger_id"
     t.index ["project_submission_id"], name: "index_flags_on_project_submission_id"
+    t.index ["resolved_by_id"], name: "index_flags_on_resolved_by_id"
   end
 
   create_table "flipper_features", force: :cascade do |t|
@@ -353,7 +352,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_02_085933) do
   add_foreign_key "announcements", "admin_users"
   add_foreign_key "announcements", "users"
   add_foreign_key "contents", "lessons"
-  add_foreign_key "flags", "admin_users"
+  add_foreign_key "flags", "admin_users", column: "resolved_by_id"
   add_foreign_key "flags", "project_submissions"
   add_foreign_key "flags", "users", column: "flagger_id"
   add_foreign_key "lesson_completions", "lessons", on_delete: :cascade

--- a/spec/factories/flags.rb
+++ b/spec/factories/flags.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
 
     trait :resolved do
       status { :resolved }
+      resolved_by { association :admin_user }
     end
   end
 end

--- a/spec/models/admin_user_spec.rb
+++ b/spec/models/admin_user_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe AdminUser do
   it_behaves_like 'authenticatable_with_two_factor', :admin_user
   it_behaves_like 'two_factor_authenticatable'
 
-  it { is_expected.to have_many(:flags).dependent(:nullify) }
+  it { is_expected.to have_many(:flags).dependent(:nullify).with_foreign_key(:resolved_by_id) }
 
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_uniqueness_of(:name) }


### PR DESCRIPTION
Because:
- This is the domain name we used for this association before and it communicates the admin users relationship to the flag better.

This commit:
- Removes legacy resolved_by_id column from flags
- Renames admin user column on flags to resolved_by_id
- Validates that resolved flags should always have a resolved_by set