### PR TITLE
Fix: Current theme not set for some users

### DIFF
--- a/app/controllers/concerns/current_theme.rb
+++ b/app/controllers/concerns/current_theme.rb
@@ -20,6 +20,6 @@ module CurrentTheme
   end
 
   def current_theme
-    @current_theme ||= Users::Theme.for(cookies[:theme])
+    @current_theme ||= Users::Theme.for(cookies[:theme]) || Users::Theme.for('light')
   end
 end


### PR DESCRIPTION
Because:
- We're seeing quite a few error reports in Sentry about the theme name being nil for mac users.

This commit:
- Returns the light theme as the default if the theme cannot be found from the users theme cookie.

