### PR TITLE
Fix: Correctly render mermaid diagrams in markdown preview tool

### DIFF
--- a/app/components/content_container_component.html.erb
+++ b/app/components/content_container_component.html.erb
@@ -1,6 +1,6 @@
  <div class='max-w-prose mx-auto <%= classes %>'>
 
-   <div class="lesson-content prose prose-gray prose-a:text-blue-800 visited:prose-a:text-purple-800 prose-code:bg-gray-100 prose-code:p-1 prose-code:font-normal dark:prose-a:text-blue-300 dark:visited:prose-a:text-purple-300 dark:prose-code:bg-gray-700/40 prose-code:rounded-md break-words line-numbers dark:prose-invert dark:antialiased prose-pre:rounded-xl prose-pre:bg-slate-800 prose-pre:shadow-lg dark:prose-pre:bg-slate-800/70 dark:prose-pre:shadow-none dark:prose-pre:ring-1 dark:prose-pre:ring-slate-300/10 " data-controller="syntax-highlighting diagramming" <%= tag.attributes(data: data_attributes) %>>
+   <div class="lesson-content prose prose-gray prose-a:text-blue-800 visited:prose-a:text-purple-800 prose-code:bg-gray-100 prose-code:p-1 prose-code:font-normal dark:prose-a:text-blue-300 dark:visited:prose-a:text-purple-300 dark:prose-code:bg-gray-700/40 prose-code:rounded-md break-words line-numbers dark:prose-invert dark:antialiased prose-pre:rounded-xl prose-pre:bg-slate-800 prose-pre:shadow-lg dark:prose-pre:bg-slate-800/70 dark:prose-pre:shadow-none dark:prose-pre:ring-1 dark:prose-pre:ring-slate-300/10 " data-controller="syntax-highlighting" <%= tag.attributes(data: data_attributes) %>>
     <%= content %>
    </div>
 

--- a/app/javascript/controllers/diagramming_controller.js
+++ b/app/javascript/controllers/diagramming_controller.js
@@ -3,10 +3,7 @@ import mermaid from 'mermaid'
 
 export default class DiagrammingController extends Controller {
   async connect () {
-    const isMarkdownPreview = Boolean(document.querySelector('#preview-container'))
-    const querySelector = isMarkdownPreview ? ':not(.hidden) > #preview-container .mermaid' : '.mermaid'
-
     mermaid.initialize({ startOnLoad: false, theme: 'dark' })
-    await mermaid.run({ querySelector })
+    await mermaid.run()
   }
 }

