### PR TITLE
Chore: Rename flag taken_action column to action_taken

### DIFF
--- a/app/models/flag.rb
+++ b/app/models/flag.rb
@@ -19,7 +19,7 @@ class Flag < ApplicationRecord
 
   enum reason: REASONS.each_with_object({}) { |reason, hash| hash[reason.name] = reason.value }
   enum status: { active: 0, resolved: 1 }
-  enum taken_action: { pending: 0, dismiss: 1, ban: 2, removed_project_submission: 3, notified_user: 4 }
+  enum action_taken: { pending: 0, dismiss: 1, ban: 2, removed_project_submission: 3, notified_user: 4 }
 
   scope :by_status, ->(status) { where(status:) }
   scope :count_for, ->(status) { by_status(status).count }
@@ -32,12 +32,12 @@ class Flag < ApplicationRecord
   def resolve(action_taken:, resolved_by:)
     update(
       status: :resolved,
-      taken_action: action_taken,
+      action_taken:,
       resolved_by:
     )
   end
 
-  def action_taken
-    Flags::Action.for(taken_action)
+  def action_taken_value
+    Flags::Action.for(action_taken)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,7 +52,7 @@ class User < ApplicationRecord
   end
 
   def dismissed_flags
-    flags.where(taken_action: :dismiss)
+    flags.where(action_taken: :dismiss)
   end
 
   def started_course?(course)

--- a/app/views/admin/flags/index.html.erb
+++ b/app/views/admin/flags/index.html.erb
@@ -70,7 +70,7 @@
                   </td>
 
                   <% if params[:status] == "resolved" %>
-                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-gray-300"><%= flag.action_taken.past_tense %></td>
+                    <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-gray-300"><%= flag.action_taken_value.past_tense %></td>
                   <% end %>
 
                   <% if flag.resolved? %>

--- a/app/views/admin/flags/show.html.erb
+++ b/app/views/admin/flags/show.html.erb
@@ -11,7 +11,7 @@
 
         <% if @flag.resolved? %>
           <%= render Ui::BadgeComponent.new(color: 'gray') do %>
-            <%= @flag.action_taken.past_tense %>
+            <%= @flag.action_taken_value.past_tense %>
           <% end %>
         <% end %>
       </div>

--- a/db/migrate/20240806061546_rename_flag_taken_action_to_action_taken.rb
+++ b/db/migrate/20240806061546_rename_flag_taken_action_to_action_taken.rb
@@ -1,0 +1,5 @@
+class RenameFlagTakenActionToActionTaken < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :flags, :taken_action, :action_taken
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_06_054115) do
+ActiveRecord::Schema[7.0].define(version: 2024_08_06_061546) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -130,7 +130,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_08_06_054115) do
     t.bigint "project_submission_id", null: false
     t.text "extra", default: ""
     t.integer "status", default: 0, null: false
-    t.integer "taken_action", default: 0, null: false
+    t.integer "action_taken", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "reason", default: 4, null: false

--- a/spec/models/flag_spec.rb
+++ b/spec/models/flag_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Flag do
   end
 
   it do
-    expect(flag).to define_enum_for(:taken_action)
+    expect(flag).to define_enum_for(:action_taken)
       .with_values(%i[pending dismiss ban removed_project_submission notified_user])
   end
 
@@ -94,12 +94,12 @@ RSpec.describe Flag do
   end
 
   describe '#resolve' do
-    it 'updates the status and taken_action of the flag' do
+    it 'updates the status and action taken of the flag' do
       admin_user = create(:admin_user)
 
       expect { flag.resolve(action_taken: :dismiss, resolved_by: admin_user) }
         .to change { flag.status }.from('active').to('resolved')
-        .and change { flag.taken_action }.from('pending').to('dismiss')
+        .and change { flag.action_taken }.from('pending').to('dismiss')
     end
 
     it 'sets who resolved the flag' do
@@ -111,11 +111,11 @@ RSpec.describe Flag do
     end
   end
 
-  describe '#action_taken' do
-    it 'returns a value object for the taken_action' do
-      flag.taken_action = 'dismiss'
+  describe '#action_taken_value' do
+    it 'returns a value object for the action_taken' do
+      flag.action_taken = 'dismiss'
 
-      expect(flag.action_taken).to be_a(Flags::Action)
+      expect(flag.action_taken_value).to be_a(Flags::Action)
     end
   end
 end

--- a/spec/models/flags/actions/ban_spec.rb
+++ b/spec/models/flags/actions/ban_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Flags::Actions::Ban do
 
       it "changes the flag action taken to 'ban'" do
         expect { described_class.perform(admin_user:, flag:) }
-          .to change { flag.reload.taken_action }.from('pending').to('ban')
+          .to change { flag.reload.action_taken }.from('pending').to('ban')
       end
 
       it 'resolves the flag' do

--- a/spec/models/flags/actions/dismiss_spec.rb
+++ b/spec/models/flags/actions/dismiss_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Flags::Actions::Dismiss do
     context 'when successful' do
       it 'changes the flag action taken to dismissed' do
         expect { described_class.perform(admin_user:, flag:) }
-          .to change { flag.reload.taken_action }.from('pending').to('dismiss')
+          .to change { flag.reload.action_taken }.from('pending').to('dismiss')
       end
 
       it 'resolves the flag' do

--- a/spec/models/flags/actions/notify_user_spec.rb
+++ b/spec/models/flags/actions/notify_user_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Flags::Actions::NotifyUser do
 
       it "changes the flag action taken to 'notified_user'" do
         expect { described_class.perform(admin_user:, flag:) }
-          .to change { flag.reload.taken_action }.from('pending').to('notified_user')
+          .to change { flag.reload.action_taken }.from('pending').to('notified_user')
       end
 
       it 'resolves the flag' do

--- a/spec/models/flags/actions/remove_project_submission_spec.rb
+++ b/spec/models/flags/actions/remove_project_submission_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Flags::Actions::RemoveProjectSubmission do
 
       it "changes the flag action taken to 'removed_project_submission'" do
         expect { described_class.perform(admin_user:, flag:) }
-          .to change { flag.reload.taken_action }.from('pending').to('removed_project_submission')
+          .to change { flag.reload.action_taken }.from('pending').to('removed_project_submission')
       end
 
       it 'resolves the flag' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -174,8 +174,8 @@ RSpec.describe User do
 
   describe '#dismissed_flags' do
     it 'returns flags the user has made that have been dismissed' do
-      non_dismissed_flag = create(:flag, flagger: user, taken_action: :ban)
-      dismissed_flag = create(:flag, flagger: user, taken_action: :dismiss)
+      non_dismissed_flag = create(:flag, flagger: user, action_taken: :ban)
+      dismissed_flag = create(:flag, flagger: user, action_taken: :dismiss)
 
       expect(user.dismissed_flags).to contain_exactly(dismissed_flag)
     end


### PR DESCRIPTION
Because:
- We are using action_taken in the UI. Using the same name makes it easier and safer to pass actions through the stack.
