### PR TITLE
Feature: Add course contents sidebar to the lesson page

### DIFF
--- a/app/assets/images/icons/panel-left.svg
+++ b/app/assets/images/icons/panel-left.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+  <rect x="3" y="3" width="18" height="18" rx="2" stroke-linecap="round" stroke-linejoin="round" />
+  <path d="M9 3v18" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/app/assets/stylesheets/custom_styles/layout.css
+++ b/app/assets/stylesheets/custom_styles/layout.css
@@ -2,8 +2,40 @@
   @apply max-w-7xl mx-auto py-10 px-4 sm:py-14 sm:px-6 lg:px-8;
 }
 
+html:has([data-controller~="lessons--sidebar-toggle"]) {
+  scroll-padding-top: 3.5rem;
+}
+
 @utility highlight-white {
   @layer utilities {
     box-shadow: inset 0 1px 0 0 hsl(0deg 0% 100% / 5%);
+  }
+}
+
+@utility scrollbar-thin {
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-gray-300) transparent;
+  scrollbar-gutter: stable;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: var(--color-gray-300);
+    border-radius: 9999px;
+  }
+
+  .dark & {
+    scrollbar-color: var(--color-gray-700) transparent;
+  }
+
+  .dark &::-webkit-scrollbar-thumb {
+    background-color: var(--color-gray-700);
   }
 }

--- a/app/components/lessons/sidebar/completion_icon_component.html.erb
+++ b/app/components/lessons/sidebar/completion_icon_component.html.erb
@@ -1,0 +1,7 @@
+<%= inline_svg_tag(
+      'icons/checkmark-circle-solid.svg',
+      class: "sidebar-completion-icon-#{lesson.id} h-5 w-5 shrink-0 #{color_class}",
+      aria: true,
+      title: title,
+      data: { test_id: 'lesson-sidebar-completion' }
+    ) %>

--- a/app/components/lessons/sidebar/completion_icon_component.rb
+++ b/app/components/lessons/sidebar/completion_icon_component.rb
@@ -1,0 +1,21 @@
+module Lessons
+  module Sidebar
+    class CompletionIconComponent < ApplicationComponent
+      def initialize(lesson:)
+        @lesson = lesson
+      end
+
+      private
+
+      attr_reader :lesson
+
+      def color_class
+        lesson.completed? ? 'text-teal-600' : 'text-gray-300 dark:text-gray-700'
+      end
+
+      def title
+        lesson.completed? ? 'Lesson completed' : 'Lesson not completed'
+      end
+    end
+  end
+end

--- a/app/components/lessons/sidebar/lesson_component.html.erb
+++ b/app/components/lessons/sidebar/lesson_component.html.erb
@@ -1,0 +1,15 @@
+<%= link_to(
+      lesson_path(lesson),
+      class: 'flex items-center justify-between gap-2 px-2 py-1.5 rounded-md no-underline text-sm text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-gray-200 aria-[current=page]:bg-gray-100 dark:aria-[current=page]:bg-gray-800 aria-[current=page]:font-semibold aria-[current=page]:text-gray-900 dark:aria-[current=page]:text-gray-100',
+      aria: { current: ('page' if current?) },
+      data: { test_id: 'lesson-sidebar-link', 'lessons--sidebar-toggle-target': 'item' }
+    ) do %>
+  <span class="flex items-center gap-2 min-w-0">
+    <%= inline_svg_tag "icons/#{icon_name}.svg", class: 'h-4 w-4 shrink-0 text-gray-400 dark:text-gray-500' %>
+    <span class="truncate"><%= lesson.display_title %></span>
+  </span>
+
+  <% if current_user %>
+    <%= render Lessons::Sidebar::CompletionIconComponent.new(lesson:) %>
+  <% end %>
+<% end %>

--- a/app/components/lessons/sidebar/lesson_component.rb
+++ b/app/components/lessons/sidebar/lesson_component.rb
@@ -1,0 +1,23 @@
+module Lessons
+  module Sidebar
+    class LessonComponent < ApplicationComponent
+      def initialize(lesson:, current_lesson:, current_user: nil)
+        @lesson = lesson
+        @current_lesson = current_lesson
+        @current_user = current_user
+      end
+
+      private
+
+      attr_reader :lesson, :current_lesson, :current_user
+
+      def current?
+        lesson.id == current_lesson.id
+      end
+
+      def icon_name
+        lesson.is_project? ? 'wrench-screwdriver' : 'book'
+      end
+    end
+  end
+end

--- a/app/components/lessons/sidebar/progress_bar_component.html.erb
+++ b/app/components/lessons/sidebar/progress_bar_component.html.erb
@@ -1,0 +1,16 @@
+<div class="sidebar-progress-bar">
+  <div class="w-full bg-gray-200 dark:bg-gray-800 rounded-full h-1.5 overflow-hidden">
+    <div
+      class="bg-teal-600 dark:bg-teal-500 h-full rounded-full transition-all"
+      style="width: <%= percentage %>%;"
+      role="progressbar"
+      aria-valuenow="<%= percentage %>"
+      aria-valuemin="0"
+      aria-valuemax="100"
+      aria-label="Course progress">
+    </div>
+  </div>
+  <span class="mt-2 block text-xs text-gray-500 dark:text-gray-400">
+    <%= percentage %>% complete
+  </span>
+</div>

