### PR TITLE
Chore: Remove explicit protect from forgery callback

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,8 +2,6 @@ class ApplicationController < ActionController::Base
   include CurrentTheme
   include Pagy::Backend
 
-  protect_from_forgery with: :exception
-
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :set_sentry_user, if: :current_user
   before_action :store_user_location!, if: :storable_location?


### PR DESCRIPTION
Because:
- By default it already enabled and included in `ActionController::Base`. Our declaration in `ApplicationController` is unnecessary.

