### PR TITLE
Feature: Improve accessible text for links wrapping images in lessons

### DIFF
--- a/lib/kramdown/converter/odin_html.rb
+++ b/lib/kramdown/converter/odin_html.rb
@@ -12,7 +12,7 @@ module Kramdown
 
         attributes = { href: element.attr['src'], 'aria-label': "image showing #{element.attr['alt']}" }
           .merge(EXTERNAL_LINK_ATTRIBUTES)
-        %(<a#{html_attributes(attributes)}>#{super}</a>)
+        "<a#{html_attributes(attributes)}>#{super}</a>"
       end
 
       def convert_a(element, indent)

--- a/lib/kramdown/converter/odin_html.rb
+++ b/lib/kramdown/converter/odin_html.rb
@@ -10,7 +10,8 @@ module Kramdown
       def convert_img(element, _indent)
         return super if @stack.last.type == :a || element.attr['alt'] == ''
 
-        attributes = { href: element.attr['src'] }.merge(EXTERNAL_LINK_ATTRIBUTES)
+        attributes = { href: element.attr['src'], 'aria-label': "image showing #{element.attr['alt']}" }
+          .merge(EXTERNAL_LINK_ATTRIBUTES)
         %(<a#{html_attributes(attributes)}>#{super}</a>)
       end
 

--- a/spec/services/markdown_converter_spec.rb
+++ b/spec/services/markdown_converter_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe MarkdownConverter do
         MARKDOWN
 
         html_result = <<~HTML
-          <p><a href="https://example.com/image.jpeg" rel="noreferrer"><img src="https://example.com/image.jpeg" alt="an image" /></a></p>
+          <p><a href="https://example.com/image.jpeg" aria-label="image showing an image" rel="noreferrer"><img src="https://example.com/image.jpeg" alt="an image" /></a></p>
         HTML
 
         expect(described_class.new(markdown).as_html).to eq(html_result)


### PR DESCRIPTION
## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Currently, images in lessons are wrapped in anchors - the accessible text for these anchors are just the images' alt text.

For example, in [Understanding Errors](https://www.theodinproject.com/lessons/foundations-understanding-errors#the-anatomy-of-an-error), for the first image when tabbing through and navigating by link, Orca reads out "reference error example - link" and that's it. It's not 100% clear that this link's purpose is associated with opening an image; it could be a link to an article or code sandbox.

A lot of our lessons' images' alt text can do with improving, but it would make sense to ensure that these associated anchors have a more specific accessible name at the conversion time. Improving the alt texts is a separate and significantly larger task.

After chatting with Eric about approaches, giving the anchors an aria-label with `image showing <alt text>` should be sufficient. The anchors have a clearer purpose while the images are left alone to avoid redundancy.
Orca reads the link as "image showing reference error example - link" and reads the image as "reference error example - image".

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Adds aria-label to anchors that wrap images in the markdown converter
- Amends associated test

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
N/A


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
