### PR TITLE
Fix: ignore bun.lock generated during test asset precompile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@
 
 # Ruby tool versions
 .tool-versions
+
+bun.lock


### PR DESCRIPTION
Because:
Bun was being invoked during the Tailwind precompile step, causing a bun.lock file to appear even though we use Yarn. This comes from an upstream issue in the latest css-bundling version we recently upgraded to.
<img width="1169" height="120" alt="Screenshot 2025-11-23 at 22 10 44" src="https://github.com/user-attachments/assets/9f6b64de-d54b-4dd7-aaf9-393675769477" />


This commit:
- The issue is fixed in css-bundling but not yet released.
- For now, this commit adds bun.lock to .gitignore to prevent it from cluttering the repo or being committed by mistake.
