### PR TITLE
Fix: copy-clipboard color for light mode

### DIFF
--- a/app/assets/stylesheets/custom_styles/prism-theme.css
+++ b/app/assets/stylesheets/custom_styles/prism-theme.css
@@ -108,3 +108,7 @@ code[class*="language-"] {
   counter-increment: linenumber;
   line-height: 1.7rem;
 }
+
+.light .copy-to-clipboard-button[data-copy-state^="copy"] span {
+  color: #bbb;
+}


### PR DESCRIPTION
## Because
When hovering, and after clicking the copy button on a code snippet, the text is very low contrast and difficult to read, prior to this change.


## This PR
- adding the color #bbb to the copy-to-clipboard button specifically when it is in light mode and also while it is in both data-copy-state of copy and copy-success.

## Issue
Closes #4998

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide]
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
