### PR TITLE
Chore: Migrate progress circle component to class variants

### DIFF
--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -1,4 +1,16 @@
 class ApplicationComponent < ViewComponent::Base
   include Classy::Yaml::ComponentHelpers
   include Turbo::FramesHelper
+
+  class << self
+    attr_reader :class_variants
+
+    def style(&)
+      @class_variants = ClassVariants.build(&)
+    end
+  end
+
+  def classes_for(slot)
+    self.class.class_variants.render(slot, type: variant)
+  end
 end

--- a/app/components/course/badge_component.html.erb
+++ b/app/components/course/badge_component.html.erb
@@ -6,7 +6,7 @@
   <% end %>
 <% else %>
   <%= link_to path_course_path(course.path, course) do %>
-    <div class="shadow-md dark:shadow-none rounded-full flex <%= yass(default_badge: size) %>" data-test-id='default-badge'>
+    <div class="shadow-md dark:shadow-none rounded-full flex <%= classes_for(:default_badge) %>" data-test-id='default-badge'>
       <%= image_tag badge, alt: course.title, class: 'p-2.5' %>
     </div>
   <% end %>

--- a/app/components/course/badge_component.rb
+++ b/app/components/course/badge_component.rb
@@ -1,6 +1,16 @@
 class Course::BadgeComponent < ApplicationComponent
   delegate :user_signed_in?, to: :helpers
 
+  style do
+    variant type: :default do
+      slot :default_badge, class: 'w-24 h-24 sm:w-28 sm:h-28'
+    end
+
+    variant type: :small do
+      slot :default_badge, class: 'w-24 h-24'
+    end
+  end
+
   def initialize(course:, options: {})
     @course = course
     @options = options
@@ -26,6 +36,10 @@ class Course::BadgeComponent < ApplicationComponent
 
   def size
     options[:size] || :default
+  end
+
+  def variant
+    size
   end
 
   def option_params

--- a/app/components/course/badge_component.yml
+++ b/app/components/course/badge_component.yml
@@ -1,3 +1,0 @@
-default_badge:
-  default: 'w-24 h-24 sm:w-28 sm:h-28'
-  small: 'w-24 h-24'

--- a/app/components/overlays/flash_component.html.erb
+++ b/app/components/overlays/flash_component.html.erb
@@ -1,15 +1,15 @@
-<div class="rounded-md p-4 mb-4 shadow <%= classes(:bg) %>" data-controller="flash" data-test-id="flash">
+<div class="rounded-md p-4 mb-4 shadow <%= classes_for(:bg) %>" data-controller="flash" data-test-id="flash">
   <div class="flex items-center">
     <div class="shrink-0">
-       <%= inline_svg_tag icon_path, class: "h-5 w-5 #{classes(:icon)}", aria: true, title: 'Icon', desc: "#{type} icon" %>
+       <%= inline_svg_tag icon_path, class: "h-5 w-5 #{classes_for(:icon)}", aria: true, title: 'Icon', desc: "#{type} icon" %>
     </div>
     <div class="ml-3">
-      <span class="block text-sm font-medium <%= classes(:text) %>"><%= message %></span>
+      <span class="block text-sm font-medium <%= classes_for(:text) %>"><%= message %></span>
     </div>
 
     <div class="ml-auto pl-3">
       <div class="-mx-1.5 -my-1.5">
-        <button type="button" class="inline-flex rounded-md p-1.5 focus:outline-hidden focus:ring-2 focus:ring-offset-2 <%= classes(:button) %>" data-action="click->flash#dismiss">
+        <button type="button" class="inline-flex rounded-md p-1.5 focus:outline-hidden focus:ring-2 focus:ring-offset-2 <%= classes_for(:button) %>" data-action="click->flash#dismiss">
           <span class="sr-only">Dismiss</span>
            <%= inline_svg_tag 'icons/x-mark.svg', class: 'h-5 w-5', aria: true, title: 'Dismiss icon', desc: 'Dismiss button icon' %>
         </button>

--- a/app/components/overlays/flash_component.rb
+++ b/app/components/overlays/flash_component.rb
@@ -1,7 +1,7 @@
 class Overlays::FlashComponent < ApplicationComponent
-  DISSALLOWED_TYPES = %i[timedout].freeze
+  DISALLOWED_TYPES = %i[timedout].freeze
 
-  FLASH_CLASSES = ClassVariants.build do
+  style do
     variant type: :notice do
       slot :bg, class: 'bg-green-100'
       slot :icon, class: 'text-green-700'
@@ -24,7 +24,7 @@ class Overlays::FlashComponent < ApplicationComponent
   end
 
   def render?
-    DISSALLOWED_TYPES.exclude?(type)
+    DISALLOWED_TYPES.exclude?(type)
   end
 
   def icon_path
@@ -34,8 +34,8 @@ class Overlays::FlashComponent < ApplicationComponent
     }.fetch(type)
   end
 
-  def classes(slot)
-    FLASH_CLASSES.render(slot, type: type)
+  def variant
+    type
   end
 
   private

