### PR TITLE
Fix: Fix desktop sidebar padding

### DIFF
--- a/app/assets/stylesheets/custom_styles/layout.css
+++ b/app/assets/stylesheets/custom_styles/layout.css
@@ -15,7 +15,7 @@ html:has([data-controller~="lessons--sidebar-toggle"]) {
 @utility scrollbar-thin {
   scrollbar-width: thin;
   scrollbar-color: var(--color-gray-300) transparent;
-  scrollbar-gutter: stable;
+  scrollbar-gutter: stable both-edges;
 
   &::-webkit-scrollbar {
     width: 6px;

--- a/app/components/lessons/sidebar_component.html.erb
+++ b/app/components/lessons/sidebar_component.html.erb
@@ -21,10 +21,10 @@
 <%# Static desktop sidebar — xl+ %>
 <aside class="hidden xl:block xl:h-full" data-test-id="lesson-sidebar">
   <div class="sticky top-0 h-screen overflow-y-auto scrollbar-thin pt-4 pb-20 pr-2">
-    <div class="mb-4 flex flex-col gap-2">
+    <div class="mb-4 px-2 flex flex-col gap-2">
       <%= render Ui::BackLinkComponent.new(path: path_course_path(course.path, course), name: 'Back to course') %>
 
-      <%= link_to course.title, path_course_path(course.path, course), class: 'text-lg font-semibold text-gray-800 dark:text-gray-200 no-underline hover:underline px-2' %>
+      <%= link_to course.title, path_course_path(course.path, course), class: 'text-lg font-semibold text-gray-800 dark:text-gray-200 no-underline hover:underline' %>
 
       <% if progress_percentage %>
         <%= render Lessons::Sidebar::ProgressBarComponent.new(percentage: progress_percentage) %>

--- a/app/components/lessons/sidebar_component.html.erb
+++ b/app/components/lessons/sidebar_component.html.erb
@@ -1,9 +1,9 @@
 <%= render Overlays::DrawerComponent.new(hook_class: 'lesson-sidebar-drawer', breakpoint: :xl, close_label: 'Close course contents', aria_label: 'Course contents') do %>
   <div class="flex grow flex-col gap-y-4 overflow-y-auto scrollbar-thin bg-white dark:bg-gray-900 px-4 pb-6 pt-5">
-    <div class="flex flex-col gap-2">
+    <div class="px-2 flex flex-col gap-2">
       <%= render Ui::BackLinkComponent.new(path: path_course_path(course.path, course), name: 'Back to course') %>
 
-      <%= link_to course.title, path_course_path(course.path, course), class: 'text-lg font-semibold text-gray-800 dark:text-gray-200 no-underline hover:underline px-2' %>
+      <%= link_to course.title, path_course_path(course.path, course), class: 'text-lg font-semibold text-gray-800 dark:text-gray-200 no-underline hover:underline' %>
 
       <% if progress_percentage %>
         <%= render Lessons::Sidebar::ProgressBarComponent.new(percentage: progress_percentage) %>

--- a/app/components/lessons/sidebar_component.html.erb
+++ b/app/components/lessons/sidebar_component.html.erb
@@ -20,7 +20,7 @@
 
 <%# Static desktop sidebar — xl+ %>
 <aside class="hidden xl:block xl:h-full" data-test-id="lesson-sidebar">
-  <div class="sticky top-0 h-screen overflow-y-auto scrollbar-thin pt-4 pb-20 pr-2">
+  <div class="sticky top-0 h-screen overflow-y-auto scrollbar-thin pt-4 pb-20 px-2">
     <div class="mb-4 px-2 flex flex-col gap-2">
       <%= render Ui::BackLinkComponent.new(path: path_course_path(course.path, course), name: 'Back to course') %>
 

--- a/app/components/lessons/sidebar_component.html.erb
+++ b/app/components/lessons/sidebar_component.html.erb
@@ -20,7 +20,7 @@
 
 <%# Static desktop sidebar — xl+ %>
 <aside class="hidden xl:block xl:h-full" data-test-id="lesson-sidebar">
-  <div class="sticky top-0 h-screen overflow-y-auto scrollbar-thin pt-4 pb-20">
+  <div class="sticky top-0 h-screen overflow-y-auto scrollbar-thin pt-4 pb-20 pr-4">
     <div class="mb-4 flex flex-col gap-2">
       <%= render Ui::BackLinkComponent.new(path: path_course_path(course.path, course), name: 'Back to course') %>
 

--- a/app/components/lessons/sidebar_component.html.erb
+++ b/app/components/lessons/sidebar_component.html.erb
@@ -3,7 +3,7 @@
     <div class="flex flex-col gap-2">
       <%= render Ui::BackLinkComponent.new(path: path_course_path(course.path, course), name: 'Back to course') %>
 
-      <%= link_to course.title, path_course_path(course.path, course), class: 'text-lg font-semibold text-gray-800 dark:text-gray-200 no-underline hover:underline' %>
+      <%= link_to course.title, path_course_path(course.path, course), class: 'text-lg font-semibold text-gray-800 dark:text-gray-200 no-underline hover:underline px-2' %>
 
       <% if progress_percentage %>
         <%= render Lessons::Sidebar::ProgressBarComponent.new(percentage: progress_percentage) %>
@@ -20,11 +20,11 @@
 
 <%# Static desktop sidebar — xl+ %>
 <aside class="hidden xl:block xl:h-full" data-test-id="lesson-sidebar">
-  <div class="sticky top-0 h-screen overflow-y-auto scrollbar-thin pt-4 pb-20 pr-4">
+  <div class="sticky top-0 h-screen overflow-y-auto scrollbar-thin pt-4 pb-20 pr-2">
     <div class="mb-4 flex flex-col gap-2">
       <%= render Ui::BackLinkComponent.new(path: path_course_path(course.path, course), name: 'Back to course') %>
 
-      <%= link_to course.title, path_course_path(course.path, course), class: 'text-lg font-semibold text-gray-800 dark:text-gray-200 no-underline hover:underline' %>
+      <%= link_to course.title, path_course_path(course.path, course), class: 'text-lg font-semibold text-gray-800 dark:text-gray-200 no-underline hover:underline px-2' %>
 
       <% if progress_percentage %>
         <%= render Lessons::Sidebar::ProgressBarComponent.new(percentage: progress_percentage) %>

--- a/app/views/lessons/_sidebar_skeleton.html.erb
+++ b/app/views/lessons/_sidebar_skeleton.html.erb
@@ -1,5 +1,5 @@
 <div class="hidden xl:block xl:h-full" aria-hidden="true">
-  <div class="sticky top-0 h-screen overflow-hidden pt-4 pb-20 pr-4 animate-pulse">
+  <div class="sticky top-0 h-screen overflow-hidden pt-4 pb-20 px-2 animate-pulse">
     <div class="mb-4 flex flex-col gap-2">
       <div class="h-3 w-20 bg-gray-200 dark:bg-gray-800 rounded"></div>
       <div class="h-5 w-40 bg-gray-200 dark:bg-gray-800 rounded"></div>

--- a/app/views/lessons/_sub_navbar.html.erb
+++ b/app/views/lessons/_sub_navbar.html.erb
@@ -1,8 +1,8 @@
 <div
-  class="sticky -top-px z-20 bg-white dark:bg-gray-900 -mx-4 sm:-mx-6 lg:-mx-8 xl:-mr-4 xl:-ml-10 group-[.sidebar-collapsed]/sidebar-layout:xl:-ml-4"
+  class="sticky -top-px z-20 bg-white dark:bg-gray-900"
   data-controller="sticky-state"
   data-sticky-state-stuck-class="border-b border-gray-200 dark:border-gray-800">
-  <div class="h-12 flex items-center px-4 sm:px-6 lg:px-8">
+  <div class="h-12 flex items-center">
     <button
       type="button"
       class="inline-flex items-center justify-center p-1.5 rounded-md text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800"

--- a/app/views/lessons/_sub_navbar.html.erb
+++ b/app/views/lessons/_sub_navbar.html.erb
@@ -1,11 +1,11 @@
 <div
-  class="sticky -top-px z-20 bg-white dark:bg-gray-900"
+  class="sticky px-4 sm:px-6 lg:px-8 -top-px z-20 bg-white dark:bg-gray-900"
   data-controller="sticky-state"
   data-sticky-state-stuck-class="border-b border-gray-200 dark:border-gray-800">
   <div class="h-12 flex items-center">
     <button
       type="button"
-      class="inline-flex items-center justify-center -ml-1.5 p-1.5 rounded-md text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800"
+      class="inline-flex items-center justify-center p-1.5 rounded-md text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800"
       data-action="click->lessons--sidebar-toggle#toggle"
       aria-label="Toggle course contents"
       data-test-id="sidebar-toggle-btn">

--- a/app/views/lessons/_sub_navbar.html.erb
+++ b/app/views/lessons/_sub_navbar.html.erb
@@ -5,7 +5,7 @@
   <div class="h-12 flex items-center">
     <button
       type="button"
-      class="inline-flex items-center justify-center p-1.5 rounded-md text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800"
+      class="inline-flex items-center justify-center -ml-1.5 p-1.5 rounded-md text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800"
       data-action="click->lessons--sidebar-toggle#toggle"
       aria-label="Toggle course contents"
       data-test-id="sidebar-toggle-btn">

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -7,7 +7,7 @@
   data-lessons--sidebar-toggle-collapsed-class="sidebar-collapsed"
   data-lessons--sidebar-toggle-visibility-outlet=".lesson-sidebar-drawer">
 
-  <div class="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8 xl:flex xl:gap-x-10 xl:max-w-none xl:px-2">
+  <div class="max-w-screen-2xl mx-auto xl:flex xl:max-w-none">
 
     <%= turbo_frame_tag(
           'lesson-sidebar-frame',
@@ -24,9 +24,9 @@
 
       <%= render 'lessons/sub_navbar' %>
 
-      <div class="xl:flex xl:gap-x-10" data-controller="lesson-toc diagramming" data-lesson-toc-item-classes-value="no-underline hover:text-gray-800 text-sm dark:hover:text-gray-300">
+      <div class="xl:flex xl:gap-x-10 px-6 sm:px-8 xl:px-10" data-controller="lesson-toc diagramming" data-lesson-toc-item-classes-value="no-underline hover:text-gray-800 text-sm dark:hover:text-gray-300">
 
-        <main class="py-10 sm:pt-14 xl:flex-1 xl:min-w-0 sm:py-14 group-[.sidebar-collapsed]/sidebar-layout:xl:pl-[328px]">
+        <main class="py-10 sm:pt-14 xl:flex-1 xl:min-w-0 sm:py-14 group-[.sidebar-collapsed]/sidebar-layout:xl:pl-72">
           <div class="mx-auto xl:max-w-[65ch]">
             <%= render 'lessons/header', lesson: @lesson %>
 

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -15,7 +15,7 @@
           loading: :lazy,
           target: '_top',
           data: { turbo_permanent: true },
-          class: 'block xl:w-72 xl:shrink-0 border-gray-200 dark:border-gray-800 xl:border-r group-[.sidebar-collapsed]/sidebar-layout:xl:hidden'
+          class: 'block xl:w-80 xl:shrink-0 border-gray-200 dark:border-gray-800 xl:border-r group-[.sidebar-collapsed]/sidebar-layout:xl:hidden'
         ) do %>
       <%= render 'lessons/sidebar_skeleton' %>
     <% end %>
@@ -26,7 +26,7 @@
 
       <div class="xl:flex xl:gap-x-10 px-6 sm:px-8 xl:px-10" data-controller="lesson-toc diagramming" data-lesson-toc-item-classes-value="no-underline hover:text-gray-800 text-sm dark:hover:text-gray-300">
 
-        <main class="py-10 sm:pt-14 xl:flex-1 xl:min-w-0 sm:py-14 group-[.sidebar-collapsed]/sidebar-layout:xl:pl-72">
+        <main class="py-10 sm:pt-14 xl:flex-1 xl:min-w-0 sm:py-14 group-[.sidebar-collapsed]/sidebar-layout:xl:pl-80">
           <div class="mx-auto xl:max-w-[65ch]">
             <%= render 'lessons/header', lesson: @lesson %>
 

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -7,7 +7,7 @@
   data-lessons--sidebar-toggle-collapsed-class="sidebar-collapsed"
   data-lessons--sidebar-toggle-visibility-outlet=".lesson-sidebar-drawer">
 
-  <div class="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8 xl:flex xl:gap-x-10 xl:max-w-none xl:px-4">
+  <div class="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8 xl:flex xl:gap-x-10 xl:max-w-none xl:px-2">
 
     <%= turbo_frame_tag(
           'lesson-sidebar-frame',


### PR DESCRIPTION


<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
In most cases, seems fine since we have block padding in the sidebar itself and visually some left "padding" (which is from the containing div) but the lack of right padding is very noticeable with the progress bar or highlighted lesson.
In the mobile sidebar, since it's a standalone element, it has its own padding on all 4 sides.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Fixes padding in sidebar component
- Reduces container padding to match
- Simplifies sidebar toggle CSS to prevent horizontal overflow issues

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #5364


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
