### PR TITLE
Fix: Deleting a project submission is always deleting the first item in the list

### DIFF
--- a/app/components/project_submissions/user_solution_component.html.erb
+++ b/app/components/project_submissions/user_solution_component.html.erb
@@ -39,7 +39,11 @@
                 class: 'text-gray-700 dark:text-gray-300 group flex items-center px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-600 hover:text-gray-900 dark:hover:text-gray-200',
                 role: 'menuitem',
                 tabindex: '-1',
-                data: { action: 'dialog-router#open:prevent visibility#off', dialog_router_id_param: 'delete_user_submission', test_id: 'delete-submission-btn' }
+                data: {
+                  action: 'dialog-router#open:prevent visibility#off',
+                  dialog_router_id_param: dom_id(project_submission, 'delete_user_submission'),
+                  test_id: 'delete-submission-btn'
+                }
               ) do %>
             <%= inline_svg_tag 'icons/trash.svg', class: 'mr-3 h-4 w-4 text-gray-400 group-hover:text-gray-500 dark:group-hover:text-gray-300', aria: true, title: 'edit', desc: 'edit icon' %>
             Delete
@@ -49,7 +53,7 @@
     </div>
   </div>
 
-  <%= render Overlays::DialogComponent.new(id: 'delete_user_submission') do |component| %>
+  <%= render Overlays::DialogComponent.new(id: dom_id(project_submission, 'delete_user_submission')) do |component| %>
     <div>
       <h3 id="dialog-title" class="text-base font-semibold text-gray-900 dark:text-white">Delete project</h3>
       <div class="mt-2">

--- a/spec/system/user_project_submissions/delete_submission_spec.rb
+++ b/spec/system/user_project_submissions/delete_submission_spec.rb
@@ -2,26 +2,34 @@ require 'rails_helper'
 
 RSpec.describe 'Deleting a Project Submission on the Dashboard' do
   let(:user) { create(:user) }
-  let(:lesson) { create(:lesson, :project) }
 
   before do
-    create(:project_submission, user:, lesson:)
+    create(:project_submission, user:, lesson: create(:lesson, :project, title: 'My Project'))
+    create(:project_submission, user:, lesson: create(:lesson, :project, title: 'Another Project'))
+
     sign_in(user)
     visit dashboard_path
   end
 
   it 'successfully deletes a submission' do
     sleep 0.1 # it will not open the dropdown without this
+
     within(:test_id, 'user-submissions-list') do
-      expect(page).to have_content(lesson.title)
+      expect(page).to have_content('My Project')
+      expect(page).to have_content('Another Project')
     end
 
-    find(:test_id, 'submission-action-menu-btn').click
-    find(:test_id, 'delete-submission-btn').click
-    find(:test_id, 'confirm-delete-submission-btn').click
+    within(:test_project_submission, 2) do
+      expect(page).to have_content('My Project')
+
+      find(:test_id, 'submission-action-menu-btn').click
+      find(:test_id, 'delete-submission-btn').click
+      find(:test_id, 'confirm-delete-submission-btn').click
+    end
 
     within(:test_id, 'user-submissions-list') do
-      expect(page).to have_no_content(lesson.title)
+      expect(page).to have_no_content('My Project')
+      expect(page).to have_content('Another Project')
     end
   end
 end


### PR DESCRIPTION
Because:
- The submissions all had the same delete dialog id (delete_user_submission), which meant the dialog for the first item was always opened instead of the intended one if the list included more than one item.
- Closes: https://github.com/TheOdinProject/theodinproject/pull/5206

This commit:
- Scopes the delete dialog id to each item by including it's id.
- Amends the system spec for deleting project submissions to cover this scenario.