### PR TITLE
Chore: Make coverage reports opt-in

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,8 @@
-require 'simplecov'
+if ENV.fetch('COVERAGE', false)
+  require 'simplecov'
+  SimpleCov.start 'rails'
+end
 
-SimpleCov.start 'rails'
 ENV['RAILS_ENV'] ||= 'test'
 
 require File.expand_path('../config/environment', __dir__)


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
There are a couple reasons I thought this was a good idea:
1. Coverage reports take up a not-insignificant amount of time in a test run. On the machine I'm making this PR for, generating the reports consumes over 10 seconds in a full test run.
  **Without Coverage**<img width="1902" height="179" alt="image" src="https://github.com/user-attachments/assets/1aa9d21e-5620-47e2-b6a2-73c221c33cc5" />
  **With Coverage**<img width="1902" height="207" alt="image" src="https://github.com/user-attachments/assets/79811e46-b407-406d-a460-b306a3bc0ba9" />
2. In a partial run, the generated coverage reports aren't very useful. I often run one file or sometimes even one spec. In such a run, the coverage is more noise than anything, as it doesn't have the full context of the tests that weren't run in order to generate an accurate report. This is also the case in the current CI config, where tests are executed in parallel on different workers, meaning none of the coverage reports generate an accurate picture.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Wraps require and init for `SimpleCov` in a conditional check that looks for a `'COVERAGE'` env variable. To generate a report, the dev now needs to run something like `COVERAGE=1 bin/rails spec`

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
If we decide we want it, there are ways to have SimpleCov emit JSON reports and have it merge them together. This could potentially be used to generate an accurate, combined report in the CI env. I figure that'd be something for a different PR/issue though.

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
