### PR TITLE
Chore: Remove stray completion debugging code

### DIFF
--- a/app/views/lessons/completions/create.turbo_stream.erb
+++ b/app/views/lessons/completions/create.turbo_stream.erb
@@ -1,6 +1,5 @@
 <% if params[:icon_only] %>
   <%= turbo_stream.replace dom_id(@lesson, 'complete-button'), method: :morph do %>
-    <% @lesson.completed? %>
     <%= render Complete::IconComponent.new(lesson: @lesson, current_user:, animate: true) %>
   <% end %>
 <% else %>


### PR DESCRIPTION
Because:
- This must have been adding when debugging something in the past.
- It doesn't do anything and can be removed.
