### PR TITLE
Feature: Rename announcement admin user association to created_by

### DIFF
--- a/app/controllers/admin/announcements_controller.rb
+++ b/app/controllers/admin/announcements_controller.rb
@@ -19,7 +19,7 @@ module Admin
     end
 
     def create
-      @announcement = Announcement.new(announcement_params.merge(admin_user: current_admin_user))
+      @announcement = Announcement.new(announcement_params.merge(created_by: current_admin_user))
 
       if @announcement.save
         create_activity(@announcement, 'created')

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -10,7 +10,8 @@ class AdminUser < ApplicationRecord
   devise :invitable, :recoverable, :trackable, :timeoutable, :validatable,
          password_length: 8..128
 
-  has_many :flags, foreign_key: :resolved_by_id, dependent: :nullify, inverse_of: :resolved_by
+  has_many :flags, foreign_key: :resolved_by_id, inverse_of: :resolved_by, dependent: :nullify
+  has_many :announcements, foreign_key: :created_by_id, inverse_of: :created_by, dependent: :nullify
 
   validates :name, presence: true, uniqueness: true
   validates :role, presence: true, inclusion: { in: roles.values }

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,8 +1,7 @@
 class Announcement < ApplicationRecord
   include PublicActivity::Common
 
-  belongs_to :user, optional: true
-  belongs_to :admin_user, optional: true
+  belongs_to :created_by, class_name: 'AdminUser', inverse_of: :announcements
 
   validates :message, presence: true
   validates :message, length: { maximum: 100 }
@@ -30,10 +29,6 @@ class Announcement < ApplicationRecord
 
   def active?
     status == :active
-  end
-
-  def created_by
-    admin_user || Null::AdminUser.new
   end
 
   private

--- a/app/models/null/admin_user.rb
+++ b/app/models/null/admin_user.rb
@@ -1,5 +1,0 @@
-class Null::AdminUser
-  def name
-    'Deleted Admin User'
-  end
-end

--- a/db/migrate/20240806054115_rename_announcement_admin_user.rb
+++ b/db/migrate/20240806054115_rename_announcement_admin_user.rb
@@ -1,0 +1,7 @@
+class RenameAnnouncementAdminUser < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :announcements, :user_id, :bigint
+    rename_column :announcements, :admin_user_id, :created_by_id
+    change_column_null :announcements, :created_by_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_05_080849) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_06_054115) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -93,12 +93,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_05_080849) do
     t.datetime "updated_at", precision: nil, null: false
     t.string "message", limit: 255
     t.datetime "expires_at", precision: nil, null: false
-    t.bigint "user_id"
     t.string "learn_more_url"
-    t.bigint "admin_user_id"
-    t.index ["admin_user_id"], name: "index_announcements_on_admin_user_id"
+    t.bigint "created_by_id", null: false
+    t.index ["created_by_id"], name: "index_announcements_on_created_by_id"
     t.index ["expires_at"], name: "index_announcements_on_expires_at"
-    t.index ["user_id"], name: "index_announcements_on_user_id"
   end
 
   create_table "contents", force: :cascade do |t|
@@ -349,8 +347,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_05_080849) do
     t.index ["username"], name: "index_users_on_username"
   end
 
-  add_foreign_key "announcements", "admin_users"
-  add_foreign_key "announcements", "users"
+  add_foreign_key "announcements", "admin_users", column: "created_by_id"
   add_foreign_key "contents", "lessons"
   add_foreign_key "flags", "admin_users", column: "resolved_by_id"
   add_foreign_key "flags", "project_submissions"

--- a/spec/factories/announcements.rb
+++ b/spec/factories/announcements.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :announcement do
     message { 'a message for all users' }
     expires_at { 1.day.from_now }
-    user
+    created_by { association :admin_user }
     learn_more_url { 'https://example.com' }
 
     trait :without_validations do

--- a/spec/models/admin_user_spec.rb
+++ b/spec/models/admin_user_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe AdminUser do
   it_behaves_like 'two_factor_authenticatable'
 
   it { is_expected.to have_many(:flags).dependent(:nullify).with_foreign_key(:resolved_by_id) }
+  it { is_expected.to have_many(:announcements).dependent(:nullify).with_foreign_key(:created_by_id) }
 
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_uniqueness_of(:name) }

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Announcement do
-  it { is_expected.to belong_to(:admin_user).optional }
+  it { is_expected.to belong_to(:created_by) }
+
   it { is_expected.to validate_presence_of(:message) }
   it { is_expected.to validate_length_of(:message).is_at_most(100) }
   it { is_expected.to validate_presence_of(:expires_at) }
@@ -108,25 +109,6 @@ RSpec.describe Announcement do
     context 'when the announcement is expired' do
       it 'returns false' do
         expect(build(:announcement, expires_at: 1.day.ago)).not_to be_active
-      end
-    end
-  end
-
-  describe '#created_by' do
-    context 'when the announcement was created by an admin user' do
-      it 'returns the admin user' do
-        admin_user = build_stubbed(:admin_user)
-        announcement = build_stubbed(:announcement, admin_user:)
-
-        expect(announcement.created_by).to eq(admin_user)
-      end
-    end
-
-    context 'when the announcement has no admin user' do
-      it 'returns a null admin user' do
-        announcement = build_stubbed(:announcement)
-
-        expect(announcement.created_by).to be_a(Null::AdminUser)
       end
     end
   end


### PR DESCRIPTION
Because:
- Created by better represents the admins relationship with the announcement.

This commit:
- Removes announcement user_id column
- Adds a null constraint to the created by foreign key
- Removes null admin user - we don't need it anymore.
