### PR TITLE
Feature: Nested lesson_toc anchor elements now inherit the size of their parent li element

### DIFF
--- a/app/javascript/controllers/lesson_toc_controller.js
+++ b/app/javascript/controllers/lesson_toc_controller.js
@@ -57,6 +57,6 @@ export default class LessonTocController extends Controller {
   tocItem (heading) {
     const id = heading.firstChild.getAttribute('href')
 
-    return `<li class="p-2 pl-4"><a class="${this.itemClassesValue}" href="${id}">${heading.innerText}</a></li>`
+    return `<li><a class="block w-full h-full p-2.5 pl-4 ${this.itemClassesValue}" href="${id}">${heading.innerText}</a></li>`
   }
 }


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
This PR helps an accessibility issue within the `lesson table of contents` where individuals found it difficult to click the `<a>` element due to it's size on the screen.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
1. Updated the `a` element styling to now inherit the size of its parent `li` element tag.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #5344 

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
