### PR TITLE
Chore: Use factories instead of UI clicks in system test setup

### DIFF
--- a/spec/system/course_progress_badge_spec.rb
+++ b/spec/system/course_progress_badge_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe 'Course Progress Badge' do
   let!(:second_lesson) { create(:lesson, course:) }
 
   context 'when signed in' do
-    before do
-      sign_in(create(:user))
-    end
+    let(:user) { create(:user) }
+
+    before { sign_in(user) }
 
     context 'when course has not been started' do
       it 'displays 0% completion' do
@@ -23,9 +23,8 @@ RSpec.describe 'Course Progress Badge' do
 
     context 'when course has some progress' do
       it 'shows percentage of completion' do
-        visit lesson_path(first_lesson)
+        create(:lesson_completion, user:, lesson: first_lesson, course:)
 
-        find(:test_id, 'complete-button').click
         visit path_course_path(path, course)
 
         within :test_id, 'progress-circle' do
@@ -36,11 +35,8 @@ RSpec.describe 'Course Progress Badge' do
 
     context 'when course is completed' do
       it 'shows 100% completion' do
-        visit lesson_path(first_lesson)
-        find(:test_id, 'complete-button').click
-
-        visit lesson_path(second_lesson)
-        find(:test_id, 'complete-button').click
+        create(:lesson_completion, user:, lesson: first_lesson, course:)
+        create(:lesson_completion, user:, lesson: second_lesson, course:)
 
         visit path_course_path(path, course)
 

--- a/spec/system/lesson_project_submissions/edit_submission_spec.rb
+++ b/spec/system/lesson_project_submissions/edit_submission_spec.rb
@@ -11,12 +11,13 @@ RSpec.describe 'Editing a Project Submission' do
   end
 
   before do
+    create(:project_submission, user:, lesson:)
     sign_in(user)
-    visit lesson_path(lesson)
-    Pages::ProjectSubmissions::Form.new.open.fill_in.submit
   end
 
   it 'successfully edits a submission' do
+    visit lesson_path(lesson)
+
     within(:test_id, 'current-user-solution') do
       find(:test_id, 'submission-action-menu-btn').click
       find(:test_id, 'edit-submission').click

--- a/spec/system/user_dashboard/open_course_spec.rb
+++ b/spec/system/user_dashboard/open_course_spec.rb
@@ -5,18 +5,15 @@ RSpec.describe 'Opening Course from User Dashboard' do
   let!(:foundations_course) { create(:course, title: 'Foundations', path: default_path) }
 
   context 'when user has completed a course' do
+    let(:user) { create(:user) }
+
     before do
       first_lesson = create(:lesson, course: foundations_course)
       second_lesson = create(:lesson, course: foundations_course)
+      create(:lesson_completion, user:, lesson: first_lesson, course: foundations_course)
+      create(:lesson_completion, user:, lesson: second_lesson, course: foundations_course)
 
-      sign_in(create(:user))
-
-      visit lesson_path(first_lesson)
-      find(:test_id, 'complete-button').click
-
-      visit lesson_path(second_lesson)
-      find(:test_id, 'complete-button').click
-
+      sign_in(user)
       visit dashboard_path
     end
 

--- a/spec/system/user_dashboard/resume_course_spec.rb
+++ b/spec/system/user_dashboard/resume_course_spec.rb
@@ -6,14 +6,13 @@ RSpec.describe 'Resuming Course from User Dashboard' do
   let!(:incomplete_lesson) { create(:lesson, course: foundations_course) }
 
   context 'when user has completed first lesson in course' do
+    let(:user) { create(:user) }
+
     before do
-      lesson = create(:lesson, course: foundations_course)
+      completed_lesson = create(:lesson, course: foundations_course)
+      create(:lesson_completion, user:, lesson: completed_lesson, course: foundations_course)
 
-      sign_in(create(:user))
-
-      visit lesson_path(lesson)
-      find(:test_id, 'complete-button').click
-
+      sign_in(user)
       visit dashboard_path
     end
 


### PR DESCRIPTION
## Because
Several system specs were driving the UI to mark lessons complete purely as setup for what they actually wanted to test (dashboard resume/open buttons, the course progress badge, project submission editing). Each `visit lesson_path` + `find('complete-button').click` pair pays for a Cuprite round-trip and couples the spec to a UI selector unrelated to its assertion.

## This PR
- Replaces UI-driven setup with `create(:lesson_completion, ...)` (and `create(:project_submission, ...)`) across four system specs
- Extracts `let(:user)` where the same user is now needed in both the factory call and `sign_in`


