### PR TITLE
Chore: Remove Inline Private Attr Readers

### DIFF
--- a/app/models/github/lesson_content_importer.rb
+++ b/app/models/github/lesson_content_importer.rb
@@ -1,7 +1,4 @@
 class Github::LessonContentImporter
-  attr_reader :lesson, :content
-  private :lesson, :content
-
   def initialize(lesson)
     @lesson = lesson
     @content = lesson.content || lesson.build_content
@@ -34,6 +31,8 @@ class Github::LessonContentImporter
   end
 
   private
+
+  attr_reader :lesson, :content
 
   def content_needs_updated?
     content.body != content_converted_to_html

--- a/app/models/omniauth_providers/builder.rb
+++ b/app/models/omniauth_providers/builder.rb
@@ -1,8 +1,5 @@
 module OmniauthProviders
   class Builder
-    attr_reader :auth, :user
-    private :auth, :user
-
     def initialize(auth, user)
       @auth = auth
       @user = user
@@ -13,6 +10,8 @@ module OmniauthProviders
     end
 
     private
+
+    attr_reader :auth, :user
 
     def provider_attributes
       {


### PR DESCRIPTION
Because:
- We moved away from this style a while ago and it being flagged in a pending Rubocop bump