### PR TITLE
Chore: Abort lesson import when bad credentials are provided

### DIFF
--- a/app/models/github/lesson_content_importer.rb
+++ b/app/models/github/lesson_content_importer.rb
@@ -26,8 +26,11 @@ class Github::LessonContentImporter
 
   def import
     content.update!(body: content_converted_to_html) if content_needs_updated?
+  rescue Octokit::Unauthorized => e
+    abort "Is your GitHub API token correct? Unauthorized: #{e.message}"
   rescue Octokit::Error => e
-    log_error(e.message)
+    Rails.logger.error "Failed to import '#{lesson.title}' message: #{e.message}"
+    false
   end
 
   private
@@ -46,10 +49,5 @@ class Github::LessonContentImporter
 
   def github_response
     Octokit.contents('theodinproject/curriculum', path: lesson.github_path)
-  end
-
-  def log_error(message)
-    Rails.logger.error "Failed to import '#{lesson.title}' message: #{message}"
-    false
   end
 end

--- a/spec/models/github/lesson_content_importer_spec.rb
+++ b/spec/models/github/lesson_content_importer_spec.rb
@@ -72,5 +72,25 @@ RSpec.describe Github::LessonContentImporter do
         )
       end
     end
+
+    context 'when there is an unauthorized error with octokit' do
+      before do
+        allow(Octokit).to receive(:contents)
+          .with('theodinproject/curriculum', path: '/ruby_basics/variables')
+          .and_raise(
+            Octokit::Unauthorized.new(
+              method: 'GET',
+              status: '401',
+              body: { error: 'Bad credentials' }
+            )
+          )
+      end
+
+      it 'aborts the lesson import' do
+        expect { importer.import }.to raise_error(
+          SystemExit
+        ).and output("Is your GitHub API token correct? Unauthorized: GET : 401 - Error: Bad credentials\n").to_stderr
+      end
+    end
   end
 end


### PR DESCRIPTION
Because:
- If your GitHub Api token is incorrect, the lesson import task will silently fail. It will run through every lesson, incrementing the progress bar, and look as if it has succeeded. Resulting in a lot of confusion when you go to a lesson page and the content is blank.

This commit:
- Abort the lesson import task if an incorrect GitHub API token is provided and print out a message about what might have gone wrong.
