### PR TITLE
Feature: Center lesson content

### DIFF
--- a/app/views/lessons/_header.html.erb
+++ b/app/views/lessons/_header.html.erb
@@ -1,5 +1,5 @@
-<header class="mb-16 grid grid-cols-12">
-  <div class="flex space-y-4 items-center flex-col col-span-full justify-center xl:space-y-0 xl:space-x-4 xl:flex-row xl:justify-start xl:col-start-2">
+<header class="mb-16">
+  <div class="flex space-y-4 items-center flex-col justify-center xl:space-y-0 xl:space-x-4 xl:flex-row xl:justify-start">
     <%= render Course::BadgeComponent.new(course: lesson.course, options: {show_badge: true }) %>
 
     <div class="text-center xl:text-left">

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -1,51 +1,56 @@
 <%= title(@lesson.display_title) %>
 
 <div class="bg-white dark:bg-gray-900">
-  <div class="page-container pb-10">
+  <div class="py-10 px-4 sm:py-14 sm:px-6 lg:px-8">
+    <div class="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8 xl:grid xl:grid-cols-[1fr_minmax(0,65ch)_1fr] xl:gap-x-10">
 
-    <%= render 'lessons/header', lesson: @lesson %>
+      <div class="xl:col-start-2">
+        <%= render 'lessons/header', lesson: @lesson %>
+      </div>
 
-    <main class="grid grid-cols-12 gap-x-6" data-controller="lesson-toc diagramming" data-lesson-toc-item-classes-value="no-underline hover:text-gray-800 text-sm dark:hover:text-gray-300">
-      <article class="col-span-full xl:col-span-7 xl:col-start-2 xl:max-w-prose">
-        <%= render ContentContainerComponent.new(classes: 'xl:mx-0 pb-6', data_attributes: { lesson_toc_target: 'lessonContent' }) do |component| %>
-          <%= @lesson.body.html_safe %>
+      <main class="xl:contents" data-controller="lesson-toc diagramming" data-lesson-toc-item-classes-value="no-underline hover:text-gray-800 text-sm dark:hover:text-gray-300">
 
-          <% component.with_footer do %>
-            <%= link_to github_edit_url(@lesson), target: :_blank, rel: 'noreferrer noopener', class: 'text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 pr-5 text-sm' do %>
-              <%= inline_svg_tag 'icons/github.svg', class: 'h-4 w-4 mr-1 inline', aria: true, title: 'Improve on GitHub', desc: 'Github logo icon' %>
-              <span class="underline hover:no-underline">Improve on GitHub</span>
-            <% end %>
+        <article class="mx-auto xl:col-start-2 xl:max-w-none">
+          <%= render ContentContainerComponent.new(classes: 'xl:mx-0 pb-6', data_attributes: { lesson_toc_target: 'lessonContent' }) do |component| %>
+            <%= @lesson.body.html_safe %>
 
-            <%= link_to github_report_url(@lesson), target: :_blank, rel: 'noreferrer noopener', class: 'inline-flex items-center underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 pr-5 text-sm' do %>
-              <%= inline_svg_tag 'icons/flag.svg', class: 'h-4 w-4 mr-1 inline', aria: true, title: 'Report an issue', desc: 'Report icon' %>
-              <span>Report an issue</span>
-            <% end %>
+            <% component.with_footer do %>
+              <%= link_to github_edit_url(@lesson), target: :_blank, rel: 'noreferrer noopener', class: 'text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 pr-5 text-sm' do %>
+                <%= inline_svg_tag 'icons/github.svg', class: 'h-4 w-4 mr-1 inline', aria: true, title: 'Improve on GitHub', desc: 'Github logo icon' %>
+                <span class="underline hover:no-underline">Improve on GitHub</span>
+              <% end %>
 
