### PR TITLE
Fix: CI sometimes failing due to secret_key_base type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Prevent https://github.com/rails/rails/issues/53661
+        run: touch tmp/local_secret.txt && openssl rand -hex 64 > tmp/local_secret.txt
+
       - name: Setup Ruby and install gems
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
Because:
- A change introduced in Rails 7.2 triggered this.
- It's a race condition with generating the file that holds the secret key base in a multi-process environment such as our CI.

This commit:
- If the file is created ahead of time, it should be read from by all processes.
- We should hopefully be able to get rid of this at some point down the line.
