### PR TITLE
Chore: Add spec:fast task to run all specs except system tests

### DIFF
--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+if Rails.env.local?
+  require 'rspec/core/rake_task'
+
+  namespace :spec do
+    # Usage: `bin/rails spec:fast`
+    desc 'Run all specs except system specs'
+    RSpec::Core::RakeTask.new(:fast) do |t|
+      t.exclude_pattern = 'spec/system/**/*'
+      t.rspec_opts = '--order rand'
+      t.verbose = false
+    end
+  end
+end


### PR DESCRIPTION
## Because
Minor developer convenience that allows for faster feedback loops. Non system specs take roughly 10 seconds on my local, compared to 1 minute 30 plus setup time for system specs

## Examples

Using new task

<img width="455" height="171" alt="image" src="https://github.com/user-attachments/assets/8a273977-03c6-4094-bc8e-e2095f0618c1" />

Just system specs (via existing `spec:system` task)

<img width="627" height="195" alt="image" src="https://github.com/user-attachments/assets/9871be87-5d5a-486a-8151-e9fe16bc1cd5" />
