### PR TITLE
Fix: Flaky CI test runs

### DIFF
--- a/spec/support/cuprite.rb
+++ b/spec/support/cuprite.rb
@@ -15,6 +15,7 @@ Capybara.register_driver(:odin_cuprite) do |app|
     app,
     window_size: [1200, 1200],
     browser_options: {},
+    flatten: false,
     process_timeout: 30,
     timeout: 60,
     inspector: true,


### PR DESCRIPTION
Because:
- We are seeing intermittent failures with `Ferrum::NoSuchTargetError` being raised.

This commit:
- It appears to be an issue with the latest version of Ferrum, configuring it with `flatten: false` is reported to fix it.

