### PR TITLE
Feature: project submission UI changes

### DIFF
--- a/app/components/project_submissions/item_component.html.erb
+++ b/app/components/project_submissions/item_component.html.erb
@@ -15,11 +15,11 @@
     </div>
 
     <div class="flex flex-row md:items-center">
-      <%= link_to 'View GitHub repo', project_submission.repo_url, target: '_blank', rel: 'noreferrer', class: 'button button--gray mr-4', data: { test_id: 'view-code-btn' } %>
-
       <% if project_submission.lesson.previewable? && project_submission.live_preview_url? %>
         <%= link_to 'Live preview', project_submission.live_preview_url, target: '_blank', rel: 'noreferrer', class: 'button button--gray mr-4', data: { test_id: 'live-preview-btn' } %>
       <% end %>
+
+      <%= link_to 'View GitHub repo', project_submission.repo_url, target: '_blank', rel: 'noreferrer', class: 'button button--gray mr-4', data: { test_id: 'view-code-btn' } %>
 
       <div class="flex-none absolute top-7 right-0 md:relative md:top-auto md:right-auto" data-controller="visibility" data-action="visibility:click:outside->visibility#off" data-visibility-visible-value="false">
         <button type="button" data-action="click->visibility#toggle" data-test-id="submission-action-menu-btn" class="-m-2.5 block p-2.5 text-gray-500 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100" id="options-menu-0-button" aria-expanded="false" aria-haspopup="true">

--- a/app/components/project_submissions/item_component.html.erb
+++ b/app/components/project_submissions/item_component.html.erb
@@ -15,10 +15,10 @@
     </div>
 
     <div class="flex flex-row md:items-center">
-      <%= link_to 'View GitHub repo', project_submission.repo_url, target: '_blank', rel: 'noreferrer', class: 'button button--gray font-semibold mr-4', data: { test_id: 'view-code-btn' } %>
+      <%= link_to 'View GitHub repo', project_submission.repo_url, target: '_blank', rel: 'noreferrer', class: 'button button--gray mr-4', data: { test_id: 'view-code-btn' } %>
 
       <% if project_submission.lesson.previewable? && project_submission.live_preview_url? %>
-        <%= link_to 'Live preview', project_submission.live_preview_url, target: '_blank', rel: 'noreferrer', class: 'button button--gray font-semibold mr-4', data: { test_id: 'live-preview-btn' } %>
+        <%= link_to 'Live preview', project_submission.live_preview_url, target: '_blank', rel: 'noreferrer', class: 'button button--gray mr-4', data: { test_id: 'live-preview-btn' } %>
       <% end %>
 
       <div class="flex-none absolute top-7 right-0 md:relative md:top-auto md:right-auto" data-controller="visibility" data-action="visibility:click:outside->visibility#off" data-visibility-visible-value="false">

--- a/app/components/project_submissions/user_solution_component.html.erb
+++ b/app/components/project_submissions/user_solution_component.html.erb
@@ -7,10 +7,10 @@
     </div>
 
     <div class="flex flex-row shrink-0 md:items-center">
-      <%= link_to 'View GitHub repo', project_submission.repo_url, target: '_blank', rel: 'noreferrer', class: 'button button--gray font-semibold mr-4', data: { test_id: 'view-code-btn' } %>
+      <%= link_to 'View GitHub repo', project_submission.repo_url, target: '_blank', rel: 'noreferrer', class: 'button button--gray mr-4', data: { test_id: 'view-code-btn' } %>
 
       <% if project_submission.lesson.previewable? && project_submission.live_preview_url? %>
-        <%= link_to 'Live preview', project_submission.live_preview_url, target: '_blank', rel: 'noreferrer', class: 'button button--gray font-semibold mr-4', data: { test_id: 'live-preview-btn' } %>
+        <%= link_to 'Live preview', project_submission.live_preview_url, target: '_blank', rel: 'noreferrer', class: 'button button--gray mr-4', data: { test_id: 'live-preview-btn' } %>
       <% end %>
 
       <div class="flex-none absolute top-7 right-0 md:relative md:top-auto md:right-auto" data-controller="visibility" data-action="visibility:click:outside->visibility#off" data-visibility-visible-value="false">

--- a/app/components/project_submissions/user_solution_component.html.erb
+++ b/app/components/project_submissions/user_solution_component.html.erb
@@ -7,11 +7,11 @@
     </div>
 
     <div class="flex flex-row shrink-0 md:items-center">
-      <%= link_to 'View GitHub repo', project_submission.repo_url, target: '_blank', rel: 'noreferrer', class: 'button button--gray mr-4', data: { test_id: 'view-code-btn' } %>
-
       <% if project_submission.lesson.previewable? && project_submission.live_preview_url? %>
         <%= link_to 'Live preview', project_submission.live_preview_url, target: '_blank', rel: 'noreferrer', class: 'button button--gray mr-4', data: { test_id: 'live-preview-btn' } %>
       <% end %>
+
+      <%= link_to 'View GitHub repo', project_submission.repo_url, target: '_blank', rel: 'noreferrer', class: 'button button--gray mr-4', data: { test_id: 'view-code-btn' } %>
 
       <div class="flex-none absolute top-7 right-0 md:relative md:top-auto md:right-auto" data-controller="visibility" data-action="visibility:click:outside->visibility#off" data-visibility-visible-value="false">
         <button type="button" data-action="click->visibility#toggle" data-test-id="submission-action-menu-btn" class="-m-2.5 block p-2.5 text-gray-500 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100" id="options-menu-0-button" aria-expanded="false" aria-haspopup="true">


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
This PR updates the order in which the project buttons ([Live Preview] and [View GitHub Repo]) are displayed including their `font-weight`.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Reverses the order of [Live Preview] and [View GitHub Repo] buttons
- Removes `font-semibold` from both buttons for consistency

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #5336 

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
