### PR TITLE
Fix: Flaky tests that use ActionMailer

### DIFF
--- a/spec/requests/admin/team_members/password_resets_spec.rb
+++ b/spec/requests/admin/team_members/password_resets_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe 'Team member password resets' do
+  before do
+    Mail::TestMailer.deliveries.clear
+  end
+
   describe 'POST #create' do
     context 'when signed in as an admin and the team member exists' do
       it 'sends a password reset email' do
@@ -8,10 +12,9 @@ RSpec.describe 'Team member password resets' do
         other_admin = create(:admin_user)
         sign_in(admin)
 
-        expect do
-          post admin_team_member_password_resets_path(other_admin)
-        end.to change { ActionMailer::Base.deliveries.count }.by(1)
+        post admin_team_member_password_resets_path(other_admin)
 
+        expect(subject).to have_sent_email.to(other_admin.email) # rubocop:disable RSpec/NamedSubject
         expect(response).to redirect_to(admin_team_path)
       end
     end
@@ -21,10 +24,9 @@ RSpec.describe 'Team member password resets' do
         admin = create(:admin_user)
         sign_in(admin)
 
-        expect do
-          post admin_team_member_password_resets_path(team_member_id: 101)
-        end.not_to change { ActionMailer::Base.deliveries.count }
+        post admin_team_member_password_resets_path(team_member_id: 101)
 
+        expect(subject).not_to have_sent_email # rubocop:disable RSpec/NamedSubject
         expect(response).to redirect_to(admin_team_path)
         expect(flash[:alert]).to eq('Team member not found')
       end
@@ -36,10 +38,9 @@ RSpec.describe 'Team member password resets' do
         admin = create(:admin_user)
         sign_in(user)
 
-        expect do
-          post admin_team_member_password_resets_path(admin)
-        end.not_to change { ActionMailer::Base.deliveries.count }
+        post admin_team_member_password_resets_path(admin)
 
+        expect(subject).not_to have_sent_email # rubocop:disable RSpec/NamedSubject
         expect(response).to redirect_to(new_admin_user_session_path)
       end
     end

--- a/spec/requests/admin/team_members/reactivation_spec.rb
+++ b/spec/requests/admin/team_members/reactivation_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe 'Team member reactivation' do
   describe 'PUT #update' do
     context 'when signed in as an admin and the team member exists' do
+      before do
+        Mail::TestMailer.deliveries.clear
+      end
+
       it 'reactivates the team member' do
         admin = create(:admin_user)
         deactivated_admin = create(:admin_user, :deactivated)
@@ -31,14 +35,12 @@ RSpec.describe 'Team member reactivation' do
         deactivated_admin = create(:admin_user, :deactivated, email: 'deactivated@odin.com')
         sign_in(admin)
 
-        expect do
-          put admin_team_member_reactivation_path(team_member_id: deactivated_admin.id)
-        end.to change { ActionMailer::Base.deliveries.count }
+        put admin_team_member_reactivation_path(team_member_id: deactivated_admin.id)
 
-        mailer = ActionMailer::Base.deliveries.last
-
-        expect(mailer.to).to eq(['deactivated@odin.com'])
-        expect(mailer.subject).to eq('Joining The Odin Project Admin Team')
+        # rubocop:disable RSpec/NamedSubject
+        expect(subject).to have_sent_email.to(deactivated_admin.email)
+        expect(subject).to have_sent_email.with_subject('Joining The Odin Project Admin Team')
+        # rubocop:enable RSpec/NamedSubject
       end
     end
 

--- a/spec/requests/admin/team_members/resend_invitation_spec.rb
+++ b/spec/requests/admin/team_members/resend_invitation_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe 'Resend team member invite' do
+  before do
+    Mail::TestMailer.deliveries.clear
+  end
+
   describe 'POST #create' do
     context 'when signed in as an admin and the team member is pending' do
       it 'sends another invitation email to the team member' do
@@ -8,14 +12,12 @@ RSpec.describe 'Resend team member invite' do
         pending_admin = create(:admin_user, :pending, email: 'pending@odin.com')
         sign_in(admin)
 
-        expect do
-          post admin_team_member_resend_invitation_path(pending_admin)
-        end.to change { ActionMailer::Base.deliveries.count }
+        post admin_team_member_resend_invitation_path(pending_admin)
 