--- a/app/components/lessons/sidebar/progress_bar_component.rb
+++ b/app/components/lessons/sidebar/progress_bar_component.rb
@@ -1,0 +1,13 @@
+module Lessons
+  module Sidebar
+    class ProgressBarComponent < ApplicationComponent
+      def initialize(percentage:)
+        @percentage = percentage
+      end
+
+      private
+
+      attr_reader :percentage
+    end
+  end
+end

--- a/app/components/lessons/sidebar/section_component.html.erb
+++ b/app/components/lessons/sidebar/section_component.html.erb
@@ -1,0 +1,14 @@
+<details class="group border-b border-gray-100 dark:border-gray-800" <%= 'open' if expanded? %>>
+  <summary class="flex items-center justify-between gap-2 py-3 px-2 cursor-pointer list-none text-sm font-semibold text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 rounded-md">
+    <span class="truncate"><%= section.title %></span>
+    <%= inline_svg_tag 'icons/chevron-down.svg', class: 'h-4 w-4 shrink-0 text-gray-400 transition-transform group-open:rotate-180' %>
+  </summary>
+
+  <ul class="pb-2 space-y-1">
+    <% section.lessons.each do |lesson| %>
+      <li>
+        <%= render Lessons::Sidebar::LessonComponent.new(lesson:, current_lesson:, current_user:) %>
+      </li>
+    <% end %>
+  </ul>
+</details>

--- a/app/components/lessons/sidebar/section_component.rb
+++ b/app/components/lessons/sidebar/section_component.rb
@@ -1,0 +1,19 @@
+module Lessons
+  module Sidebar
+    class SectionComponent < ApplicationComponent
+      def initialize(section:, current_lesson:, current_user: nil)
+        @section = section
+        @current_lesson = current_lesson
+        @current_user = current_user
+      end
+
+      private
+
+      attr_reader :section, :current_lesson, :current_user
+
+      def expanded?
+        section.id == current_lesson.section_id
+      end
+    end
+  end
+end

--- a/app/components/lessons/sidebar_component.html.erb
+++ b/app/components/lessons/sidebar_component.html.erb
@@ -1,0 +1,90 @@
+<%# Off-canvas drawer — below xl %>
+<div
+  class="relative z-40 xl:hidden lesson-sidebar-drawer hidden"
+  role="dialog"
+  aria-modal="true"
+  aria-label="Course contents"
+  data-controller="visibility"
+  data-visibility-target="content"
+  data-visibility-visible-value="false">
+
+  <div
+    class="fixed inset-0 bg-gray-900/80 dark:bg-black/70 hidden"
+    data-visibility-target="content"
+    data-action="click->visibility#off"
+    aria-hidden="true"
+    data-transition-enter="transition-opacity ease-linear duration-200"
+    data-transition-enter-start="opacity-0"
+    data-transition-enter-end="opacity-100"
+    data-transition-leave="transition-opacity ease-linear duration-200"
+    data-transition-leave-start="opacity-100"
+    data-transition-leave-end="opacity-0"></div>
+
+  <div class="fixed inset-0 flex">
+    <div
+      class="relative mr-16 flex w-full max-w-xs flex-1 hidden"
+      data-visibility-target="content"
+      data-transition-enter="transition ease-in-out duration-200 transform"
+      data-transition-enter-start="-translate-x-full"
+      data-transition-enter-end="translate-x-0"
+      data-transition-leave="transition ease-in-out duration-200 transform"
+      data-transition-leave-start="translate-x-0"
+      data-transition-leave-end="-translate-x-full">
+
+      <div
+        class="absolute left-full top-0 flex w-16 justify-center pt-5 hidden"
+        data-visibility-target="content"
+        data-transition-enter="ease-in-out duration-200"
+        data-transition-enter-start="opacity-0"
+        data-transition-enter-end="opacity-100"
+        data-transition-leave="ease-in-out duration-200"
+        data-transition-leave-start="opacity-100"
+        data-transition-leave-end="opacity-0">
+
+        <button type="button" class="-m-2.5 p-2.5" data-action="click->visibility#off">
+          <span class="sr-only">Close course contents</span>
+          <%= inline_svg_tag 'icons/x-mark.svg', class: 'h-6 w-6 text-white', aria: true, title: 'Close course contents' %>
+        </button>
+      </div>
+
+      <div class="flex grow flex-col gap-y-4 overflow-y-auto scrollbar-thin bg-white dark:bg-gray-900 px-4 pb-6 pt-5">
+        <div class="flex flex-col gap-2">
+          <%= render Ui::BackLinkComponent.new(path: path_course_path(course.path, course), name: 'Back to course') %>
+
+          <%= link_to course.title, path_course_path(course.path, course), class: 'text-lg font-semibold text-gray-800 dark:text-gray-200 no-underline hover:underline' %>
+
+          <% if progress_percentage %>
+            <%= render Lessons::Sidebar::ProgressBarComponent.new(percentage: progress_percentage) %>
+          <% end %>
+        </div>
+
+        <nav aria-label="Course contents">
+          <% sections.each do |section| %>
+            <%= render Lessons::Sidebar::SectionComponent.new(section:, current_lesson:, current_user:) %>
+          <% end %>
+        </nav>
+      </div>
+    </div>
+  </div>
+</div>
+
+<%# Static desktop sidebar — xl+ %>
+<aside class="hidden xl:block xl:h-full" data-test-id="lesson-sidebar">
+  <div class="sticky top-0 h-screen overflow-y-auto scrollbar-thin pt-4 pb-20">
+    <div class="mb-4 flex flex-col gap-2">
+      <%= render Ui::BackLinkComponent.new(path: path_course_path(course.path, course), name: 'Back to course') %>
+
+      <%= link_to course.title, path_course_path(course.path, course), class: 'text-lg font-semibold text-gray-800 dark:text-gray-200 no-underline hover:underline' %>
+
+      <% if progress_percentage %>
+        <%= render Lessons::Sidebar::ProgressBarComponent.new(percentage: progress_percentage) %>
+      <% end %>
+    </div>
+
+    <nav aria-label="Course contents">
+      <% sections.each do |section| %>
+        <%= render Lessons::Sidebar::SectionComponent.new(section:, current_lesson:, current_user:) %>
+      <% end %>
+    </nav>
+  </div>
+</aside>

