### PR TITLE
Chore: Remove Chart JS TW Colors Plugin

### DIFF
--- a/app/javascript/controllers/chart_controller.js
+++ b/app/javascript/controllers/chart_controller.js
@@ -1,8 +1,6 @@
 import { Controller } from '@hotwired/stimulus'
 
 import { Chart } from 'chart.js/auto'
-import twColorsPlugin from 'chartjs-plugin-tailwindcss-colors'
-import twConfig from '../../../tailwind.config'
 
 export default class ChartController extends Controller {
   static values = {
@@ -17,7 +15,7 @@ export default class ChartController extends Controller {
       {
         type: this.typeValue,
         data: this.dataValue,
-        plugins: [twColorsPlugin(twConfig), ...this.chartTypePlugins()],
+        plugins: [...this.chartTypePlugins()],
         options: {
           maintainAspectRatio: false,
           responsive: true,

--- a/app/views/admin/reports/lesson_completions/show.html.erb
+++ b/app/views/admin/reports/lesson_completions/show.html.erb
@@ -21,8 +21,8 @@
                 label: 'Lesson completions',
                 data: @lesson_completions_stats.values,
                 fill: true,
-                backgroundColor: 'blue-200',
-                borderColor: 'blue-600',
+                backgroundColor: '#bedbff',
+                borderColor: '#155dfc',
                 borderWidth: 2
               }
             ],

--- a/app/views/admin/reports/paths/show.html.erb
+++ b/app/views/admin/reports/paths/show.html.erb
@@ -64,8 +64,8 @@
                 {
                   label: 'Lesson completions',
                   data: @path_lesson_completions.map(&:count),
-                  borderColor: 'emerald-600',
-                  backgroundColor: 'emerald-200',
+                  borderColor: '#009966',
+                  backgroundColor: '#a4f4cf',
                   borderWidth: 1,
                   barThickness: 20,
                   borderRadius: 4

--- a/app/views/admin/reports/users/index.html.erb
+++ b/app/views/admin/reports/users/index.html.erb
@@ -38,8 +38,8 @@
                 label: 'Sign ups',
                 data: @sign_up_stats.values,
                 fill: true,
-                backgroundColor: 'blue-200',
-                borderColor: 'blue-600',
+                backgroundColor: '#bedbff',
+                borderColor: '#155dfc',
                 borderWidth: 2,
               }
             ],

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "browserslist": "^4.23.3",
     "chart.js": "^4.4.4",
     "chartjs-plugin-crosshair": "^2.0.0",
-    "chartjs-plugin-tailwindcss-colors": "^0.2.4",
     "chokidar": "^4.0.3",
     "debounce": "^2.2.0",
     "el-transition": "^0.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1776,20 +1776,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chartjs-plugin-tailwindcss-colors@npm:^0.2.4":
-  version: 0.2.4
-  resolution: "chartjs-plugin-tailwindcss-colors@npm:0.2.4"
-  dependencies:
-    color-name: "npm:^2.0.0"
-    lodash: "npm:^4.17.21"
-    tiny-invariant: "npm:^1.3.1"
-  peerDependencies:
-    chart.js: ^3.0.0
-    tailwindcss: ^3.0.0
-  checksum: 10c0/949762a47af51877cb8fe68c6d0dd4732be5acfad26e83c1a06075bf75006425ce80e9abac1e79e644a0099f0a521b460824de1d708111b046e9ec53ffedf665
-  languageName: node
-  linkType: hard
-
 "chevrotain-allstar@npm:~0.3.0":
   version: 0.3.1
   resolution: "chevrotain-allstar@npm:0.3.1"
@@ -1879,13 +1865,6 @@ __metadata:
   version: 1.1.3
   resolution: "color-name@npm:1.1.3"
   checksum: 10c0/566a3d42cca25b9b3cd5528cd7754b8e89c0eb646b7f214e8e2eaddb69994ac5f0557d9c175eb5d8f0ad73531140d9c47525085ee752a91a2ab15ab459caf6d6
-  languageName: node
-  linkType: hard
-
-"color-name@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "color-name@npm:2.0.0"
-  checksum: 10c0/fc0304606e5c5941f4649a9975c03a2ecd52a22aba3dadb3309b3e4ee61d78c3e13ff245e80b9a930955d38c5f32a9004196a7456c4542822aa1fcfea8e928ed
   languageName: node
   linkType: hard
 
@@ -4659,13 +4638,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.21":
-  version: 4.17.21
-  resolution: "lodash@npm:4.17.21"
-  checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
-  languageName: node
-  linkType: hard
-
 "loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
@@ -5828,7 +5800,6 @@ __metadata:
     browserslist: "npm:^4.23.3"
     chart.js: "npm:^4.4.4"
     chartjs-plugin-crosshair: "npm:^2.0.0"
-    chartjs-plugin-tailwindcss-colors: "npm:^0.2.4"
     chokidar: "npm:^4.0.3"
     debounce: "npm:^2.2.0"
     el-transition: "npm:^0.0.7"
@@ -6446,13 +6417,6 @@ __metadata:
   dependencies:
     any-promise: "npm:^1.0.0"
   checksum: 10c0/f375aeb2b05c100a456a30bc3ed07ef03a39cbdefe02e0403fb714b8c7e57eeaad1a2f5c4ecfb9ce554ce3db9c2b024eba144843cd9e344566d9fcee73b04767
-  languageName: node
-  linkType: hard
-
-"tiny-invariant@npm:^1.3.1":
-  version: 1.3.3
-  resolution: "tiny-invariant@npm:1.3.3"
-  checksum: 10c0/65af4a07324b591a059b35269cd696aba21bef2107f29b9f5894d83cc143159a204b299553435b03874ebb5b94d019afa8b8eff241c8a4cfee95872c2e1c1c4a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Because:
- We're not using enough of it's features to justify the extra dependencies.
- It's preventing us from upgrading to Tailwind 4
