### PR TITLE
Chore: Use inline-svg helper with all applicable SVGs

### DIFF
--- a/app/assets/images/icons/bars-3.svg
+++ b/app/assets/images/icons/bars-3.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" >
+  <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+</svg>

--- a/app/assets/images/icons/ham-burger.svg
+++ b/app/assets/images/icons/ham-burger.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
-  <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
-</svg>

--- a/app/assets/images/icons/x.svg
+++ b/app/assets/images/icons/x.svg
@@ -1,3 +1,0 @@
-<svg class="" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" aria-hidden="true">
-  <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-</svg>

--- a/app/components/announcement_component.html.erb
+++ b/app/components/announcement_component.html.erb
@@ -19,7 +19,7 @@
       <div class="absolute inset-y-0 right-0 flex items-start pt-1 pr-1 sm:items-start sm:pt-1 sm:pr-2">
         <button type="button" class="-mr-1 flex p-2 rounded-md hover:bg-gray-200 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-white" data-action="click->announcement#dismiss" data-test-id="announcement-close-button">
           <span class="sr-only">Dismiss</span>
-          <%= inline_svg_tag 'icons/x.svg', class: 'h-6 w-6 text-gray-600 dark:text-gray-300', aria: true, title: 'dismiss', desc: 'dismiss icon' %>
+          <%= inline_svg_tag 'icons/x-mark.svg', class: 'h-6 w-6 text-gray-600 dark:text-gray-300', aria: true, title: 'Dismiss announcement' %>
         </button>
       </div>
     <% end %>

--- a/app/components/modal_component.html.erb
+++ b/app/components/modal_component.html.erb
@@ -35,7 +35,7 @@
           <div class="absolute right-0 top-0 pr-4 pt-4">
             <button type="button" data-action="click->visibility#off click->modal#close" class="rounded-md bg-white dark:bg-gray-800 text-gray-400 dark:text-gray-300 hover:text-gray-500 dark:hover:text-gray-400 focus:outline-none focus:ring-2 focus:ring-gold-500">
               <span class="sr-only">Close</span>
-              <%= inline_svg_tag 'icons/x.svg', class: 'h-6 w-6', aria: true, title: 'close', desc: 'close button' %>
+              <%= inline_svg_tag 'icons/x-mark.svg', class: 'h-6 w-6', aria: true, title: 'Close modal' %>
             </button>
           </div>
 

--- a/app/views/layouts/admin/_nav_bar.html.erb
+++ b/app/views/layouts/admin/_nav_bar.html.erb
@@ -4,9 +4,7 @@
 
     <button type="button" class="-m-2.5 p-2.5 text-gray-700 dark:text-gray-300 lg:hidden" data-action="open-menu#open">
       <span class="sr-only">Open sidebar</span>
-      <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
-      </svg>
+      <%= inline_svg_tag 'icons/bars-3.svg', class: 'h-6 w-6', aria: true, title: 'Open mobile menu' %>
     </button>
 
     <!-- Profile dropdown -->

--- a/app/views/layouts/admin/_sidebar_nav.html.erb
+++ b/app/views/layouts/admin/_sidebar_nav.html.erb
@@ -65,9 +65,7 @@ nav_links = [
 
         <button type="button" class="-m-2.5 p-2.5" data-action="click->visibility#off">
           <span class="sr-only">Close sidebar</span>
-          <svg class="h-6 w-6 text-white" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-          </svg>
+          <%= inline_svg_tag 'icons/x-mark.svg', class: 'h-6 w-6 text-white', aria: true, title: 'Close menu' %>
         </button>
       </div>
 

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -51,7 +51,7 @@
       <div class="-mr-2 flex items-center md:hidden" data-controller="open-menu" data-open-menu-visibility-outlet=".off-canvas-menu">
         <button type="button" data-action="open-menu#open" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 dark:text-gray-300 dark:hover:text-gray-200 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-gold-500" aria-controls="mobile-menu" aria-expanded="false">
           <span class="sr-only">Open mobile menu</span>
-          <%= inline_svg_tag 'icons/ham-burger.svg', class: 'block h-6 w-6', aria: true, title: 'Open mobile menu button' %>
+          <%= inline_svg_tag 'icons/bars-3.svg', class: 'block h-6 w-6', aria: true, title: 'Open mobile menu' %>
         </button>
       </div>
     </div>

--- a/app/views/shared/_off_canvas_menu.html.erb
+++ b/app/views/shared/_off_canvas_menu.html.erb
@@ -40,9 +40,7 @@
         data-transition-leave-end="transform opacity-0">
         <button type="button" data-action="click->visibility#off" class="ml-1 flex items-center justify-center h-10 w-10 rounded-full focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white">
           <span class="sr-only">Close sidebar</span>
-          <svg class="h-6 w-6 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-          </svg>
+          <%= inline_svg_tag 'icons/x-mark.svg', class: 'h-6 w-6 text-white', aria: true, title: 'Close menu' %>
         </button>
       </div>
 


### PR DESCRIPTION
Because:
- We had a few icons that were using plain SVG syntax in the views.

This commit:
- Renames ham-burger.svg to bars-3.svg to bring it inline with Heroicons naming
- Removes the x.svg icon - its the exact same as the x-mark.svg icon
- Replace open menu button SVGs with the inline_svg helper
- Replace closer and dismiss button SVGs with the inline_svg helper
