### PR TITLE
Fix: Swap Theme Icons

### DIFF
--- a/app/models/users/theme.rb
+++ b/app/models/users/theme.rb
@@ -3,8 +3,8 @@ module Users
     include Comparable
 
     DEFAULT_THEMES = [
-      %w[light sun],
-      %w[dark moon]
+      %w[light moon],
+      %w[dark sun]
     ].freeze
 
     def self.default_themes

--- a/spec/models/users/theme_spec.rb
+++ b/spec/models/users/theme_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe Users::Theme do
   describe '.default_themes' do
     it 'returns the default themes' do
       expect(described_class.default_themes).to contain_exactly(
-        an_object_having_attributes(name: 'light', icon: 'sun'),
-        an_object_having_attributes(name: 'dark', icon: 'moon')
+        an_object_having_attributes(name: 'light', icon: 'moon'),
+        an_object_having_attributes(name: 'dark', icon: 'sun')
       )
     end
   end
@@ -26,26 +26,26 @@ RSpec.describe Users::Theme do
 
   describe '.for' do
     it 'returns the theme for the given name' do
-      expect(described_class.for('dark')).to have_attributes(name: 'dark', icon: 'moon')
+      expect(described_class.for('dark')).to have_attributes(name: 'dark', icon: 'sun')
     end
   end
 
   describe '#to_s' do
     it 'returns the theme name' do
-      expect(described_class.new(name: 'light', icon: 'sun').to_s).to eq('light')
+      expect(described_class.new(name: 'light', icon: 'moon').to_s).to eq('light')
     end
   end
 
   describe '#dark_mode?' do
     context 'when the theme is dark' do
       it 'returns true' do
-        expect(described_class.new(name: 'dark', icon: 'moon')).to be_dark_mode
+        expect(described_class.new(name: 'dark', icon: 'sun')).to be_dark_mode
       end
     end
 
     context 'when the theme is light' do
       it 'returns false' do
-        expect(described_class.new(name: 'light', icon: 'sun')).not_to be_dark_mode
+        expect(described_class.new(name: 'light', icon: 'moon')).not_to be_dark_mode
       end
     end
   end


### PR DESCRIPTION
## Because
This PR modifies the displayed icon seen within the nav bar of the website, displaying the moon icon while in light mode, and the sun icon while in dark mode.

## This PR
- In order to swap the displayed icon, theme.rb was modified to replace instances of "sun" with "moon" and vice versa. 
- Corresponding tests within Theme_spec.rb were modified in light of these changes. 

## Issue
Closes #5056

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
