### PR TITLE
Fix: Remove duplicate header logo anchor element

### DIFF
--- a/app/components/logo_component.html.erb
+++ b/app/components/logo_component.html.erb
@@ -1,3 +1,4 @@
 <%= link_to redirect_to_path, 'aria-label': 'Return back home' do %>
+  <%= image_tag 'icons/odin-icon.svg', alt: 'Odin Logo', class: 'lg:hidden h-12 w-auto' %>
   <%= inline_svg_tag 'logo.svg', class: "#{classes} text-gray-800 dark:text-gray-300", aria: true, title: 'Odin Logo' %>
 <% end %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -4,10 +4,6 @@
     <div class="flex justify-between">
       <div class="flex">
         <div class="shrink-0 flex items-center">
-          <%= link_to root_path, class: 'logo', 'aria-label': 'Return back home' do %>
-            <%= image_tag 'icons/odin-icon.svg', alt: 'Odin Logo', class: 'block lg:hidden h-12 w-auto' %>
-          <% end %>
-
           <%= render LogoComponent.new(classes: 'hidden lg:block h-12 w-auto') %>
         </div>
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
There are 2 header logo anchor elements that are always shown on desktop/mobile. The anchor elements are functionally identical (same `href` and `aria-label`), the only difference being the contents.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Axe the first anchor element and move the `<img>` inside the second anchor element. 
- Drop `block` from the `<img>` classes since that's the default anyway.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #5200

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
