### PR TITLE
Feature: Remove 'Andale Mono' from code font stack for better readability

### DIFF
--- a/app/assets/stylesheets/custom_styles/prism-theme.css
+++ b/app/assets/stylesheets/custom_styles/prism-theme.css
@@ -1,7 +1,7 @@
 code[class*="language-"],
 pre[class*="language-"] {
   color: #ccc;
-  font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+  font-family: Consolas, Monaco, 'Ubuntu Mono', monospace;
   font-size: 1rem;
   text-align: left;
   white-space: pre;


### PR DESCRIPTION
## Because

At small font sizes, the design of the comma in 'Andale Mono' closely resembles a period. This can cause confusion, particularly for new learners trying to distinguish between , and . in code examples. Given The Odin Project’s educational focus, clarity and readability of code snippets are essential.

## This PR

- Removed `'Andale Mono'` from the font stack used for `<code>` and `<pre>` elements.

## Issue

N/A

## Additional Information

This change was made after noticing readability issues when viewing code blocks with small font sizes, where commas appeared nearly identical to periods when rendered in 'Andale Mono'. 

A related [issue](https://github.com/readthedocs/sphinx_rtd_theme/issues/524) is discussed on another project.

## Pull Request Requirements

-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [ ] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If applicable, this PR includes new or updated automated tests
