### PR TITLE
Docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+.git
+.github

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM ruby:3.4.6
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+WORKDIR /home/user
+RUN echo -e "#!/bin/bash\nrails db:create && rails db:environment:set RAILS_ENV=development && rails db:schema:load && rails db:seed && rails curriculum:update_content" >> /usr/bin/load \
+    && chmod +x /usr/bin/load \
+    && echo -e "#!/bin/bash\nrails curriculum:update_content" >> /usr/bin/update \
+    && chmod +x /usr/bin/update
+
+COPY .yarn .yarn
+COPY package.json yarn.lock .yarnrc.yml .node-version ./
+ENV BASH_ENV "${HOME}/.bash_env"
+RUN touch "${BASH_ENV}" && echo '. "${BASH_ENV}"' >> ~/.bashrc && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.4/install.sh | PROFILE="${BASH_ENV}" bash
+RUN echo node > .nvmrc && nvm install 24 && npm install --global yarn && yarn install
+
+COPY Gemfile Gemfile.lock .ruby-version ./
+RUN gem install bundler:2.7.1 foreman && bundle install
+
+CMD bin/dev

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,37 @@
+services:
+  top:
+    build: .
+    image: top
+    container_name: top
+    tty: true
+    depends_on:
+      - postgres
+      - redis
+    volumes:
+      - ./:/home/user
+    env_file: .env
+    ports:
+      - 3000:3000
+    environment:
+      POSTGRES_HOST: postgres
+      REDIS_URL: redis://redis:6379/1
+
+  postgres:
+    image: postgres:18.4
+    volumes:
+      - db-data:/var/lib/postgresql/18/docker
+    environment:
+      POSTGRES_USER: ${POSTGRES_USERNAME}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 10s
+      retries: 5
+      start_period: 30s
+      timeout: 10s
+
+  redis:
+    image: redis:8.6.2-alpine
+
+volumes:
+  db-data:

--- a/compose.yaml
+++ b/compose.yaml
@@ -17,7 +17,8 @@ services:
       REDIS_URL: redis://redis:6379/1
 
   postgres:
-    image: postgres:18.4
+    image: postgres:18.4-alpine3.23
+    container_name: top-postgres
     volumes:
       - db-data:/var/lib/postgresql/18/docker
     environment:
@@ -32,6 +33,7 @@ services:
 
   redis:
     image: redis:8.6.2-alpine
+    container_name: top-redis
 
 volumes:
   db-data:


### PR DESCRIPTION
Experimental Draft for Container to try and make a fast setting up of TOP to make it easier for newer people to have it running and making changes. Alternatively could make deployment easier in the future.

set up the `.env`, importantly to populate the database with content it needs to have `github API key`, and add `postgress username and password`, both will be used by both postgres and top images automatically.

run `docker compose up use flag -d`  wait until it builds the image and runs the container. by default the image will run with command `bin/dev`, we can update it in `compose.yaml` with `command:` for different start up commands, but this is not important for now as `bin/dev` will get the server running.

I'm not sure at what point you might need to restart the server since it has hotloading. But once it is up and running, you can run commands on the image directly with `docker exec` example: `docker exec top rails db:seed` will run the `rails sb:seed` command inside the container. For 4 commands, `seed`, `set_env`, `schema:load` and `update_curriculum` I created an easy to use script `load` which will use all of them. After the server finished building the image, just run `docker exec top load` which will run the script to populate the database. Afterward you only need to run the update when you need to pull new changes with `docker exec top update` which is shortcut for `docker exec top rails curriculum:update_content`

After that we create a virtual Volume that links the current directory instead of copying files to the image, this way any changes you do in the files / code of the current directory, will auto reflect inside Docker image. Which is the part this draft is trying to test and challenge to see how easy it is actually for developing using this container running. We only initially copy few files like `package.json` at the start of image building, because of docker layers. This will be explained further bellow.

Remember any command can be run, for example to run the rspec command you would do  `docker exec top bin/rspec`

The database auto creates a volume so to clear it up you can check the name with `docker volume ls` and then use docker `volume rm $name`  you might need to run docker compose down first to free up the volume usage

To open bash session and explore the running image manually run `docker exec -it top bash` which will give you interactive bash into the container.

If you need to restart the container you can do `docker compose down` and then `docker compose up -d` the `-d` flag is to run de-attached otherwise your terminal will be occupied.

The slowest part of building the image is installing Gems and Node packages. Thats why we take advantage of docker layers by first moving all important files to build `node_modules` like `package.json` then we build it with yum. after that we move the files to build the Ruby gems by copying the `Gemfiles` and then we build the gems.

By doing it this way, building `node_modules` or `Gemfiles` will ever retrigger ONLY when either of those files gets edited. If they are not edited they will be cached and spinning up a new compose will much faster than first run. You can see after running `docker compose down` and `docker compose up -d`
