### PR TITLE
Feature: Admin users with associations should never be deleted

### DIFF
--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -10,8 +10,8 @@ class AdminUser < ApplicationRecord
   devise :invitable, :recoverable, :trackable, :timeoutable, :validatable,
          password_length: 8..128
 
-  has_many :flags, foreign_key: :resolved_by_id, inverse_of: :resolved_by, dependent: :nullify
-  has_many :announcements, foreign_key: :created_by_id, inverse_of: :created_by, dependent: :nullify
+  has_many :flags, foreign_key: :resolved_by_id, inverse_of: :resolved_by, dependent: :restrict_with_exception
+  has_many :announcements, foreign_key: :created_by_id, inverse_of: :created_by, dependent: :restrict_with_exception
 
   validates :name, presence: true, uniqueness: true
   validates :role, presence: true, inclusion: { in: roles.values }

--- a/spec/models/admin_user_spec.rb
+++ b/spec/models/admin_user_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe AdminUser do
   it_behaves_like 'authenticatable_with_two_factor', :admin_user
   it_behaves_like 'two_factor_authenticatable'
 
-  it { is_expected.to have_many(:flags).dependent(:nullify).with_foreign_key(:resolved_by_id) }
-  it { is_expected.to have_many(:announcements).dependent(:nullify).with_foreign_key(:created_by_id) }
+  it { is_expected.to have_many(:flags).dependent(:restrict_with_exception).with_foreign_key(:resolved_by_id) }
+  it { is_expected.to have_many(:announcements).dependent(:restrict_with_exception).with_foreign_key(:created_by_id) }
 
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_uniqueness_of(:name) }


### PR DESCRIPTION
Because:
- Instead of deleting, We want to always deactivate admins that have handled flags or created announcements.

This commit:
- Changes admin user flag and announcements associations to use restrict_with_exception as their dependent option
- This will raise an `ActiveRecord::DeleteRestrictionError` exception if we try to delete a user that has any  records associated with them