### PR TITLE
Feature: Adds active announcements tile to v2 admin dashboard.

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -2,6 +2,7 @@ module Admin
   class DashboardController < Admin::BaseController
     def show
       @active_flags_count = Flag.count_for(:active)
+      @active_announcements_count = Announcement.active.count
     end
   end
 end

--- a/app/views/admin/dashboard/show.html.erb
+++ b/app/views/admin/dashboard/show.html.erb
@@ -13,7 +13,12 @@
         <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-800 dark:text-gray-200"><%= @active_flags_count %></dd>
       </li>
     <% end %>
-
+    <%= link_to admin_announcements_path do %>
+      <li class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 px-4 py-5 hover:border-gray-300 border border-gray-200 dark:border-gray-700 dark:hover:border-gray-600 sm:p-6">
+        <dt class="truncate text-sm font-medium text-gray-500 dark:text-gray-300">Active announcements</dt>
+        <dd class="mt-1 text-3xl font-semibold tracking-tight text-gray-800 dark:text-gray-200"><%= @active_announcements_count %></dd>
+      </li>
+    <% end %>
   </ul>
 
   <div class="border-b border-gray-200 dark:border-gray-800 pb-5 mt-6">


### PR DESCRIPTION
## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
This change adds a tile indicating active announcement count on the admin dashboard. This will allow admins to briefly see if there have been new announcements. Clicking on the tile will navigate the admin to the announcements page.

## This PR
- Adds a `.active_count` scope on `announcement.rb`. It builds off of the existing `.active` scope.
- The new scope is used in the admin/dashboardcontroller to populate `active_announcements_count`.
- `active_announcements_count` is presented in the view as another tile similar to the unresolved flags tile.
- The `announcement` model spec is updated to test for this new scope.


## Issue
Closes #4619


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
