### PR TITLE
Feature: Return to first page when sorting

### DIFF
--- a/app/components/sort_component.html.erb
+++ b/app/components/sort_component.html.erb
@@ -20,7 +20,7 @@
 
       <% options.each do |option| %>
         <li class="text-gray-900 dark:text-gray-200 relative cursor-default select-none py-2 pl-8 pr-4" id="listbox-option-0" role="option">
-          <%= link_to request.params.merge(sort: option.fetch(:value), direction: option.fetch(:direction)), role: 'menuitem', tabindex: '-1' do %>
+          <%= link_to url_for(sort: option.fetch(:value), direction: option.fetch(:direction)), role: 'menuitem', tabindex: '-1' do %>
             <span class="font-normal text-sm block <%= 'font-semibold' if selected?(option) %>"><%= option.fetch(:label) %> </span>
           <% end %>
           <% if selected?(option) %>


### PR DESCRIPTION
Because:
- When I sort by newest or most liked, I want to be brought back to the first page and the top of the list, so I can actually see the most liked and newest submissions first.
- Closes https://github.com/TheOdinProject/theodinproject/issues/4347

This commit:
- Stops sending the current page param with the sort request.
