### PR TITLE
Chore: Simplify progress circle implementation.

### DIFF
--- a/app/components/progress_circle/component.html.erb
+++ b/app/components/progress_circle/component.html.erb
@@ -1,24 +1,34 @@
 
   <div
     data-controller="progress"
-    data-progress-circumference-value="<%= circumference %>"
     data-progress-percent-value="<%= percentage %>"
     data-test-id='progress-circle'
     class="inline-flex items-center justify-center group <%= yass(container_size: size) %>">
-    <svg height="100%" width="100%" class="overflow-visible z-20 transform-gpu origin-center -rotate-90" viewBox="0 0 20 20">
-      <circle class="text-gray-200 dark:text-gray-400" stroke-width="1.3" stroke="currentColor" fill="none" r="9" cx="50%" cy="50%" />
+
+    <svg width="100%" height="100%" fill="none" class="overflow-visible z-20" viewBox="0 0 20 20">
       <circle
-        class="text-teal-700 dark:text-teal-600 transition-stroke-dashoffset ease-in duration-500"
+        class="text-gray-200 dark:text-gray-400"
+        cx="50%"
+        cy="50%"
+        r="calc(50% - 1px)"
+        stroke-width="1.3"
+        stroke="currentColor"
+        fill="none" />
+      <circle
+        class="text-teal-700 dark:text-teal-600 origin-center -rotate-90"
         data-progress-target="progressCircle"
+        cx="50%"
+        cy="50%"
+        r="calc(50% - 1px)"
         stroke-width="1.4"
-        stroke-linecap="round"
         stroke="currentColor"
         fill="transparent"
-        style="<%= "stroke-dasharray: #{circumference}, #{circumference}; stroke-dashoffset: #{circumference};" %>"
-        r="9"
-        cx="50%"
-        cy="50%" />
-    </svg>
+        stroke-dasharray="100 200"
+        stroke-dashoffset="<%= 100 - percentage %>"
+        stroke-linecap="round"
+        pathLength="100" />
+      </svg>
+
     <div class="z-10 absolute group-hover:opacity-0 rounded-full overflow-hidden <%= background_color %> <%= show_icon? %> <%= yass(icon: size) %>">
       <div class="<%= yass(icon_size: size) %>">
         <%= icon %>

--- a/app/components/progress_circle/component.rb
+++ b/app/components/progress_circle/component.rb
@@ -1,6 +1,4 @@
 class ProgressCircle::Component < ApplicationComponent
-  RADIUS = 9
-
   renders_one :icon
 
   def initialize(percentage: 0, options: {})
@@ -22,10 +20,6 @@ class ProgressCircle::Component < ApplicationComponent
 
   def background_color
     options.fetch(:background_color, 'bg-white dark:bg-gray-900')
-  end
-
-  def circumference
-    RADIUS * 2 * Math::PI
   end
 
   def show_icon?

--- a/app/javascript/controllers/progress_controller.js
+++ b/app/javascript/controllers/progress_controller.js
@@ -4,12 +4,14 @@ export default class ProgressController extends Controller {
   static targets = ['progressCircle']
 
   static values = {
-    percent: Number,
-    circumference: Number
+    percent: Number
   }
 
   connect () {
-    const offset = this.circumferenceValue - (this.percentValue / 100) * this.circumferenceValue
-    setTimeout(() => { this.progressCircleTarget.style.strokeDashoffset = offset }, 200)
+    const percentageRemaining = 100 - this.percentValue
+
+    if (this.progressCircleTarget.getAttribute('stroke-dashoffset') !== percentageRemaining) {
+      this.progressCircleTarget.setAttribute('stroke-dashoffset', percentageRemaining)
+    }
   }
 }


### PR DESCRIPTION
Because:
- We can use the pathLength attribute to simplify our progress circle implementation and avoid needing to calculate and pass around the circumference of the circle when updating the percentage.