--- a/app/components/lessons/sidebar_component.rb
+++ b/app/components/lessons/sidebar_component.rb
@@ -1,0 +1,20 @@
+module Lessons
+  class SidebarComponent < ApplicationComponent
+    def initialize(course:, sections:, current_lesson:, current_user: nil)
+      @course = course
+      @sections = sections
+      @current_lesson = current_lesson
+      @current_user = current_user
+    end
+
+    private
+
+    attr_reader :course, :sections, :current_lesson, :current_user
+
+    def progress_percentage
+      return if current_user.blank?
+
+      course.progress_for(current_user).percentage
+    end
+  end
+end

--- a/app/components/lessons/sidebar_toggle_controller.js
+++ b/app/components/lessons/sidebar_toggle_controller.js
@@ -1,0 +1,53 @@
+import { Controller } from '@hotwired/stimulus'
+
+export default class SidebarToggleController extends Controller {
+  static outlets = ['visibility']
+  static classes = ['collapsed']
+  static targets = ['item']
+  static values = { storageKey: String }
+
+  connect () {
+    if (this.isDesktop() && window.localStorage.getItem(this.storageKeyValue) === 'true') {
+      this.element.classList.add(this.collapsedClass)
+    }
+  }
+
+  itemTargetConnected (item) {
+    if (item.getAttribute('href') === window.location.pathname) {
+      item.setAttribute('aria-current', 'page')
+      item.closest('details').open = true
+    } else {
+      item.removeAttribute('aria-current')
+    }
+  }
+
+  toggle () {
+    if (this.isDesktop()) {
+      this.isCollapsed() ? this.expand() : this.collapse()
+    } else if (this.hasVisibilityOutlet) {
+      this.visibilityOutlet.toggle()
+    }
+  }
+
+  collapse () {
+    this.element.classList.add(this.collapsedClass)
+    this.persist(true)
+  }
+
+  expand () {
+    this.element.classList.remove(this.collapsedClass)
+    this.persist(false)
+  }
+
+  isDesktop () {
+    return window.matchMedia('(min-width: 1280px)').matches
+  }
+
+  isCollapsed () {
+    return this.element.classList.contains(this.collapsedClass)
+  }
+
+  persist (collapsed) {
+    window.localStorage.setItem(this.storageKeyValue, String(collapsed))
+  }
+}

--- a/app/controllers/lessons/course_contents_controller.rb
+++ b/app/controllers/lessons/course_contents_controller.rb
@@ -1,0 +1,18 @@
+module Lessons
+  class CourseContentsController < ApplicationController
+    before_action :set_cache_control_header_to_no_store
+
+    def show
+      @lesson = Lesson.find(params[:lesson_id])
+      @course = @lesson.course
+      @sections = @course.sections.includes(:lessons)
+
+      return unless user_signed_in?
+
+      Courses::MarkCompletedLessons.call(
+        user: current_user,
+        lessons: @sections.flat_map(&:lessons),
+      )
+    end
+  end
+end

