### PR TITLE
Chore: Bump ViewComponents Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ gem 'sidekiq-cron', '~> 2.3'
 gem 'stackprof', '~> 0.2'
 gem 'stimulus-rails', '~> 1.3'
 gem 'turbo-rails', '~> 2.0'
-gem 'view_component', '~> 3.16'
+gem 'view_component', '~> 4.0'
 
 # https://github.com/jamesmartin/inline_svg/issues/151
 gem 'inline_svg', '~> 1.10'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,7 +286,6 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
-    method_source (1.1.0)
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2024.0806)
@@ -587,10 +586,9 @@ GEM
     vcr (6.3.1)
       base64
     version_gem (1.1.4)
-    view_component (3.16.0)
-      activesupport (>= 5.2.0, < 8.0)
-      concurrent-ruby (~> 1.0)
-      method_source (~> 1.0)
+    view_component (4.0.2)
+      activesupport (>= 7.1.0, < 8.1)
+      concurrent-ruby (~> 1)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.1)
@@ -690,7 +688,7 @@ DEPENDENCIES
   stimulus-rails (~> 1.3)
   turbo-rails (~> 2.0)
   vcr (~> 6.3)
-  view_component (~> 3.16)
+  view_component (~> 4.0)
   web-console (~> 4.2)
   webmock (~> 3.25)
 

--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -1,6 +1,8 @@
 class ApplicationComponent < ViewComponent::Base
   include Turbo::FramesHelper
 
+  delegate :inline_svg_tag, :inline_svg, to: :helpers
+
   class << self
     attr_reader :class_variants
 


### PR DESCRIPTION
Because:
- We were a major version behind.
- The upgrade is possible now with the removal of the classy_yaml gem.
