### PR TITLE
Chore: Migrate vertical navigation item component styles to class variants

### DIFF
--- a/app/components/vertical_navigation/item_component.html.erb
+++ b/app/components/vertical_navigation/item_component.html.erb
@@ -1,4 +1,4 @@
-<%= link_to href, class: "#{yass(link: status)} group rounded-md px-3 py-2 flex items-center text-sm font-medium" do %>
-  <%= inline_svg_tag "icons/#{icon_path}", class: "#{yass(icon: status)} shrink-0 -ml-1 mr-3 h-6 w-6", aria: true, title: "#{name} icon" %>
+<%= link_to href, class: "#{classes_for(:link)} group rounded-md px-3 py-2 flex items-center text-sm font-medium" do %>
+  <%= inline_svg_tag "icons/#{icon_path}", class: "#{classes_for(:icon)} shrink-0 -ml-1 mr-3 h-6 w-6", aria: true, title: "#{name} icon" %>
   <span class="truncate"> <%= name %> </span>
 <% end %>

--- a/app/components/vertical_navigation/item_component.rb
+++ b/app/components/vertical_navigation/item_component.rb
@@ -1,4 +1,17 @@
 class VerticalNavigation::ItemComponent < ApplicationComponent
+  style do
+    variant type: :active do
+      slot :link, class: 'bg-gray-200 text-gray-900 dark:bg-gray-700/50 dark:text-gray-300'
+      slot :icon, class: 'text-gray-500 group-hover:text-gray-700 dark:text-gray-300 dark:group-hover:text-gray-300'
+    end
+
+    variant type: :inactive do
+      slot :link,
+           class: 'text-gray-600 hover:bg-gray-50 hover:text-gray-900 dark:hover:bg-gray-600/70 dark:hover:text-gray-300 dark:text-gray-400' # rubocop:disable Layout/LineLength
+      slot :icon, class: 'text-gray-400 group-hover:text-gray-500 dark:text-gray-400 dark:group-hover:text-gray-300'
+    end
+  end
+
   def initialize(name:, href:, icon_path:)
     @name = name
     @href = href
@@ -7,6 +20,10 @@ class VerticalNavigation::ItemComponent < ApplicationComponent
 
   def status
     current_page?(href) ? :active : :inactive
+  end
+
+  def variant
+    status
   end
 
   private

--- a/app/components/vertical_navigation/item_component.yml
+++ b/app/components/vertical_navigation/item_component.yml
@@ -1,6 +1,0 @@
-link:
-  active: 'bg-gray-200 text-gray-900 dark:bg-gray-700/50 dark:text-gray-300'
-  inactive: 'text-gray-600 hover:bg-gray-50 hover:text-gray-900 dark:hover:bg-gray-600/70 dark:hover:text-gray-300 dark:text-gray-400'
-icon:
-  active: 'text-gray-500 group-hover:text-gray-700 dark:text-gray-300 dark:group-hover:text-gray-300'
-  inactive: 'text-gray-400 group-hover:text-gray-500 dark:text-gray-400 dark:group-hover:text-gray-300'


### PR DESCRIPTION
Because:
- We previously used classy-yaml for style variants, but it is unmaintained and incompatible with the latest versions of ViewComponents.
- Closes https://github.com/TheOdinProject/theodinproject/issues/5098

This commit:
- Migrates vertical navigation item styles to class variants.