### PR TITLE
Fix: Correct a typo in community guide page

### DIFF
--- a/app/views/guides/community/rules.html.erb
+++ b/app/views/guides/community/rules.html.erb
@@ -49,7 +49,7 @@
       <li>Send direct messages, friend requests, or ping another user without prior consent</li>
       <li>Ask your question in multiple channels</li>
       <li>Intrude into a public 1:1 conversation by providing a different answer</li>
-      <li>Avoid asking low effort questions that are missing relevant details</li>
+      <li>Ask low effort questions that are missing relevant details</li>
       <li>Share resources that are not relevant to our curriculum</li>
       <li>Correct or confront another user about their misconduct</li>
       <li>Act unprofessionally or treat anyone disrespectfully</li>


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
"Avoid asking" is redundant under a "Don't" list — "Don't Avoid Asking" reads as a double negative.
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->


## This PR
Changed "Avoid asking low effort questions that are missing relevant details" → "Ask low effort questions that are missing relevant details" under the "Don't" list
<!-- A bullet point list of one or more items describing the specific changes. -->

## Issue
N/A
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
N/A

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
