### PR TITLE
Fix: Capitalize "googled" -> "Googled"

### DIFF
--- a/app/views/guides/community/rules.html.erb
+++ b/app/views/guides/community/rules.html.erb
@@ -161,7 +161,7 @@
       Avoid asking low effort questions because it puts too much responsibility on others to properly guide you to the answer. For example:
       <ul>
         <li>Not providing enough details or context</li>
-        <li>Asking questions that can be easily googled or not doing your own research first</li>
+        <li>Asking questions that can be easily Googled or not doing your own research first</li>
         <li>Posting multiple short messages in rapid succession because they are often incomplete sentences that make it hard for others understand the full situation.</li>
       </ul>
     </p>


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
Capitalize Googled to recognize Google as a trademarked term.


## This PR

- "Asking questions that can be easily googled" -> "Asking questions that can be easily Googled"


## Issue
Closes https://github.com/TheOdinProject/curriculum/issues/29308

## Additional Information


## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
