### PR TITLE
Chore: Optimise Heroku deploy

### DIFF
--- a/.buildcache
+++ b/.buildcache
@@ -1,5 +1,0 @@
-public/packs
-tmp/cache/assets
-~/.cache/yarn
-node_modules
-tmp/cache/bootsnap-load-path-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Build assets
         env:
           RAILS_ENV: test
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SKIP_YARN_INSTALL: true
         run: |
           bin/rails javascript:build
           bin/rails css:build

--- a/.slugcleanup
+++ b/.slugcleanup
@@ -1,5 +1,4 @@
 app/javascript
-app/assets/javascripts
 app/assets/stylesheets
 node_modules
 tmp

--- a/.slugignore
+++ b/.slugignore
@@ -2,7 +2,3 @@ spec
 doc
 .github
 .rubocop
-
-# Ignore any javascript test files outside of spec/
-*.test.js
-*.test.jsx

--- a/lib/tasks/heroku.rake
+++ b/lib/tasks/heroku.rake
@@ -17,17 +17,3 @@ namespace :heroku do
     Rake::Task['curriculum:content:import'].invoke
   end
 end
-
-# https://github.com/heroku/heroku-buildpack-ruby/pull/892#issuecomment-640900787
-namespace :yarn do
-  task install: :environment do
-    # These yarn settings come from the nodejs buildpack
-    # https://github.com/heroku/heroku-buildpack-nodejs/blob/02af461e42c37e7d10120e94cb1f2fa8508cb2a5/lib/dependencies.sh
-    yarn_flags = '--production=false --frozen-lockfile --ignore-engines --prefer-offline --cache-folder=~/.cache/yarn'
-
-    puts '*** [yarn:install] Configuring yarn with all build dependencies'
-    command = "yarn install #{yarn_flags}"
-    puts "Running: #{command}"
-    system command
-  end
-end


### PR DESCRIPTION
Because:
- We used caching buildpacks to cache assets and dependencies to speed up deployments. But they don't make a difference anymore. The Node and Heroku buildpacks already do a good enough job at caching.
- Yarn install runs twice because we are using both the Node and Ruby buildpacks - adding a few seconds onto our time to deploy
- We use a slug clean up buildpack to make sure our slug size on heroku does not grow beyond the 300mb soft limit. With our switch to Js-bundling for assets, we needed to change the javascript directory that will be cleaned up.

This commit:
- Remove the .buildcache file as we aren't using the caching buildpacks its used with anymore.
- Adds `SKIP_YARN_INSTALL` env var to CI, review apps, and the production environment. This will skip the yarn install task that is normally automatically invoked by the assets:precompile task. 
- Removes the yarn:install override rake task we had for Heroku. It only seemed to work for Webpacker.
- Amends the slugcleanup and slugignore files to clean up the appropriate directories after our recent assets overhaul.