-        mailer = ActionMailer::Base.deliveries.last
-
-        expect(mailer.to).to eq(['pending@odin.com'])
-        expect(mailer.subject).to eq('Joining The Odin Project Admin Team')
+        # rubocop:disable RSpec/NamedSubject
+        expect(subject).to have_sent_email.to(pending_admin.email)
+        expect(subject).to have_sent_email.with_subject('Joining The Odin Project Admin Team')
+        # rubocop:enable RSpec/NamedSubject
       end
     end
 
@@ -23,25 +25,22 @@ RSpec.describe 'Resend team member invite' do
       it 'does not send the team member another invite' do
         admin = create(:admin_user)
         active_admin = create(:admin_user, :activated, email: 'active@odin.com')
-
         sign_in(admin)
 
-        expect do
-          post admin_team_member_resend_invitation_path(active_admin)
-        end.not_to change { ActionMailer::Base.deliveries.count }
+        post admin_team_member_resend_invitation_path(active_admin)
+
+        expect(subject).not_to have_sent_email # rubocop:disable RSpec/NamedSubject
       end
     end
 
     context "when signed in as an admin and the team member doesn't exist" do
       it 'does not send an invitation email' do
         admin = create(:admin_user)
-
         sign_in(admin)
 
-        expect do
-          post admin_team_member_resend_invitation_path(team_member_id: 1007)
-        end.not_to change { ActionMailer::Base.deliveries.count }
+        post admin_team_member_resend_invitation_path(team_member_id: 1007)
 
+        expect(subject).not_to have_sent_email # rubocop:disable RSpec/NamedSubject
         expect(response).to redirect_to(admin_team_path)
         expect(flash[:alert]).to eq('Team member not found')
       end
@@ -53,10 +52,9 @@ RSpec.describe 'Resend team member invite' do
         admin = create(:admin_user)
         sign_in(user)
 
-        expect do
-          post admin_team_member_resend_invitation_path(admin)
-        end.not_to change { ActionMailer::Base.deliveries.count }
+        post admin_team_member_resend_invitation_path(admin)
 
+        expect(subject).not_to have_sent_email # rubocop:disable RSpec/NamedSubject
         expect(response).to redirect_to(new_admin_user_session_path)
       end
     end

--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -2,6 +2,10 @@ require 'rails_helper'
 
 RSpec.describe 'User Registrations' do
   describe 'POST #create' do
+    before do
+      Mail::TestMailer.deliveries.clear
+    end
+
     around do |example|
       perform_enqueued_jobs do
         example.run
@@ -11,10 +15,11 @@ RSpec.describe 'User Registrations' do
     context 'when the user is valid' do
       it 'sends the welcome email' do
         post user_registration_path(params: { user: attributes_for(:user, email: 'odin@example.com') })
-        mail = ActionMailer::Base.deliveries.last
 
-        expect(mail.to).to eq(['odin@example.com'])
-        expect(mail.subject).to eq('Getting started with The Odin Project')
+        # rubocop:disable RSpec/NamedSubject
+        expect(subject).to have_sent_email.to('odin@example.com')
+        expect(subject).to have_sent_email.with_subject('Getting started with The Odin Project')
+        # rubocop:enable RSpec/NamedSubject
       end
     end
 
@@ -22,7 +27,7 @@ RSpec.describe 'User Registrations' do
       it 'does not send the welcome email' do
         post user_registration_path(params: { user: attributes_for(:user, email: 'odin@') })
 
-        expect(ActionMailer::Base.deliveries).to be_empty
+        expect(subject).not_to have_sent_email # rubocop:disable RSpec/NamedSubject
       end
     end
 
@@ -36,7 +41,7 @@ RSpec.describe 'User Registrations' do
       it 'does not send the welcome email' do
         post user_registration_path(params: { user: attributes_for(:user, email: 'odin@example.com') })
 
-        expect(ActionMailer::Base.deliveries).to be_empty
+        expect(subject).not_to have_sent_email # rubocop:disable RSpec/NamedSubject
       end
     end
   end

--- a/spec/support/mail.rb
+++ b/spec/support/mail.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include Mail::Matchers
+end

--- a/spec/support/retry.rb
+++ b/spec/support/retry.rb
@@ -6,7 +6,7 @@ if ENV['CI'].present?
     config.display_try_failure_messages = true
 
     config.around :each, type: :system do |ex|
-      ex.run_with_retry retry: 3
+      ex.run_with_retry retry: 2
     end
   end
 end


### PR DESCRIPTION
Because:
- Emails appear to be leaking between parallel tests

This commit:
- Use matchers included with the Mail gem as they are meant to be more reliable
- The mail matchers expect to be run against the subject in request specs, I've opted to disable the named subject cop to instead of moving the requests into subjects to keep all set up within tests and keep them as readable as possible.