### PR TITLE
Feature: Add reminder and link about expectations to community solutions page

### DIFF
--- a/app/views/lessons/project_submissions/index.html.erb
+++ b/app/views/lessons/project_submissions/index.html.erb
@@ -10,7 +10,6 @@
 
   <%= turbo_frame_tag 'submissions-list', data: { test_id: 'submissions-list', turbo_action: :advance } do %>
     <div class="mb-4 text-left">
-
       <header class="flex flex-col space-y-6 justify-between items-center text-center md:space-y-0 md:text-left md:flex-row">
         <div class="flex md:flex-start flex-col space-y-1">
           <h3 class="text-3xl font-medium text-gray-900 dark:text-gray-200" id="solutions"><%= @lesson.display_title %> solutions</h3>
@@ -22,16 +21,16 @@
       </header>
 
       <div class="py-4 flex justify-end">
-          <div class="w-64">
-            <%= render SortComponent.new(
-                  selected: { value: params[:sort], direction: params[:direction] },
-                  options: [
-                    { value: 'created_at', label: 'Newest', direction: 'desc', default: true },
-                    { value: 'created_at', label: 'Oldest', direction: 'asc', default: false },
-                    { value: 'likes_count', label: 'Most liked', direction: 'desc', default: false }
-                  ]
-                ) %>
-          </div>
+        <div class="w-64">
+          <%= render SortComponent.new(
+            selected: { value: params[:sort], direction: params[:direction] },
+            options: [
+              { value: 'created_at', label: 'Newest', direction: 'desc', default: true },
+              { value: 'created_at', label: 'Oldest', direction: 'asc', default: false },
+              { value: 'likes_count', label: 'Most liked', direction: 'desc', default: false }
+            ]
+          ) %>
+        </div>
       </div>
 
       <%= render CardComponent.new do |card| %>
@@ -49,10 +48,10 @@
               <div class="text-center">
                 <%= inline_svg_tag 'icons/folder-plus.svg', class: 'mx-auto h-12 w-12 text-gray-400 dark:text-gray-500', aria: true, title: 'No solutions', desc: 'No solutions icon' %>
 
-              <h3 class="mt-2 text-xl font-semibold text-gray-900 dark:text-gray-200">No solutions</h3>
-              <%= link_to "Return to #{@lesson.display_title}", lesson_path(@lesson, anchor: 'project-solution'), class: 'block mt-2 text-sm underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300', data: { turbo_frame: '_top'} %>
+                <h3 class="mt-2 text-xl font-semibold text-gray-900 dark:text-gray-200">No solutions</h3>
+                <%= link_to "Return to #{@lesson.display_title}", lesson_path(@lesson, anchor: 'project-solution'), class: 'block mt-2 text-sm underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300', data: { turbo_frame: '_top'} %>
+              </div>
             </div>
-          </div>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/lessons/project_submissions/index.html.erb
+++ b/app/views/lessons/project_submissions/index.html.erb
@@ -20,6 +20,10 @@
         </div>
       </header>
 