--- a/app/javascript/controllers/sticky_state_controller.js
+++ b/app/javascript/controllers/sticky_state_controller.js
@@ -1,0 +1,24 @@
+import { Controller } from '@hotwired/stimulus'
+
+const FULLY_VISIBLE = 1
+
+export default class StickyStateController extends Controller {
+  static classes = ['stuck']
+
+  connect () {
+    this.observer = new window.IntersectionObserver(
+      ([entry]) => this.toggleStuck(entry.intersectionRatio < FULLY_VISIBLE),
+      { threshold: [FULLY_VISIBLE] }
+    )
+
+    this.observer.observe(this.element)
+  }
+
+  disconnect () {
+    this.observer?.disconnect()
+  }
+
+  toggleStuck (stuck) {
+    this.stuckClasses.forEach((cls) => this.element.classList.toggle(cls, stuck))
+  }
+}

--- a/app/views/lessons/_header.html.erb
+++ b/app/views/lessons/_header.html.erb
@@ -1,24 +1,12 @@
-<header class="mb-16">
-  <div class="flex space-y-4 items-center flex-col justify-center xl:space-y-0 xl:space-x-4 xl:flex-row xl:justify-start">
-    <%= render Course::BadgeComponent.new(course: lesson.course, options: {show_badge: true }) %>
-
-    <div class="text-center xl:text-left">
-      <div class="flex flex-col xl:flex-row items-center gap-0 sm:gap-3">
-        <h1 class="text-2xl font-semibold text-gray-800 dark:text-gray-200" data-test-id="lesson-title-header">
-          <%= lesson.display_title %>
-        </h1>
-        <% if lesson.recently_added? %>
-          <%= render Ui::BadgeComponent.new(color: 'green') do %>
-            new
-          <% end %>
-        <% end %>
-      </div>
-
-      <%= link_to path_course_url(lesson.course.path, lesson.course), class: 'no-underline' do %>
-        <h2 class="min-w-full text-lg text-gray-500 dark:text-gray-400" data-test-id="course-title-header">
-          <%= lesson.course.title %> Course
-        </h2>
+<header class="mb-8 max-w-prose mx-auto xl:mx-0">
+  <div class="flex items-center gap-3">
+    <h1 class="text-3xl font-semibold text-gray-800 dark:text-gray-200" data-test-id="lesson-title-header">
+      <%= lesson.display_title %>
+    </h1>
+    <% if lesson.recently_added? %>
+      <%= render Ui::BadgeComponent.new(color: 'green') do %>
+        new
       <% end %>
-    </div>
+    <% end %>
   </div>
 </header>

--- a/app/views/lessons/_sidebar_skeleton.html.erb
+++ b/app/views/lessons/_sidebar_skeleton.html.erb
@@ -1,0 +1,16 @@
+<div class="hidden xl:block xl:h-full" aria-hidden="true">
+  <div class="sticky top-0 h-screen overflow-hidden pt-4 pb-20 pr-4 animate-pulse">
+    <div class="mb-4 flex flex-col gap-2">
+      <div class="h-3 w-20 bg-gray-200 dark:bg-gray-800 rounded"></div>
+      <div class="h-5 w-40 bg-gray-200 dark:bg-gray-800 rounded"></div>
+      <div class="h-1.5 w-full bg-gray-200 dark:bg-gray-800 rounded-full mt-2"></div>
+      <div class="h-3 w-16 bg-gray-200 dark:bg-gray-800 rounded"></div>
+    </div>
+
+    <div class="flex flex-col gap-6 pt-2">
+      <% 14.times do %>
+        <div class="h-4 w-full bg-gray-200 dark:bg-gray-800 rounded"></div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/lessons/_sub_navbar.html.erb
+++ b/app/views/lessons/_sub_navbar.html.erb
@@ -1,0 +1,15 @@
+<div
+  class="sticky -top-px z-20 bg-white dark:bg-gray-900 -mx-4 sm:-mx-6 lg:-mx-8 xl:-mr-4 xl:-ml-10 group-[.sidebar-collapsed]/sidebar-layout:xl:-ml-4"
+  data-controller="sticky-state"
+  data-sticky-state-stuck-class="border-b border-gray-200 dark:border-gray-800">
+  <div class="h-12 flex items-center px-4 sm:px-6 lg:px-8">
+    <button
+      type="button"
+      class="inline-flex items-center justify-center p-1.5 rounded-md text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800"
+      data-action="click->lessons--sidebar-toggle#toggle"
+      aria-label="Toggle course contents"
+      data-test-id="sidebar-toggle-btn">
+      <%= inline_svg_tag 'icons/panel-left.svg', class: 'h-5 w-5', aria: true, title: 'Toggle course contents' %>
+    </button>
+  </div>
+</div>

--- a/app/views/lessons/completions/create.turbo_stream.erb
+++ b/app/views/lessons/completions/create.turbo_stream.erb
@@ -11,3 +11,11 @@
 <%= turbo_stream.update dom_id(@lesson.course, 'progress') do %>
   <%= render ProgressCircle::Component.new(percentage: @lesson.course.progress_for(current_user).percentage) %>
 <% end %>