-            <%= link_to github_commits_url(@lesson), target: :_blank, rel: 'noreferrer noopener', class: 'underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 text-sm ml-auto text-right' do %>
-              See lesson changelog
+              <%= link_to github_report_url(@lesson), target: :_blank, rel: 'noreferrer noopener', class: 'inline-flex items-center underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 pr-5 text-sm' do %>
+                <%= inline_svg_tag 'icons/flag.svg', class: 'h-4 w-4 mr-1 inline', aria: true, title: 'Report an issue', desc: 'Report icon' %>
+                <span>Report an issue</span>
+              <% end %>
+
+              <%= link_to github_commits_url(@lesson), target: :_blank, rel: 'noreferrer noopener', class: 'underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 text-sm ml-auto text-right' do %>
+                See lesson changelog
+              <% end %>
             <% end %>
           <% end %>
-        <% end %>
 
-        <% if user_signed_in? && @lesson.accepts_submission? %>
-          <div class="py-10 border-t border-gray-100 dark:border-white/5">
-            <div class="max-w-2xl mx-auto xl:max-w-full border border-gray dark:border-white/5 rounded-lg p-4 dark:bg-gray-800">
-              <%= render 'lessons/project_solution', lesson: @lesson, project_submission: @project_submission %>
+          <% if user_signed_in? && @lesson.accepts_submission? %>
+            <div class="py-10 border-t border-gray-100 dark:border-white/5">
+              <div class="max-w-2xl mx-auto xl:max-w-full border border-gray dark:border-white/5 rounded-lg p-4 dark:bg-gray-800">
+                <%= render 'lessons/project_solution', lesson: @lesson, project_submission: @project_submission %>
+              </div>
             </div>
+          <% end %>
+
+          <div class="pt-10 border-t border-gray-100 dark:border-white/5">
+            <%= render 'lesson_buttons', lesson: @lesson, course: @lesson.course, user: @user %>
           </div>
-        <% end %>
+        </article>
 
-        <div class="pt-10 border-t border-gray-100 dark:border-white/5">
-          <%= render 'lesson_buttons', lesson: @lesson, course: @lesson.course, user: @user %>
-        </div>
-      </article>
-
-      <aside class="col-span-3 col-start-10 justify-self-end hidden xl:block">
-        <div class="sticky top-12 pb-20">
-          <h4 class="text-md pb-4 text-gray-700 dark:text-gray-300">Lesson contents</h4>
-          <ul class="flex flex-col text-gray-500 dark:text-gray-400" data-lesson-toc-target="toc"></ul>
-        </div>
-      </aside>
-    </main>
+        <aside class="hidden xl:block xl:col-start-3 xl:w-72 xl:justify-self-start">
+          <div class="sticky top-12 pb-20">
+            <h4 class="text-md pb-4 text-gray-700 dark:text-gray-300">Lesson contents</h4>
+            <ul class="flex flex-col text-gray-500 dark:text-gray-400" data-lesson-toc-target="toc"></ul>
+          </div>
+        </aside>
+      </main>
+    </div>
   </div>
 </div>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,6 +1,6 @@
 <%= render 'shared/off_canvas_menu' %>
 <nav class="border-gray-200 bg-white dark:bg-gray-900 dark:border-gray-800 <%= 'border-b' unless @landing_page %>">
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2">
+  <div class="mx-auto px-4 sm:px-6 lg:px-8 py-2">
     <div class="flex justify-between">
       <div class="flex">
         <div class="shrink-0 flex items-center">


### PR DESCRIPTION
Because:
- Previously, to keep the lesson content and sidebar within the width of our page container, which was dictated by the navbar, we positioned lesson content to the left instead of center on the page. This gave us room within the 7xl width to contain both the content and the sidebar.
- But it looked really weird when you got the bottom of the page when completing a lesson, where content was again centered.

This commit:
- Expand the navbar to full width so we no longer have to confine page content within it's width.
- Use a 3 column grid for lesson content - the left column will be empty, the middle column will make sure lesson content is dead center, and the right column will contain the lesson toc sidebar.
- Move the lesson header within the same grid so it can stay in sync with lesson content responsive movements.