--- a/app/components/progress_circle/component.html.erb
+++ b/app/components/progress_circle/component.html.erb
@@ -3,7 +3,7 @@
     data-controller="progress"
     data-progress-percent-value="<%= percentage %>"
     data-test-id='progress-circle'
-    class="inline-flex items-center justify-center group <%= yass(container_size: size) %>">
+    class="inline-flex items-center justify-center group <%= classes_for(:container_size) %>">
 
     <svg width="100%" height="100%" fill="none" class="overflow-visible z-20" viewBox="0 0 20 20">
       <circle
@@ -29,13 +29,13 @@
         pathLength="100" />
       </svg>
 
-    <div class="z-10 absolute group-hover:opacity-0 rounded-full overflow-hidden <%= background_color %> <%= show_icon_class %> <%= yass(icon: size) %>">
-      <div class="<%= yass(icon_size: size) %>">
+    <div class="z-10 absolute group-hover:opacity-0 rounded-full overflow-hidden <%= background_color %> <%= show_icon_class %>">
+      <div class="<%= classes_for(:icon_size) %>">
         <%= icon %>
       </div>
     </div>
     <span class="absolute">
-      <span class="block transition-opacity delay-200 duration-500 ease-in-out text-gray-400 leading-5 break-words w-16 sm:w-20 text-center font-medium <%= yass(text: size) %>">
+      <span class="block transition-opacity delay-200 duration-500 ease-in-out text-gray-400 leading-5 break-words w-16 sm:w-20 text-center font-medium <%= classes_for(:text) %>">
         <%= number_to_percentage(percentage, precision: 0) %> <span class="hidden sm:block">Complete</span>
       </span>
     </span>

--- a/app/components/progress_circle/component.rb
+++ b/app/components/progress_circle/component.rb
@@ -1,9 +1,27 @@
 class ProgressCircle::Component < ApplicationComponent
   renders_one :icon
 
+  style do
+    variant type: :default do
+      slot :text, class: 'text-xs sm:text-sm'
+      slot :container_size, class: 'h-24 w-24 sm:h-28 sm:w-28'
+      slot :icon_size, class: 'w-20 h-20 sm:p-2 sm:w-24 sm:h-24'
+    end
+
+    variant type: :small do
+      slot :text, class: 'text-xs p-2'
+      slot :container_size, class: 'h-24 w-24'
+      slot :icon_size, class: 'w-24 h-24 p-3'
+    end
+  end
+
   def initialize(percentage: 0, options: {})
     @percentage = percentage
     @options = options
+  end
+
+  def variant
+    size
   end
 
   private

--- a/app/components/progress_circle/component.yml
+++ b/app/components/progress_circle/component.yml
@@ -1,9 +1,0 @@
-text:
-  default: 'text-xs sm:text-sm'
-  small: 'text-xs p-2'
-container_size:
-  default: 'h-24 w-24 sm:h-28 sm:w-28'
-  small: 'h-24 w-24'
-icon_size:
-  default: 'w-20 h-20 sm:p-2 sm:w-24 sm:h-24'
-  small: 'w-24 h-24 p-3'

--- a/app/components/progress_circle/loading_component.html.erb
+++ b/app/components/progress_circle/loading_component.html.erb
@@ -1,4 +1,4 @@
-<div data-test-id='loading-progress-circle' class="inline-flex items-center justify-center group <%= yass(container_size: size) %>">
+<div data-test-id='loading-progress-circle' class="inline-flex items-center justify-center group <%= classes_for(:container_size) %>">
   <svg height="100%" width="100%" class="overflow-visible z-30 transform-gpu origin-center -rotate-90" viewBox="0 0 20 20">
     <circle class="text-gray-200 dark:text-gray-400" stroke-width="1.3" stroke="currentColor" fill="none" r="9" cx="50%" cy="50%" />
   </svg>

--- a/app/components/progress_circle/loading_component.rb
+++ b/app/components/progress_circle/loading_component.rb
@@ -1,6 +1,20 @@
 class ProgressCircle::LoadingComponent < ApplicationComponent
+  style do
+    variant type: :default do
+      slot :container_size, class: 'h-24 w-24 sm:h-28 sm:w-28'
+    end
+
+    variant type: :small do
+      slot :container_size, class: 'h-24 w-24'
+    end
+  end
+
   def initialize(size: :default)
     @size = size
+  end
+
+  def variant
+    size
   end
 
   private

--- a/app/components/progress_circle/loading_component.yml
+++ b/app/components/progress_circle/loading_component.yml
@@ -1,3 +1,0 @@
-container_size:
-  default: 'h-24 w-24 sm:h-28 sm:w-28'
-  small: 'h-24 w-24'


### PR DESCRIPTION
Because:
- We previously used classy-yaml for style variants, but it is unmaintained and  incompatible with the latest versions of ViewComponents.
- Closes: https://github.com/TheOdinProject/theodinproject/issues/5096

This commit:
- Improves the DSL of class variants in components by allowing them to be declared within a block that will not run up against our linting line length rules.
- Adds a shared classes_for method to the application component to allow easy fetching of classes in all of our components.
- Migrates progress circle styles to class variants.
