### PR TITLE
Chore: remove unused User completions methods

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,16 +46,6 @@ class User < ApplicationRecord
     @progress[course]
   end
 
-  def completed?(lesson)
-    completed_lessons.pluck(:id).include?(lesson.id)
-  end
-
-  def latest_completed_lesson
-    return if last_lesson_completed.nil?
-
-    Lesson.find(last_lesson_completed.lesson_id)
-  end
-
   def lesson_completions_for_course(course)
     lesson_completions.where(course_id: course.id)
   end
@@ -88,10 +78,6 @@ class User < ApplicationRecord
   end
 
   private
-
-  def last_lesson_completed
-    lesson_completions.order(created_at: :asc).last
-  end
 
   def enroll_in_foundations
     default_path = Path.default_path

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -83,65 +83,6 @@ RSpec.describe User do
     end
   end
 
-  describe '#completed?' do
-    let(:lesson) { create(:lesson) }
-
-    context 'when the user has completed the lesson' do
-      it 'returns true' do
-        create(:lesson_completion, lesson:, user:)
-
-        expect(user.completed?(lesson)).to be(true)
-      end
-    end
-
-    context 'when the user has not completed the lesson' do
-      it 'returns false' do
-        expect(user.completed?(lesson)).to be(false)
-      end
-    end
-  end
-
-  describe '#latest_completed_lesson' do
-    let(:lesson_completed_last_week) { create(:lesson) }
-    let(:lesson_completed_yesterday) { create(:lesson) }
-    let(:lesson_completed_today) { create(:lesson) }
-
-    context 'when the user has completed any lessons' do
-      before do
-        create(
-          :lesson_completion,
-          lesson: lesson_completed_last_week,
-          user:,
-          created_at: Time.zone.today - 7.days
-        )
-
-        create(
-          :lesson_completion,
-          lesson: lesson_completed_yesterday,
-          user:,
-          created_at: Time.zone.today - 1.day
-        )
-
-        create(
-          :lesson_completion,
-          lesson: lesson_completed_today,
-          user:,
-          created_at: Time.zone.today
-        )
-      end
-
-      it 'returns the latest completed lesson' do
-        expect(user.latest_completed_lesson).to eql(lesson_completed_today)
-      end
-    end
-
-    context 'when the user does not have any completed lessons' do
-      it 'returns nil' do
-        expect(user.latest_completed_lesson).to be_nil
-      end
-    end
-  end
-
   describe '#lesson_completions_for_course' do
     it 'returns the users lesson completions for a course' do
       create(:lesson_completion, user:)


### PR DESCRIPTION
## Because
Both `User#completed?` and `User#latest_completed_lesson` are unused in the production codebase (only referenced/called in the test suite). Removing them cleans up dead code.

## This PR
- Deletes `User#completed?` and `User#latest_completed_lesson` from `app/models/user.rb`.
- Removes the corresponding tests from `spec/models/user_spec.rb`.

## Issue
Closes #5343

## Pull Request Requirements
- [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
- [x] The title of this PR follows the `keyword: brief description of change` format
- [x] The `Because` section summarizes the reason for this PR
- [x] The `This PR` section has a bullet point list describing the changes in this PR
- [x] I have verified all tests and linters pass after making these changes.
- [x] If this PR addresses an open issue, it is linked in the `Issue` section