+
+<%= turbo_stream.replace_all ".sidebar-completion-icon-#{@lesson.id}" do %>
+  <%= render Lessons::Sidebar::CompletionIconComponent.new(lesson: @lesson) %>
+<% end %>
+
+<%= turbo_stream.replace_all '.sidebar-progress-bar' do %>
+  <%= render Lessons::Sidebar::ProgressBarComponent.new(percentage: @lesson.course.progress_for(current_user).percentage) %>
+<% end %>

--- a/app/views/lessons/course_contents/show.html.erb
+++ b/app/views/lessons/course_contents/show.html.erb
@@ -1,0 +1,3 @@
+<%= turbo_frame_tag 'lesson-sidebar-frame', target: '_top' do %>
+  <%= render Lessons::SidebarComponent.new(course: @course, sections: @sections, current_lesson: @lesson, current_user:) %>
+<% end %>

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -1,68 +1,90 @@
 <%= title(@lesson.display_title) %>
 
-<div class="bg-white dark:bg-gray-900">
-  <div class="py-10 px-4 sm:py-14 sm:px-6 lg:px-8">
-    <div class="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8 xl:grid xl:grid-cols-[1fr_minmax(0,65ch)_1fr] xl:gap-x-10">
+<div
+  class="bg-white dark:bg-gray-900 group/sidebar-layout"
+  data-controller="lessons--sidebar-toggle"
+  data-lessons--sidebar-toggle-storage-key-value="lesson-sidebar-collapsed"
+  data-lessons--sidebar-toggle-collapsed-class="sidebar-collapsed"
+  data-lessons--sidebar-toggle-visibility-outlet=".lesson-sidebar-drawer">
 
-      <div class="xl:col-start-2">
-        <%= render 'lessons/header', lesson: @lesson %>
-      </div>
+  <div class="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8 xl:flex xl:gap-x-10 xl:max-w-none xl:px-4">
 
-      <main class="xl:contents" data-controller="lesson-toc diagramming" data-lesson-toc-item-classes-value="no-underline hover:text-gray-800 text-sm dark:hover:text-gray-300">
+    <%= turbo_frame_tag(
+          'lesson-sidebar-frame',
+          src: lesson_course_contents_path(@lesson),
+          loading: :lazy,
+          target: '_top',
+          data: { turbo_permanent: true },
+          class: 'block xl:w-72 xl:shrink-0 border-gray-200 dark:border-gray-800 xl:border-r group-[.sidebar-collapsed]/sidebar-layout:xl:hidden'
+        ) do %>
+      <%= render 'lessons/sidebar_skeleton' %>
+    <% end %>
 
-        <article class="mx-auto xl:col-start-2 xl:max-w-none">
-          <%= render ContentContainerComponent.new(classes: 'xl:mx-0 pb-6', data_attributes: { lesson_toc_target: 'lessonContent' }) do |component| %>
-            <%= @lesson.body.html_safe %>
+    <div class="xl:flex-1 xl:min-w-0">
 
-            <% component.with_footer do %>
-              <div class="flex flex-col gap-2">
-                <%= render NewTabTextLinkComponent.new(
-                      text: 'Edit on GitHub',
-                      href: github_edit_url(@lesson),
-                      classes: 'inline-flex items-center underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 text-sm'
-                    ) %>
-                <%= render NewTabTextLinkComponent.new(
-                      text: 'Report broken link',
-                      href: github_report_url(@lesson, 'broken_link'),
-                      classes: 'inline-flex items-center underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 text-sm'
-                    ) %>
-                <%= render NewTabTextLinkComponent.new(
-                      text: 'Report other issue/suggestion',
-                      href: github_report_url(@lesson, 'suggestion'),
-                      classes: 'inline-flex items-center underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 text-sm'
-                    ) %>
+      <%= render 'lessons/sub_navbar' %>
+
+      <div class="xl:flex xl:gap-x-10" data-controller="lesson-toc diagramming" data-lesson-toc-item-classes-value="no-underline hover:text-gray-800 text-sm dark:hover:text-gray-300">
+
+        <main class="py-10 sm:pt-14 xl:flex-1 xl:min-w-0 sm:py-14 group-[.sidebar-collapsed]/sidebar-layout:xl:pl-[328px]">
+          <div class="mx-auto xl:max-w-[65ch]">
+            <%= render 'lessons/header', lesson: @lesson %>
+
+            <article>
+              <%= render ContentContainerComponent.new(classes: 'xl:mx-0 pb-6', data_attributes: { lesson_toc_target: 'lessonContent' }) do |component| %>
+                <%= @lesson.body.html_safe %>
+
+                <% component.with_footer do %>
+                  <div class="flex flex-col gap-2">
+                    <%= render NewTabTextLinkComponent.new(
+                          text: 'Edit on GitHub',
+                          href: github_edit_url(@lesson),
+                          classes: 'inline-flex items-center underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 text-sm'
+                        ) %>
+                    <%= render NewTabTextLinkComponent.new(
+                          text: 'Report broken link',
+                          href: github_report_url(@lesson, 'broken_link'),
+                          classes: 'inline-flex items-center underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 text-sm'
+                        ) %>
+                    <%= render NewTabTextLinkComponent.new(
+                          text: 'Report other issue/suggestion',
+                          href: github_report_url(@lesson, 'suggestion'),
+                          classes: 'inline-flex items-center underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 text-sm'
+                        ) %>
+                  </div>
+
+                  <div class="flex flex-col">
+                    <%= render NewTabTextLinkComponent.new(
+                          text: 'See lesson changelog',
+                          href: github_commits_url(@lesson),
+                          classes: 'inline-flex items-center underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 text-sm'
+                        ) %>
+                  </div>
+                <% end %>
+              <% end %>
+
+              <% if user_signed_in? && @lesson.accepts_submission? %>
+                <div class="py-10 border-t border-gray-100 dark:border-white/5">
+                  <div class="max-w-2xl mx-auto xl:max-w-full border border-gray dark:border-white/5 rounded-lg p-4 dark:bg-gray-800">
+                    <%= render 'lessons/project_solution', lesson: @lesson, project_submission: @project_submission %>
+                  </div>
+                </div>
+              <% end %>
+
+              <div class="pt-10 border-t border-gray-100 dark:border-white/5">
+                <%= render 'lesson_buttons', lesson: @lesson, course: @lesson.course, user: @user %>
               </div>
