### PR TITLE
Fix: Deleting a lesson with lots of completions is causing the Heroku release task to timeout

### DIFF
--- a/app/models/lesson.rb
+++ b/app/models/lesson.rb
@@ -8,7 +8,7 @@ class Lesson < ApplicationRecord
   has_one :path, through: :course
   has_one :content, dependent: :destroy
   has_many :project_submissions, dependent: :destroy
-  has_many :lesson_completions, dependent: :destroy
+  has_many :lesson_completions, dependent: :delete_all
   has_many :completing_users, through: :lesson_completions, source: :user
 
   scope :most_recent_updated_at, -> { maximum(:updated_at) }


### PR DESCRIPTION
Because:
- Deleting lessons with hundreds of thousands of completions caused the release task to hang
- Dependent: :destroy was instantiating and destroying each completion record individually

This commit:
- Changes lesson completions association to use dependent: :delete_all for fast bulk deletion