### PR TITLE
Feature: Add aria-label if markdown link has title present

### DIFF
--- a/app/components/markdown/preview_component.rb
+++ b/app/components/markdown/preview_component.rb
@@ -8,7 +8,7 @@ class Markdown::PreviewComponent < ApplicationComponent
   end
 
   def allowed_attributes
-    Rails::HTML5::SafeListSanitizer::DEFAULT_ALLOWED_ATTRIBUTES + %w[id data-title]
+    Rails::HTML5::SafeListSanitizer::DEFAULT_ALLOWED_ATTRIBUTES + %w[id data-title rel aria-label]
   end
 
   private

--- a/lib/kramdown/converter/odin_html.rb
+++ b/lib/kramdown/converter/odin_html.rb
@@ -20,6 +20,13 @@ module Kramdown
           element.attr.merge!(EXTERNAL_LINK_ATTRIBUTES)
         end
 
+        # Markdown allows adding link titles but not aria-labels
+        # "title" not ideal for accessible name - "aria-label" preferred
+        # https://www.w3.org/WAI/ARIA/apg/practices/names-and-descriptions/#naming_rule_avoid_fallback
+        if element.attr.key? 'title'
+          element.attr['aria-label'] = element.attr['title']
+        end
+
         super
       end
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Markdown syntax allows adding titles via quoted text after the href within the parentheses e.g. `[text](#href "title")`. `title` is technically a common browser fallback accessible name but it's not a good one and not recommended by W3 (https://www.w3.org/WAI/ARIA/apg/practices/names-and-descriptions/#naming_rule_avoid_fallback). For example, on Linux, Orca reads out that link example as "text link title" but does not show the title when listing all links on the page (it lists the link's accessible name as "text"). An `aria-label` would be preferred here which would take priority as the accesisble name.

This is definitely not something we'll want to use much, but a sensible use case IMHO is any of our installation lessons with OS-specific instructions where we link to external guide files e.g. [Installations](https://www.theodinproject.com/lessons/foundations-installations#assignment).

Visually, it reads awkwardly if we repeated "installation instructions" in every OS link, and "Chrome installation instructions for <OS>". I think it makes sense there for the labels to just be the OSes, but currently they don't have very accessible names for the context. Enabling this would allow us to use the markdown link title syntax in such cases to satisfy both sides. An example of where I've used this syntax is for the [Text Editors lesson in a PR](https://github.com/TheOdinProject/curriculum/pull/31026)

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Adds aria-label to links if title attribute exists
- Whitelists `rel` and `aria-label` in the preview tool, as they weren't included in the default whitelist

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
N/A


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