-
-              <div class="flex flex-col">
-                <%= render NewTabTextLinkComponent.new(
-                      text: 'See lesson changelog',
-                      href: github_commits_url(@lesson),
-                      classes: 'inline-flex items-center underline hover:no-underline text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-300 text-sm'
-                    ) %>
-              </div>
-            <% end %>
-          <% end %>
-
-          <% if user_signed_in? && @lesson.accepts_submission? %>
-            <div class="py-10 border-t border-gray-100 dark:border-white/5">
-              <div class="max-w-2xl mx-auto xl:max-w-full border border-gray dark:border-white/5 rounded-lg p-4 dark:bg-gray-800">
-                <%= render 'lessons/project_solution', lesson: @lesson, project_submission: @project_submission %>
-              </div>
-            </div>
-          <% end %>
-
-          <div class="pt-10 border-t border-gray-100 dark:border-white/5">
-            <%= render 'lesson_buttons', lesson: @lesson, course: @lesson.course, user: @user %>
+            </article>
           </div>
-        </article>
+        </main>
 
-        <aside class="hidden xl:block xl:col-start-3 xl:w-72 xl:justify-self-start">
-          <div class="sticky top-12 pb-20">
+        <aside class="hidden xl:block xl:w-72 xl:shrink-0">
+          <div class="sticky top-12 pt-10 sm:pt-14 pb-20">
             <h4 class="text-md pb-4 text-gray-700 dark:text-gray-300">Lesson contents</h4>
             <ul class="flex flex-col text-gray-500 dark:text-gray-400" data-lesson-toc-target="toc"></ul>
           </div>
         </aside>
-      </main>
+      </div>
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,6 +89,7 @@ Rails.application.routes.draw do
   resources :lessons, only: :show do
     resources :project_submissions, except: :show, controller: 'lessons/project_submissions'
     resource :completion, only: %i[create destroy], controller: 'lessons/completions'
+    resource :course_contents, only: :show, controller: 'lessons/course_contents'
   end
 
   resources :project_submissions, only: :index do

--- a/spec/components/lessons/sidebar/completion_icon_component_spec.rb
+++ b/spec/components/lessons/sidebar/completion_icon_component_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe Lessons::Sidebar::CompletionIconComponent, type: :component do
+  context 'when the lesson is completed' do
+    it 'fills the icon with the completed color' do
+      lesson = create(:lesson)
+      lesson.completed = true
+
+      render_inline(described_class.new(lesson:))
+
+      expect(page).to have_css('[data-test-id="lesson-sidebar-completion"].text-teal-600')
+    end
+
+    it 'labels the icon "Lesson completed"' do
+      lesson = create(:lesson)
+      lesson.completed = true
+
+      render_inline(described_class.new(lesson:))
+
+      expect(page).to have_css('svg title', text: 'Lesson completed', visible: :all)
+    end
+  end
+
+  context 'when the lesson is incomplete' do
+    it 'fills the icon with the incomplete color' do
+      lesson = create(:lesson)
+
+      render_inline(described_class.new(lesson:))
+
+      expect(page).to have_css('[data-test-id="lesson-sidebar-completion"].text-gray-300')
+    end
+
+    it 'labels the icon "Lesson not completed"' do
+      lesson = create(:lesson)
+
+      render_inline(described_class.new(lesson:))
+
+      expect(page).to have_css('svg title', text: 'Lesson not completed', visible: :all)
+    end
+  end
+end

