### PR TITLE
Chore: Speed up admin learner search

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,7 +26,20 @@ class User < ApplicationRecord
   scope :signed_up_on, ->(date) { where(created_at: date.all_day) }
   scope :banned, -> { where(banned: true) }
 
-  pg_search_scope :search_by, against: %i[username email], using: { tsearch: { prefix: true } }
+  pg_search_scope(
+    :search_by,
+    against: %i[
+      username
+      email
+    ],
+    using: {
+      tsearch: {
+        prefix: true,
+        dictionary: 'english',
+        tsvector_column: 'search_tsvector'
+      }
+    }
+  )
 
   def progress_for(course)
     @progress ||= Hash.new { |hash, c| hash[c] = CourseProgress.new(c, self) }

--- a/app/views/admin/learners/index.html.erb
+++ b/app/views/admin/learners/index.html.erb
@@ -10,7 +10,7 @@
     <%= inline_svg_tag 'icons/magnifying-glass.svg', class: 'pointer-events-none col-start-1 row-start-1 ml-3 size-5 self-center text-gray-400' %>
   <% end %>
 
-  <%= turbo_frame_tag :learner_results, target: '_top' do %>
+  <%= turbo_frame_tag :learner_results, target: '_top', data: { turbo_action: 'advance' } do %>
     <div class="mt-8 flow-root">
       <% if @learners.any? %>
         <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 max-w-6xl px-6" data-test-id="learners-list">

--- a/db/migrate/20250212143446_add_search_ts_vector_column_to_users.rb
+++ b/db/migrate/20250212143446_add_search_ts_vector_column_to_users.rb
@@ -1,0 +1,15 @@
+class AddSearchTsVectorColumnToUsers < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    execute <<-SQL.squish
+      ALTER TABLE users
+      ADD COLUMN search_tsvector tsvector GENERATED ALWAYS AS (
+        setweight(to_tsvector('english', coalesce(email, '')), 'A') ||
+        setweight(to_tsvector('english', coalesce(username,'')), 'B')
+      ) STORED;
+    SQL
+
+    add_index :users, :search_tsvector, using: :gin, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_17_132923) do
+ActiveRecord::Schema[7.1].define(version: 2025_02_12_143446) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -327,8 +327,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_17_132923) do
     t.string "avatar"
     t.integer "path_id", default: 1
     t.boolean "banned", default: false, null: false
+    t.virtual "search_tsvector", type: :tsvector, as: "(setweight(to_tsvector('english'::regconfig, (COALESCE(email, ''::character varying))::text), 'A'::\"char\") || setweight(to_tsvector('english'::regconfig, (COALESCE(username, ''::character varying))::text), 'B'::\"char\"))", stored: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["search_tsvector"], name: "index_users_on_search_tsvector", using: :gin
     t.index ["username"], name: "index_users_on_username"
   end
 


### PR DESCRIPTION
Because:
- The default configuration is not fast enough for the amount of data we have in production.

This commit:
- Adds a ts_vector column to the users table which we can search against - this is recommended in the [pg_search docs](https://github.com/Casecommons/pg_search?tab=readme-ov-file#using-tsvector-columns)
- Sneaks in a data-turbo-action="advance" attribute to the learner search results turbo frame so we can share search result pages with admins if we need to.
