### PR TITLE
Fix: Change secondary button focus style in dark mode

### DIFF
--- a/app/assets/stylesheets/custom_styles/buttons.css
+++ b/app/assets/stylesheets/custom_styles/buttons.css
@@ -18,7 +18,7 @@
 @utility button--secondary {
   @apply border-gray-300 text-gray-700 hover:text-gray-700 bg-white hover:bg-gray-50
     focus:ring-gray-400 focus:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700
-    dark:border-gray-600 dark:focus:ring-gray-600 dark:bg-transparent;
+    dark:border-gray-600 dark:focus:ring-gray-500 dark:bg-transparent;
 }
 
 @utility button--danger {
@@ -51,4 +51,3 @@
 @utility button--google {
   @apply bg-blue-500 hover:bg-blue-600 focus:ring-blue-400;
 }
-


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Currently, focus style colour contrast ratio is approx 2:1. It should be at least 3:1.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Change secondary button focus style in dark mode.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #5202

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
