### PR TITLE
Fix: Re-intergrate Inline Code Blocks to Pink

### DIFF
--- a/app/assets/stylesheets/custom_styles/typography.css
+++ b/app/assets/stylesheets/custom_styles/typography.css
@@ -10,8 +10,8 @@
   }
 
   &:hover::before {
-    mask-image: url("/icons/link.svg");
-    content: " ";
+    mask-image: url('/icons/link.svg');
+    content: ' ';
 
     @apply h-4 w-4 bg-gray-500 dark:bg-gray-300 absolute -left-[22px] top-1/2 -translate-y-1/2 font-semibold sm:block;
   }
@@ -19,7 +19,7 @@
 
 @layer base {
   body {
-    font-family: Inter, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-family: Inter, 'Helvetica Neue', Helvetica, Arial, sans-serif;
   }
 }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,43 +6,43 @@ module.exports = {
         DEFAULT: {
           css: {
             code: {
-              "&:before": {
-                display: "none",
+              '&:before': {
+                display: 'none',
               },
-              "&:after": {
-                display: "none",
+              '&:after': {
+                display: 'none',
               },
             },
             h3: {
-              width: "fit-content",
+              width: 'fit-content',
               a: {
-                color: "var(--color-gray-800)",
-                "text-decoration": "none",
-                "font-weight": "600",
-                "&:hover": {
-                  color: "var(--color-gray-800)",
+                color: 'var(--color-gray-800)',
+                'text-decoration': 'none',
+                'font-weight': '600',
+                '&:hover': {
+                  color: 'var(--color-gray-800)',
                 },
               },
             },
             h4: {
               a: {
-                "text-decoration": "none",
+                'text-decoration': 'none',
               },
             },
             details: {
               summary: {
-                "font-size": "1.25rem",
-                "margin-bottom": "1.25rem",
-                "font-weight": "600",
-                cursor: "pointer",
+                'font-size': '1.25rem',
+                'margin-bottom': '1.25rem',
+                'font-weight': '600',
+                cursor: 'pointer',
               },
             },
           },
         },
         gray: {
           css: {
-            "--tw-prose-code": "var(--color-pink-700)",
-            "--tw-prose-invert-code": "var(--color-pink-400)",
+            '--tw-prose-code': 'var(--color-pink-700)',
+            '--tw-prose-invert-code': 'var(--color-pink-400)',
           },
         },
       },


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
As of now, all inline code blocks on the website is gray. This change makes sure that all code blocks appear pink again for better user experience and provide better visibility.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- In `theodinproject/tailwind.config.js`,  change all color variables to be singular
- In `theodinproject/app/assets/stylesheets/custom_styles/typography.css`, add a new color call `prose-gray`

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #5182 

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If applicable, this PR includes new or updated automated tests