--- a/app/javascript/controllers/diagramming_controller.js
+++ b/app/javascript/controllers/diagramming_controller.js
@@ -2,7 +2,11 @@ import { Controller } from '@hotwired/stimulus'
 import mermaid from 'mermaid'
 
 export default class DiagrammingController extends Controller {
-  async connect () {
+  connect () {
+    this.render()
+  }
+
+  async render () {
     mermaid.initialize({ startOnLoad: false, theme: 'dark' })
     await mermaid.run()
   }

--- a/app/javascript/controllers/diagramming_controller.js
+++ b/app/javascript/controllers/diagramming_controller.js
@@ -2,8 +2,11 @@ import { Controller } from '@hotwired/stimulus'
 import mermaid from 'mermaid'
 
 export default class DiagrammingController extends Controller {
-  connect () {
+  async connect () {
+    const isMarkdownPreview = Boolean(document.querySelector('#preview-container'))
+    const querySelector = isMarkdownPreview ? ':not(.hidden) > #preview-container .mermaid' : '.mermaid'
+
     mermaid.initialize({ startOnLoad: false, theme: 'dark' })
-    mermaid.init()
+    await mermaid.run({ querySelector })
   }
 }

--- a/app/views/lessons/previews/show.html.erb
+++ b/app/views/lessons/previews/show.html.erb
@@ -7,13 +7,13 @@
       <p class="mb-6 text-gray-500">Paste markdown here to check how it will look on the website!</p>
 
       <div>
-        <div data-controller='tabs share-preview' data-share-preview-url-value="<%= lessons_preview_share_path(format: :turbo_stream) %>" data-tabs-index='0' data-tabs-active-class="text-gray-700 bg-gray-300/50 hover:bg-gray-300 dark:bg-gray-700/90" data-tabs-inactive-class="hidden">
+        <div data-controller='tabs share-preview diagramming' data-share-preview-url-value="<%= lessons_preview_share_path(format: :turbo_stream) %>" data-tabs-index='0' data-tabs-active-class="text-gray-700 bg-gray-300/50 hover:bg-gray-300 dark:bg-gray-700/90" data-tabs-inactive-class="hidden">
           <div class="flex justify-between">
             <div class="flex items-center mb-3">
               <button data-action="tabs#change" class="text-gray-600 bg-gray-300/50 hover:text-gray-800 hover:bg-gray-200 dark:bg-gray-700/40 dark:text-gray-300 dark:hover:text-gray-200 dark:hover:bg-gray-600 rounded-md border border-transparent px-3 py-1.5 font-medium cursor-pointer focus:outline-none" data-tabs-target='tab'>
                 Write
               </button>
-              <button data-action="tabs#change" class="ml-2 text-gray-600 hover:text-gray-800 hover:bg-gray-200 dark:bg-gray-700/40 dark:text-gray-300 dark:hover:text-gray-200 dark:hover:bg-gray-600 rounded-md border border-transparent px-3 py-1.5 font-medium cursor-pointer focus:outline-none" data-tabs-target='tab'>
+              <button data-action="tabs#change diagramming#connect" class="ml-2 text-gray-600 hover:text-gray-800 hover:bg-gray-200 dark:bg-gray-700/40 dark:text-gray-300 dark:hover:text-gray-200 dark:hover:bg-gray-600 rounded-md border border-transparent px-3 py-1.5 font-medium cursor-pointer focus:outline-none" data-tabs-target='tab'>
                 Preview
               </button>
             </div>

--- a/app/views/lessons/previews/show.html.erb
+++ b/app/views/lessons/previews/show.html.erb
@@ -13,7 +13,7 @@
               <button data-action="tabs#change" class="text-gray-600 bg-gray-300/50 hover:text-gray-800 hover:bg-gray-200 dark:bg-gray-700/40 dark:text-gray-300 dark:hover:text-gray-200 dark:hover:bg-gray-600 rounded-md border border-transparent px-3 py-1.5 font-medium cursor-pointer focus:outline-none" data-tabs-target='tab'>
                 Write
               </button>
-              <button data-action="tabs#change diagramming#connect" class="ml-2 text-gray-600 hover:text-gray-800 hover:bg-gray-200 dark:bg-gray-700/40 dark:text-gray-300 dark:hover:text-gray-200 dark:hover:bg-gray-600 rounded-md border border-transparent px-3 py-1.5 font-medium cursor-pointer focus:outline-none" data-tabs-target='tab'>
+              <button data-action="tabs#change diagramming#render" class="ml-2 text-gray-600 hover:text-gray-800 hover:bg-gray-200 dark:bg-gray-700/40 dark:text-gray-300 dark:hover:text-gray-200 dark:hover:bg-gray-600 rounded-md border border-transparent px-3 py-1.5 font-medium cursor-pointer focus:outline-none" data-tabs-target='tab'>
                 Preview
               </button>
             </div>

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -5,7 +5,7 @@
 
     <%= render 'lessons/header', lesson: @lesson %>
 
-    <main class="grid grid-cols-12 gap-x-6" data-controller="lesson-toc" data-lesson-toc-item-classes-value="no-underline hover:text-gray-800 text-sm dark:hover:text-gray-300">
+    <main class="grid grid-cols-12 gap-x-6" data-controller="lesson-toc diagramming" data-lesson-toc-item-classes-value="no-underline hover:text-gray-800 text-sm dark:hover:text-gray-300">
       <article class="col-span-full xl:col-span-7 xl:col-start-2 xl:max-w-prose">
         <%= render ContentContainerComponent.new(classes: 'xl:mx-0 pb-6', data_attributes: { lesson_toc_target: 'lessonContent' }) do |component| %>
           <%= @lesson.body.html_safe %>

--- a/bin/test
+++ b/bin/test
@@ -9,7 +9,7 @@ puts 'Erblint:'
 results['Erblint'] = system 'bundle exec erblint --lint-all'
 
 puts 'Standard JS:'
-results['Standard'] = system 'yarn lint'
+results['Standard'] = system 'yarn lintt'
 
 puts "\n== Running specs =="
 puts 'Rspec:'

--- a/bin/test
+++ b/bin/test
@@ -9,7 +9,7 @@ puts 'Erblint:'
 results['Erblint'] = system 'bundle exec erblint --lint-all'
 
 puts 'Standard JS:'
-results['Standard'] = system 'yarn lintt'
+results['Standard'] = system 'yarn lint'
 
 puts "\n== Running specs =="
 puts 'Rspec:'


### PR DESCRIPTION
## Because

We initialise and run mermaid as soon as mermaid diagrams enter the DOM. If they have `display: none`, which they start off with as a child of a hidden parent element in the markdown preview page, they'll be rendered with incorrect SVG values - unable to rerender later as the mermaid text will have already been replaced.


## This PR

- Runs `diagramming#connect` when switching to rendered preview tab in the markdown preview tool
- If in markdown preview page, only runs mermaid rendering on non-hidden diagrams
- Replaces deprecated `mermaid.init` method with recommended new `run` method as per documentation for v10+

## Issue

Closes #4783

## Additional Information


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If applicable, this PR includes new or updated automated tests
