### PR TITLE
Chore: Puma config tweaks

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,4 +1,4 @@
-require 'barnes'
+enable_keep_alives false
 
 workers Integer(ENV['WEB_CONCURRENCY'] || 2)
 threads_count = Integer(ENV['RAILS_MAX_THREADS'] || 5)
@@ -8,14 +8,7 @@ preload_app!
 
 port        ENV['PORT']     || 3000
 environment ENV['RACK_ENV'] || 'development'
-enable_keep_alives false
 
 on_worker_boot do
-  # Worker specific setup for Rails 4.1+
-  # See: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#on-worker-boot
   ActiveRecord::Base.establish_connection
-end
-
-before_fork do
-  Barnes.start
 end


### PR DESCRIPTION
Because:
- Barnes doesn't need to be started in the puma config file.