--- a/spec/components/lessons/sidebar/lesson_component_spec.rb
+++ b/spec/components/lessons/sidebar/lesson_component_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe Lessons::Sidebar::LessonComponent, type: :component do
+  it 'renders the lesson title as a link' do
+    lesson = create(:lesson, title: 'HTML Basics')
+    component = described_class.new(lesson:, current_lesson: lesson)
+
+    render_inline(component)
+
+    expect(page).to have_link('HTML Basics', href: "/lessons/#{lesson.friendly_id}")
+  end
+
+  context 'when rendered as the current lesson' do
+    it 'marks the link with aria-current="page"' do
+      lesson = create(:lesson)
+      component = described_class.new(lesson:, current_lesson: lesson)
+
+      render_inline(component)
+
+      expect(page).to have_css('a[aria-current="page"]')
+    end
+  end
+
+  context 'when rendered as a sibling lesson' do
+    it 'does not set aria-current' do
+      lesson = create(:lesson)
+      other = create(:lesson, section: lesson.section)
+      component = described_class.new(lesson:, current_lesson: other)
+
+      render_inline(component)
+
+      expect(page).to have_no_css('a[aria-current]')
+    end
+  end
+
+  context 'when a current_user is given' do
+    it 'renders a completion icon' do
+      lesson = create(:lesson)
+      user = create(:user)
+      component = described_class.new(lesson:, current_lesson: lesson, current_user: user)
+
+      render_inline(component)
+
+      expect(page).to have_css('[data-test-id="lesson-sidebar-completion"]')
+    end
+  end
+
+  context 'when no current_user is given' do
+    it 'does not render the completion icon' do
+      lesson = create(:lesson)
+      component = described_class.new(lesson:, current_lesson: lesson)
+
+      render_inline(component)
+
+      expect(page).to have_no_css('[data-test-id="lesson-sidebar-completion"]')
+    end
+  end
+end

--- a/spec/components/lessons/sidebar/section_component_spec.rb
+++ b/spec/components/lessons/sidebar/section_component_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe Lessons::Sidebar::SectionComponent, type: :component do
+  it 'renders the section title' do
+    section = create(:section, title: 'Getting Started')
+    lesson = create(:lesson, section:)
+    component = described_class.new(section:, current_lesson: lesson)
+
+    render_inline(component)
+
+    expect(page).to have_content('Getting Started')
+  end
+
+  it 'renders one link per lesson in the section' do
+    section = create(:section)
+    lessons = create_list(:lesson, 3, section:)
+    section.reload
+    component = described_class.new(section:, current_lesson: lessons.first)
+
+    render_inline(component)
+
+    expect(page).to have_css('li', count: 3)
+  end
+
+  context 'when the section contains the current lesson' do
+    it 'renders <details> with the open attribute' do
+      section = create(:section)
+      lesson = create(:lesson, section:)
+      component = described_class.new(section:, current_lesson: lesson)
+
+      render_inline(component)
+
+      expect(page).to have_css('details[open]')
+    end
+  end
+
+  context 'when the section does not contain the current lesson' do
+    it 'renders <details> without the open attribute' do
+      section = create(:section)
+      create(:lesson, section:)
+      other_section = create(:section, course: section.course)
+      other_lesson = create(:lesson, section: other_section)
+      component = described_class.new(section:, current_lesson: other_lesson)
+
+      render_inline(component)
+
+      expect(page).to have_css('details')
+      expect(page).to have_no_css('details[open]')
+    end
+  end
+end

--- a/spec/components/lessons/sidebar_component_spec.rb
+++ b/spec/components/lessons/sidebar_component_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+
+RSpec.describe Lessons::SidebarComponent, type: :component do
+  def setup_course
+    path = create(:path)
+    course = create(:course, path:)
+    section_one = create(:section, course:)
+    section_two = create(:section, course:)
+    lesson_one = create(:lesson, section: section_one)
+    lesson_two = create(:lesson, section: section_two)
+    { course:, sections: [section_one, section_two], lesson_one:, lesson_two: }
+  end
+
+  it 'renders both the off-canvas drawer and the static desktop aside' do
+    data = setup_course
+    component = described_class.new(
+      course: data[:course],
+      sections: data[:sections],
+      current_lesson: data[:lesson_one],
+    )
+
+    render_inline(component)
+
+    expect(page).to have_css('.lesson-sidebar-drawer')
+    expect(page).to have_css('[data-test-id="lesson-sidebar"]')
+  end
+
+  it 'renders a details element for each section' do
+    data = setup_course
+    component = described_class.new(
+      course: data[:course],
+      sections: data[:sections],
+      current_lesson: data[:lesson_one],
+    )
+
+    render_inline(component)
+
+    within '[data-test-id="lesson-sidebar"]' do
+      expect(page).to have_css('details', count: 2)
+    end
+  end
+
+  it 'opens only the section that contains the current lesson' do
+    data = setup_course
+    component = described_class.new(
+      course: data[:course],
+      sections: data[:sections],
+      current_lesson: data[:lesson_two],
+    )
+
+    render_inline(component)
+
+    within '[data-test-id="lesson-sidebar"]' do
+      expect(page).to have_css('details[open]', count: 1)
+    end
+  end
+
+  it 'links back to the course via the course title' do
+    data = setup_course
+    component = described_class.new(
+      course: data[:course],
+      sections: data[:sections],
+      current_lesson: data[:lesson_one],
+    )
+
+    render_inline(component)
+
+    within '[data-test-id="lesson-sidebar"]' do
+      expect(page).to have_link(data[:course].title)
+    end
+  end
+
+  context 'when a current_user is given' do
+    it 'renders a course-progress bar reflecting their completions' do
+      data = setup_course
+      user = create(:user)
+      create(:lesson_completion, user:, lesson: data[:lesson_one], course: data[:course])
+      component = described_class.new(
+        course: data[:course],
+        sections: data[:sections],
+        current_lesson: data[:lesson_one],
+        current_user: user,
+      )
+
+      render_inline(component)
+
+      within '[data-test-id="lesson-sidebar"]' do
+        expect(page).to have_css('[role="progressbar"][aria-valuenow="50"]')
+        expect(page).to have_text('50% complete')
+      end
+    end
+  end
+
+  context 'when no current_user is given' do
+    it 'does not render a progress bar' do
+      data = setup_course
+      component = described_class.new(
+        course: data[:course],
+        sections: data[:sections],
+        current_lesson: data[:lesson_one],
+      )
+
+      render_inline(component)
+
+      expect(page).to have_no_css('[role="progressbar"]')
+    end
+  end
+end

