### PR TITLE
Chore: Run tests in parallel on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,18 +41,34 @@ jobs:
   tests:
     name: Tests
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Set N number of parallel jobs you want to run tests on.
+        # Use higher number if you have slow tests to split them on more parallel jobs.
+        # Remember to update ci_node_index below to 0..N-1
+        ci_node_total: [4]
+        # set N-1 indexes for parallel jobs
+        # When you run 2 parallel jobs then first job will have index 0, the second job will have index 1 etc
+        ci_node_index: [0, 1, 2, 3]
     services:
       postgres:
         image: postgres:15.7
+        ports:
+          - 5432:5432
         env:
           POSTGRES_USER: postgres
-          POSTGRES_DB: theodinproject_test
-          POSTGRES_PASSWORD: "password"
-        ports: ["5432:5432"]
+          POSTGRES_PASSWORD: postgres
 
       redis:
         image: redis
         ports: ["6379:6379"]
+
+    env:
+      RAILS_ENV: test
+      POSTGRES_USERNAME: postgres
+      POSTGRES_PASSWORD: postgres
+      SKIP_YARN_INSTALL: true
 
     steps:
       - name: Checkout code
@@ -74,22 +90,15 @@ jobs:
           yarn install
 
       - name: Build assets
-        env:
-          RAILS_ENV: test
-          SKIP_YARN_INSTALL: true
         run: |
           bin/rails javascript:build
           bin/rails css:build
 
       - name: Setup test database
-        env:
-          RAILS_ENV: test
-          DATABASE_URL: postgres://postgres:password@localhost:5432/theodinproject_test
         run: |
-          bin/rails db:schema:load
+          bundle exec rake parallel:create
+          bundle exec rake parallel:load_schema
+          bundle exec rake parallel:migrate
 
       - name: Run tests
-        env:
-          RAILS_ENV: test
-          DATABASE_URL: postgres://postgres:password@localhost:5432/theodinproject_test
-        run: bin/rspec
+        run: ./bin/ci_spec

--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,7 @@ end
 
 group :development, :test do
   gem 'dotenv-rails', '~> 3.1'
+  gem 'parallel_tests', '~> 4.7'
   gem 'rspec-rails', '~> 6.1'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -346,6 +346,8 @@ GEM
     orm_adapter (0.5.0)
     pagy (6.5.0)
     parallel (1.26.1)
+    parallel_tests (4.7.1)
+      parallel
     parser (3.3.4.2)
       ast (~> 2.4.1)
       racc
@@ -630,6 +632,7 @@ DEPENDENCIES
   omniauth-google-oauth2 (~> 1.1.1)
   omniauth-rails_csrf_protection (~> 1.0)
   pagy (~> 6.2)
+  parallel_tests (~> 4.7)
   pg (~> 1.5)
   propshaft (~> 0.9)
   public_activity (~> 3.0)

--- a/bin/ci_spec
+++ b/bin/ci_spec
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+
+# This script is used to run tests in parallel in Github Actions.
+# parallel_test test -n 8 --only-group 1,2
+
+CI_RUNNER_PROCESS_COUNT = 2
+
+parallel_tests_is_one_indexed = 1
+node_index = ENV['CI_NODE_INDEX'].to_i
+
+groups = "#{node_index * CI_RUNNER_PROCESS_COUNT + parallel_tests_is_one_indexed },#{node_index * CI_RUNNER_PROCESS_COUNT + parallel_tests_is_one_indexed + 1}"
+
+total_parallelism = CI_RUNNER_PROCESS_COUNT * ENV['CI_NODE_TOTAL'].to_i
+
+exec "bundle exec parallel_test ./spec -t rspec -n #{total_parallelism} --only-group #{groups}"

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,7 +20,7 @@ development: &development
 # DO NOT PUT A REAL USERNAME AND PASSWORD IN THIS FILE
 test: &test
   <<: *default
-  database: <%= ENV['POSTGRES_TEST_DB'] || 'theodinproject_test' %>
+  database: theodinproject_test<%= ENV['TEST_ENV_NUMBER'] %>
 
 production:
   adapter: postgresql

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,13 +40,14 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  test_port = 3001 + ENV['TEST_ENV_NUMBER'].to_i
   config.action_mailer.default_url_options = {
     host: ENV.fetch('HOST', 'localhost'),
-    port: ENV.fetch('HOST_PORT', 3001)
+    port: ENV.fetch('HOST_PORT', test_port)
   }
   routes.default_url_options = {
     host: ENV.fetch('HOST', 'localhost'),
-    port: ENV.fetch('HOST_PORT', 3001)
+    port: ENV.fetch('HOST_PORT', test_port)
   }
 
   # Tell Action Mailer not to deliver emails to the real world.

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_08_06_175334) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_06_175334) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/spec/services/notifications/flag_submission_spec.rb
+++ b/spec/services/notifications/flag_submission_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Notifications::FlagSubmission do
       notification_message = "OdinUser has flagged a submission on #{flagged_submission.lesson.title}\n" \
                              "Reason: inappropriate\n" \
                              "Extra: I find it offensive\n" \
-                             'Resolve the flag here: http://localhost:3001/admin/flags/120'
+                             "Resolve the flag here: http://localhost:#{Rails.application.routes.default_url_options[:port]}/admin/flags/120"
 
       expect(notification.message).to eq notification_message
     end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -6,8 +6,8 @@ Capybara.disable_animation = true
 Capybara.configure do |config|
   config.test_id = 'data-test'
   config.automatic_label_click = true
-  config.server_port = 3001
-  config.app_host = 'http://localhost:3001'
+  config.server_port = 3001 + ENV['TEST_ENV_NUMBER'].to_i
+  config.app_host = "http://localhost:#{config.server_port}"
 end
 
 Capybara.singleton_class.prepend(Module.new do


### PR DESCRIPTION
Because:
- It shaves a minute off our CI completion time 🚤 

This commit:
- Adds parallel tests gem
- Split tests in groups on Github actions using their matrix feature
- Change test setup to allow for dynamic ports based on the parallel test number thats is being used