+      <p class="prose prose-a:text-blue-800 prose-a:visited:text-purple-800 mx-auto text-center my-4 md:mx-0 md:text-left md:max-w-5/6 dark:prose-a:text-blue-300 dark:prose-a:visited:text-purple-300 dark:prose-invert">
+        Remember that <a href="https://www.theodinproject.com/lessons/foundations-recipes#project-submissions-and-reasonable-expectations" target="_blank" rel="noopener noreferrer">community submissions may not fully reflect the project specification</a> and sometimes may look or behave in ways beyond what is expected of you at this point. It is important to remember that the goal is to meet the project specification, not to match any community submissions.
+      </p>
+
       <div class="py-4 flex justify-end">
         <div class="w-64">
           <%= render SortComponent.new(

--- a/app/views/lessons/project_submissions/index.html.erb
+++ b/app/views/lessons/project_submissions/index.html.erb
@@ -22,7 +22,7 @@
       </header>
 
       <p class="prose prose-a:text-blue-800 prose-a:visited:text-purple-800 mx-auto text-center my-4 md:mx-0 md:text-left md:max-w-5/6 dark:prose-a:text-blue-300 dark:prose-a:visited:text-purple-300 dark:prose-invert">
-        Remember that <%= link_to "community submissions may not fully reflect the project specification", "/lessons/foundations-recipes#project-submissions-and-reasonable-expectations", target: "_blank", rel: "noopener noreferrer" %> and sometimes may look or behave in ways beyond what is expected of you at this point. It is important to remember that the goal is to meet the project specification, not to match any community submissions.
+        Remember that <%= link_to 'community submissions may not fully reflect the project specification', '/lessons/foundations-recipes#project-submissions-and-reasonable-expectations', target: '_blank', rel: 'noopener noreferrer' %> and sometimes may look or behave in ways beyond what is expected of you at this point. It is important to remember that the goal is to meet the project specification, not to match any community submissions.
       </p>
 
       <div class="py-4 flex justify-end">

--- a/app/views/lessons/project_submissions/index.html.erb
+++ b/app/views/lessons/project_submissions/index.html.erb
@@ -10,6 +10,7 @@
 
   <%= turbo_frame_tag 'submissions-list', data: { test_id: 'submissions-list', turbo_action: :advance } do %>
     <div class="mb-4 text-left">
+
       <header class="flex flex-col space-y-6 justify-between items-center text-center md:space-y-0 md:text-left md:flex-row">
         <div class="flex md:flex-start flex-col space-y-1">
           <h3 class="text-3xl font-medium text-gray-900 dark:text-gray-200" id="solutions"><%= @lesson.display_title %> solutions</h3>
@@ -25,16 +26,16 @@
       </p>
 
       <div class="py-4 flex justify-end">
-        <div class="w-64">
-          <%= render SortComponent.new(
-            selected: { value: params[:sort], direction: params[:direction] },
-            options: [
-              { value: 'created_at', label: 'Newest', direction: 'desc', default: true },
-              { value: 'created_at', label: 'Oldest', direction: 'asc', default: false },
-              { value: 'likes_count', label: 'Most liked', direction: 'desc', default: false }
-            ]
-          ) %>
-        </div>
+          <div class="w-64">
+            <%= render SortComponent.new(
+                  selected: { value: params[:sort], direction: params[:direction] },
+                  options: [
+                    { value: 'created_at', label: 'Newest', direction: 'desc', default: true },
+                    { value: 'created_at', label: 'Oldest', direction: 'asc', default: false },
+                    { value: 'likes_count', label: 'Most liked', direction: 'desc', default: false }
+                  ]
+                ) %>
+          </div>
       </div>
 
       <%= render CardComponent.new do |card| %>
@@ -52,10 +53,10 @@
               <div class="text-center">
                 <%= inline_svg_tag 'icons/folder-plus.svg', class: 'mx-auto h-12 w-12 text-gray-400 dark:text-gray-500', aria: true, title: 'No solutions', desc: 'No solutions icon' %>
 
-                <h3 class="mt-2 text-xl font-semibold text-gray-900 dark:text-gray-200">No solutions</h3>
-                <%= link_to "Return to #{@lesson.display_title}", lesson_path(@lesson, anchor: 'project-solution'), class: 'block mt-2 text-sm underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300', data: { turbo_frame: '_top'} %>
-              </div>
+              <h3 class="mt-2 text-xl font-semibold text-gray-900 dark:text-gray-200">No solutions</h3>
+              <%= link_to "Return to #{@lesson.display_title}", lesson_path(@lesson, anchor: 'project-solution'), class: 'block mt-2 text-sm underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300', data: { turbo_frame: '_top'} %>
             </div>
+          </div>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/lessons/project_submissions/index.html.erb
+++ b/app/views/lessons/project_submissions/index.html.erb
@@ -22,7 +22,7 @@
       </header>
 
       <p class="prose prose-a:text-blue-800 prose-a:visited:text-purple-800 mx-auto text-center my-4 md:mx-0 md:text-left md:max-w-5/6 dark:prose-a:text-blue-300 dark:prose-a:visited:text-purple-300 dark:prose-invert">
-        Remember that <a href="https://www.theodinproject.com/lessons/foundations-recipes#project-submissions-and-reasonable-expectations" target="_blank" rel="noopener noreferrer">community submissions may not fully reflect the project specification</a> and sometimes may look or behave in ways beyond what is expected of you at this point. It is important to remember that the goal is to meet the project specification, not to match any community submissions.
+        Remember that <%= link_to "community submissions may not fully reflect the project specification", "/lessons/foundations-recipes#project-submissions-and-reasonable-expectations", target: "_blank", rel: "noopener noreferrer" %> and sometimes may look or behave in ways beyond what is expected of you at this point. It is important to remember that the goal is to meet the project specification, not to match any community submissions.
       </p>
 
       <div class="py-4 flex justify-end">


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
We have a great note about expectations from community solutions and advanced/out-of-scope features in the Recipes project. The community solutions component would benefit from a reminder about this and link to that Recipes project note. https://github.com/TheOdinProject/theodinproject/discussions/5037#discussioncomment-13757690

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Adds reminder about project expectations to community solutions component

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
N/A

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
