### PR TITLE
Feature: Optimise dark mode styling for badges

### DIFF
--- a/app/components/Ui/badge_component.rb
+++ b/app/components/Ui/badge_component.rb
@@ -6,11 +6,12 @@ class Ui::BadgeComponent < ApplicationComponent
   def color_classes
     case color
     when 'yellow'
-      'bg-yellow-50 text-yellow-700 ring-yellow-600/20'
+      'bg-yellow-50 text-yellow-700 ring-yellow-600/20 ' \
+      'dark:bg-yellow-400/10 dark:text-yellow-500 dark:ring-yellow-400/20'
     when 'green'
-      'bg-green-50 text-green-700 ring-green-600/20'
+      'bg-green-50 text-green-700 ring-green-600/20 dark:bg-green-500/10 dark:text-green-400 dark:ring-green-500/20'
     else
-      'bg-gray-50 text-gray-700 ring-gray-600/20'
+      'bg-gray-50 text-gray-700 ring-gray-600/20 dark:bg-gray-400/10 dark:text-gray-400 dark:ring-gray-400/20'
     end
   end
 


### PR DESCRIPTION
Because:
- Badges didn't look very good on dark mode, they were too bright 🔆 

### Before
<img width="890" alt="Screenshot 2024-08-18 at 09 56 53" src="https://github.com/user-attachments/assets/41128a75-51d0-4e0b-8230-cf6551a4e530">

<img width="1057" alt="Screenshot 2024-08-18 at 09 56 15" src="https://github.com/user-attachments/assets/10a3e48f-37e0-47a7-b189-124045eb0f43">

<img width="1042" alt="Screenshot 2024-08-18 at 09 55 42" src="https://github.com/user-attachments/assets/f48e3c20-bb94-4d7c-988a-1c86a6bfa838">



### After:
<img width="916" alt="Screenshot 2024-08-18 at 09 57 20" src="https://github.com/user-attachments/assets/f6277bed-0cdc-4b3f-a5e2-6e992a833632">

<img width="1136" alt="Screenshot 2024-08-18 at 09 58 09" src="https://github.com/user-attachments/assets/5fe3b744-6a23-4f02-ba4a-639d6fde9de6">

<img width="1048" alt="Screenshot 2024-08-18 at 09 58 21" src="https://github.com/user-attachments/assets/20d74333-31bd-4440-b8cb-361cc6689a61">



