### PR TITLE
Chore: Update encryption settings for ActiveRecord

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -25,5 +25,6 @@ module Theodinproject
     config.middleware.insert_after ActionDispatch::Static, Rack::Deflater
     config.assets.css_compressor = nil
     config.active_job.queue_adapter = :sidekiq
+    config.active_record.encryption.support_sha1_for_non_deterministic_encryption = true
   end
 end


### PR DESCRIPTION
Because: There was a backwards compatibility issue with the new defaults in 7.1