### PR TITLE
Chore: Use counter cache on Path model to get user count

### DIFF
--- a/app/views/admin/reports/users/index.html.erb
+++ b/app/views/admin/reports/users/index.html.erb
@@ -7,7 +7,7 @@
 
     <li class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 px-4 py-5 hover:border-gray-300 border border-gray-200 dark:border-gray-700 dark:hover:border-gray-600 sm:p-6">
       <dt class="truncate text-sm font-medium text-gray-500 dark:text-gray-300">Total users</dt>
-      <dd class="mt-1 text-2xl font-semibold tracking-tight text-gray-800 dark:text-gray-200"><%= number_with_delimiter(User.count) %></dd>
+      <dd class="mt-1 text-2xl font-semibold tracking-tight text-gray-800 dark:text-gray-200"><%= number_with_delimiter(Path.pluck(:users_count).sum) %></dd>
     </li>
 
     <li class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 px-4 py-5 hover:border-gray-300 border border-gray-200 dark:border-gray-700 dark:hover:border-gray-600 sm:p-6">

--- a/app/views/static_pages/about/_overview.html.erb
+++ b/app/views/static_pages/about/_overview.html.erb
@@ -5,7 +5,7 @@
     <div class="grid grid-cols-1 sm:grid-cols-3 gap-x-8 gap-y-16">
       <%= render CardComponent.new(classes: 'col-span-3 lg:col-span-1') do |card| %>
         <% card.with_body(classes: 'text-center') do %>
-          <p class="font-bold text-2xl"><%= number_with_delimiter(User.count) %></p>
+          <p class="font-bold text-2xl"><%= number_with_delimiter(Path.pluck(:users_count).sum) %></p>
           <p class="text-gray-500 dark:text-gray-400">Learners</p>
         <% end %>
       <% end %>


### PR DESCRIPTION
Because:
Counting 1.5 million+ rows with a raw count is slow. While the query isn't in a particularly hot path, it's an easy optimization to leverage the existing user counter cache on the path model.

Outside of the material views (which are fine since they run in  background jobs) this is the slowest query on the site.

![image](https://github.com/user-attachments/assets/7d950e19-4fb0-4730-819b-3fa3e41b52ff)
![image](https://github.com/user-attachments/assets/8ccf0c04-5e13-423e-bbb5-c0cbfbce096d)


A short benchmark (NB with 22,000 records, only a fraction of actual prod records)

```
=== Pre check ===
User Count: 22256
Path Count: 22256
Path Count with pluck: 22256
Path Count with select: 22256

=== Benchmarking ===
ruby 3.4.2 (2025-02-15 revision d2930f8e7a) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
          User Count    36.000 i/100ms
          Path Count   797.000 i/100ms
 Path Count w/ pluck   846.000 i/100ms
Path Count w/ select   738.000 i/100ms
Calculating -------------------------------------
          User Count    272.277 (±39.7%) i/s    (3.67 ms/i) -    130.284k in 500.032090s
          Path Count      7.978k (± 2.7%) i/s  (125.34 μs/i) -      3.983M in 500.009255s
 Path Count w/ pluck      8.487k (± 2.6%) i/s  (117.83 μs/i) -      4.237M in 499.998475s
Path Count w/ select      7.353k (± 2.9%) i/s  (136.01 μs/i) -      3.670M in 500.048024s

Comparison:
 Path Count w/ pluck:     8486.8 i/s
          Path Count:     7978.0 i/s - 1.06x  slower
Path Count w/ select:     7352.6 i/s - 1.15x  slower
          User Count:      272.3 i/s - 31.17x  slower
```

<details>
<summary>Benchmark code</summary>

```rb
require 'benchmark/ips'

User.uncached do
  Path.uncached do
    puts '=== Pre check ==='
    puts "User Count: #{User.count}"
    puts "Path Count: #{Path.all.sum(:users_count)}"
    puts "Path Count with pluck: #{Path.pluck(:users_count).sum}"
    puts "Path Count with select: #{Path.select(:users_count).sum(&:users_count)}"

    puts "\n=== Benchmarking ===\n"
      Benchmark.ips do |x|
      x.config(time: 500, warmup: 10)

      x.report('User Count') do
        User.count
      end

      x.report('Path Count') do
        Path.all.sum(:users_count)
      end

      x.report('Path Count w/ pluck') do
        Path.pluck(:users_count).sum
      end

      x.report('Path Count w/ select') do
        Path.select(:users_count).sum(&:users_count)
      end

      x.compare!
    end
  end
end
```
</details>

I would expect actual impact to be significant higher in prod. 

