### PR TITLE
adding_mail_service_while_siging_up_through_google_and_github_auth

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -21,7 +21,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   private
   def send_welcome_email
-    return unless  @user&.persisted? && @user.sign_in_count == 1 && ENV['STAGING'].nil?
+    return unless @user&.persisted? && @user.sign_in_count == 1 && ENV['STAGING'].nil?
 
     UserMailer.send_welcome_email_to(@user).deliver_now
   end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,4 +1,5 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  after_action :send_welcome_email, only: [:github, :google]
   def github
     @user = UserProvider.find_user(auth)
 
@@ -19,7 +20,11 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   private
+  def send_welcome_email
+    return unless  @user&.persisted? && @user.sign_in_count == 1 && ENV['STAGING'].nil?
 
+    UserMailer.send_welcome_email_to(@user).deliver_now
+  end
   def update_users_avatar
     @user.update!(avatar: avatar_from_provider)
   end


### PR DESCRIPTION
In odin project the welcome mail is trigged only when user sign up through devise but when user sign up through google or github auth this welcome_email is not triggred so i try to resolve this issue by creating an after_Action method in omni_auth_controller see my changes and review this.according to me this will be an additional functionality in this website