### PR TITLE
Chore: Remove Hint.css

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4653,11 +4653,6 @@ heap@^0.2.6:
   resolved "https://registry.yarnpkg.com/heap/-/heap-0.2.7.tgz#1e6adf711d3f27ce35a81fe3b7bd576c2260a8fc"
   integrity sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==
 
-hint.css@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/hint.css/-/hint.css-3.0.0.tgz#9f3a071d7b66d41f723c529a7878a3e0c23eb0ff"
-  integrity sha512-UoJ+yLO2kEcfsm/XMU1suAIR0sxCq4HO22pw4okJQo5TQDlA2BrJ57Eaxh4eT+9PDInIDTRm9TVzzbHHWEqASQ==
-
 hotkeys-js@>=3:
   version "3.9.4"
   resolved "https://registry.yarnpkg.com/hotkeys-js/-/hotkeys-js-3.9.4.tgz#ce1aa4c3a132b6a63a9dd5644fc92b8a9b9cbfb9"


### PR DESCRIPTION
Because:
- It was removed from package.json but still in the yarn.lock file