### PR TITLE
Chore: Reconfigure `debug` gem in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,7 @@ end
 
 group :development, :test do
   gem 'brakeman', require: false
-  gem 'debug', '~> 1.10', require: false
+  gem 'debug', '~> 1.10', require: 'debug/prelude'
   gem 'dotenv-rails', '~> 3.1'
   gem 'parallel_tests', '~> 5.4'
   gem 'rspec-rails', '~> 7.0'


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
It speeds up runs of the test suite by a healthy chunk to not have the debugger loaded. This is because it periodically blocks the main thread while it does its thing--even when no breakpoint is set and it's not being actively used by the developer. Loading the debugger every time into the test environment can be prevented by setting `require: false` on the gem in the `Gemfile`.

On my machine (which I admit is a bit older and slower than the average silicon Mac), it averages about 7-8 seconds saved over a full run to not load the debugger:
**With debug loaded**<img width="1904" height="218" alt="image" src="https://github.com/user-attachments/assets/e80e8b12-1d8c-4594-bb3b-380f0525b8e4" />

**Without debug loaded**<img width="1904" height="185" alt="image" src="https://github.com/user-attachments/assets/a199ee8c-f39c-4528-9c97-7f0fb391e820" />

While making this change, I noticed that the `debug` gem is listed at the top level of Gemfile, and therefore theoretically included in the production bundle. This is a big smell to me for both security and performance reasons. So I also figured I'd move it to the local group (development and test).

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Moves the `debug` gem to the group for development and test environments
- Sets `require: false` on the gem so it's not always loaded

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
Sometimes you *do* want to debug. With this change, the `debug` gem is no longer required throughout the app. If you're wanting to debug in development, you'd have to explicitly require it wherever you're wanting to use it
```rb
# app/controllers/lessons_controller.rb

require 'debug' # now you need this

class LessonsController < ApplicationController
  def show
    binding.b # or this breakpoint won't work
  end
end
```
For debugging tests, the developer can either do the same thing (`require` the gem into the file they're wanting to set a breakpoint at) or RSpec can be ran with the `-rdebug` flag, which will load the gem.

Personally, I think this is a very minor inconvenience. Also glad to document these somewhere (the wiki?) if people think it'd be helpful.

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
