### PR TITLE
Chore: Disable turbo prefetch on submission delete

### DIFF
--- a/app/components/project_submissions/user_solution_component.html.erb
+++ b/app/components/project_submissions/user_solution_component.html.erb
@@ -42,7 +42,8 @@
                 data: {
                   action: 'dialog-router#open:prevent visibility#off',
                   dialog_router_id_param: dom_id(project_submission, 'delete_user_submission'),
-                  test_id: 'delete-submission-btn'
+                  test_id: 'delete-submission-btn',
+                  turbo_prefetch: false
                 }
               ) do %>
             <%= inline_svg_tag 'icons/trash.svg', class: 'mr-3 h-4 w-4 text-gray-400 group-hover:text-gray-500 dark:group-hover:text-gray-300', aria: true, title: 'edit', desc: 'edit icon' %>


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Extremely small thing I noticed while poking around on #5205 

[Turbo 8 prefetches links on hover](https://turbo.hotwired.dev/handbook/drive#prefetching-links-on-hover), and because the links to delete the project submissions are "technically" GETs, it wants to prefetch the URL--but there's of course no content to fetch. So a useless request is sent to the backend that fails with 404 every time.

Short video demo, but you can see what I mean by just visiting the user dashboard, opening the little actions menu next to a project submission, and then hovering your mouse over the 'Delete' link.

https://github.com/user-attachments/assets/9366711e-0749-460e-bf72-42faf4337a98



## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Disable turbo prefetching on the delete link for project submissions.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