--- a/spec/requests/lessons/course_contents_spec.rb
+++ b/spec/requests/lessons/course_contents_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe 'Lesson course contents' do
+  describe 'GET #show' do
+    let(:course) { create(:course, path: create(:path, default_path: true)) }
+    let(:section) { create(:section, course:) }
+    let(:lesson) { create(:lesson, section:) }
+
+    it 'renders the sidebar' do
+      get lesson_course_contents_path(lesson)
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include(course.title)
+    end
+
+    context 'when signed in' do
+      let(:user) { create(:user) }
+
+      before { sign_in(user) }
+
+      it 'marks completed lessons across the whole course' do
+        sibling = create(:lesson, section:)
+        create(:lesson_completion, user:, lesson: sibling, course:)
+
+        get lesson_course_contents_path(lesson)
+
+        expect(response.body).to include('Lesson completed')
+      end
+    end
+  end
+end

--- a/spec/system/lessons/sidebar_spec.rb
+++ b/spec/system/lessons/sidebar_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe 'Lesson show sidebar' do
+  let(:user) { create(:user) }
+  let(:course) { create(:course, path: create(:path, default_path: true)) }
+
+  def build_curriculum(course)
+    section_one = create(:section, position: 1, course:, title: 'Getting Started')
+    section_two = create(:section, position: 2, course:, title: 'Advanced Topics')
+    {
+      current: create(:lesson, position: 1, section: section_one, title: 'Intro'),
+      sibling: create(:lesson, position: 2, section: section_one, title: 'Next Steps'),
+      other: create(:lesson, position: 1, section: section_two, title: 'Deep Dive')
+    }
+  end
+
+  before do
+    sign_in(user)
+    page.driver.resize(1400, 900)
+  end
+
+  it 'keeps manually expanded sections open after navigating' do
+    lessons = build_curriculum(course)
+
+    visit lesson_path(lessons[:current])
+
+    within('[data-test-id="lesson-sidebar"]') do
+      find('summary', text: 'Advanced Topics').click
+      click_link lessons[:other].title
+    end
+
+    within('[data-test-id="lesson-sidebar"]') do
+      expect(page).to have_css('details[open]', text: 'Advanced Topics')
+      expect(page).to have_css('details[open]', text: 'Getting Started')
+      expect(page).to have_css('a[aria-current="page"]', text: 'Deep Dive')
+    end
+  end
+end


### PR DESCRIPTION
## Because
The lesson page had no in-page way to navigate between lessons in the same course - learners had to back out to the course page to switch lessons, and the existing header repeated course context (badge, course title link) on every lesson. Adding a persistent course-contents sidebar lets users see where they are in the course, jump between lessons, and track completion without leaving the lesson.

Closes: https://github.com/TheOdinProject/theodinproject/issues/3045

## This PR
- Adds a collapsible left sidebar to the lesson page listing every section and lesson in the current course, with the active lesson highlighted and its section expanded by default
- Introduces `Lessons::SidebarComponent`, `Lessons::Sidebar::SectionComponent`, and `Lessons::Sidebar::LessonComponent`, lazy-loaded via a Turbo Frame backed by a new `Lessons::CourseContentsController`
- Shows per-lesson completion icons and an overall course progress bar in the sidebar; both update in place when a lesson is completed via Turbo Streams
- Adds a sticky lesson sub-navbar with so the sidebar toggle button is always visiable; the collapsed state persists in `localStorage` via a new `lessons--sidebar-toggle` Stimulus controller
- Simplifies the lesson header - removes the course badge and course title link since those are in the sidebar, leaving the lesson title

----

<img width="2045" height="1029" alt="Screenshot 2026-05-03 at 16 08 14" src="https://github.com/user-attachments/assets/fae18038-fdca-4d05-900d-512b08aee84e" />

