### PR TITLE
Fix: flag actions dropdown spacing

### DIFF
--- a/app/components/flags/action_button_component.html.erb
+++ b/app/components/flags/action_button_component.html.erb
@@ -9,8 +9,8 @@
       <% end %>
 
       <ul data-controller="disable" data-visibility-target="content" class="absolute hidden right-0 z-10 mt-2 sm:w-[500px] origin-top-right divide-y divide-gray-200 overflow-hidden rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-hidden dark:bg-gray-800" tabindex="-1" role="listbox" aria-labelledby="listbox-label" aria-activedescendant="listbox-option-0">
-        <div class="divide-y divide-gray-200 dark:divide-gray-600 space-y-6">
-          <div class="space-y-4 px-4 pt-6">
+        <div class="flex flex-col divide-y divide-gray-200 dark:divide-gray-600">
+          <div class="space-y-4 px-4 py-6">
             <% Flags::Action.each do |flag_action| %>
               <div class="relative flex items-start">
                 <div class="absolute flex h-6 items-center">


### PR DESCRIPTION
Because:
- The latest version of Tailwind changes how the space utility works


