### PR TITLE
Feature: Add live notifications via Turbo Streams

### DIFF
--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,0 +1,4 @@
+module ApplicationCable
+  class Channel < ActionCable::Channel::Base
+  end
+end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,0 +1,11 @@
+module ApplicationCable
+  class Connection < ActionCable::Connection::Base
+    identified_by :current_user
+
+    # Streams are authorized by Turbo's signed stream names, so we identify the
+    # user when Warden has one but don't reject anonymous connections.
+    def connect
+      self.current_user = env['warden']&.user
+    end
+  end
+end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -2,7 +2,7 @@ class NotificationsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @notifications = current_user.notifications
+    @notifications = current_user.notifications.newest_first
   end
 
   def update

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,6 +31,6 @@ module ApplicationHelper
   end
 
   def unread_notifications?(user)
-    user.notifications.any?(&:unread?)
+    user.notifications.unread.exists?
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -2,6 +2,9 @@ class Notification < ApplicationRecord
   belongs_to :recipient, polymorphic: true
 
   scope :unread, -> { where(read_at: nil) }
+  scope :newest_first, -> { order(created_at: :desc) }
+
+  after_create_commit :broadcast_created
 
   def read?
     read_at.present?
@@ -13,5 +16,30 @@ class Notification < ApplicationRecord
 
   def mark_as_read!
     update(read_at: Time.current)
+  end
+
+  private
+
+  def broadcast_created
+    broadcast_to_list
+    broadcast_unread_indicator
+  end
+
+  def broadcast_to_list
+    broadcast_prepend_to(
+      [recipient, :notifications],
+      target: 'notifications',
+      partial: 'notifications/notification',
+      locals: { notification: self }
+    )
+  end
+
+  def broadcast_unread_indicator
+    broadcast_replace_to(
+      [recipient, :notifications],
+      target: 'notification_bell',
+      partial: 'shared/notification_bell',
+      locals: { user: recipient }
+    )
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,6 +28,9 @@
   </head>
 
   <body data-controller="dialog-router" class="h-full bg-gray-50 text-gray-600 dark:bg-gray-900 dark:text-gray-300">
+    <% if user_signed_in? %>
+      <%= turbo_stream_from current_user, :notifications %>
+    <% end %>
     <%= render AnnouncementComponent.new(announcement: Announcement.showable_messages(disabled_announcement_ids).first) %>
     <%= render 'shared/navbar' %>
     <div id="flash-messages">

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -1,0 +1,1 @@
+<%= render NotificationComponent.new(notification:) %>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="page-container h-screen">
   <h1 class="page-heading-title">Notifications</h1>
-  <ul class="space-y-3 max-w-3xl mx-auto">
+  <ul id="notifications" class="space-y-3 max-w-3xl mx-auto">
     <% unless @notifications.empty? %>
       <%= render NotificationComponent.with_collection(@notifications) %>
     <% else %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -19,13 +19,7 @@
             <%= render Nav::ItemComponent.new(path: support_us_path, text: 'Support us', test_id: 'nav-support-us') %>
           </div>
 
-          <%= link_to notifications_path, class: 'ml-3 bg-white dark:bg-gray-900 p-1 rounded-full text-gray-400 dark:text-gray-300 relative hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-gold-500', data: { test_id: 'navbar-notification-icon' } do %>
-            <span class="sr-only">View notifications</span>
-            <% if unread_notifications?(current_user) %>
-                <span data-test-id="unread-notifications" class="absolute top-1 right-0.5 w-2 h-2 rounded-lg bg-gold-500"></span>
-              <% end %>
-            <%= inline_svg_tag 'icons/bell.svg', class: 'h-6 w-6', aria: true, title: 'Notifications icon' %>
-          <% end %>
+          <%= render 'shared/notification_bell', user: current_user %>
           <%= turbo_frame_tag 'theme_switcher', class: 'flex items-center justify-center' do %>
             <%= render Theme::SwitcherComponent.new(current_theme:, type: :icon_only) %>
           <% end %>

--- a/app/views/shared/_notification_bell.html.erb
+++ b/app/views/shared/_notification_bell.html.erb
@@ -1,0 +1,7 @@
+<%= link_to notifications_path, id: 'notification_bell', class: 'ml-3 bg-white dark:bg-gray-900 p-1 rounded-full text-gray-400 dark:text-gray-300 relative hover:text-gray-500 focus:outline-hidden focus:ring-2 focus:ring-gold-500', data: { test_id: 'navbar-notification-icon' } do %>
+  <span class="sr-only">View notifications</span>
+  <% if unread_notifications?(user) %>
+    <span data-test-id="unread-notifications" class="absolute top-1 right-0.5 w-2 h-2 rounded-lg bg-gold-500"></span>
+  <% end %>
+  <%= inline_svg_tag 'icons/bell.svg', class: 'h-6 w-6', aria: true, title: 'Notifications icon' %>
+<% end %>

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -3,7 +3,7 @@ development:
   url: redis://localhost:6379/1
 
 test:
-  adapter: test
+  adapter: async
 
 production:
   adapter: redis

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe Notification do
+  describe '.newest_first' do
+    it 'orders notifications by most recently created first' do
+      oldest = create(:notification, created_at: 2.days.ago)
+      newest = create(:notification, created_at: 1.hour.ago)
+      middle = create(:notification, created_at: 1.day.ago)
+
+      expect(described_class.newest_first).to eq([newest, middle, oldest])
+    end
+  end
+end

--- a/spec/support/non_transactional.rb
+++ b/spec/support/non_transactional.rb
@@ -1,0 +1,23 @@
+# Allows an example group to opt out of transactional fixtures via the
+# `:non_transactional` metadata tag, so that `after_commit` callbacks (e.g. Turbo
+# Stream broadcasts) actually fire. Overriding `run_in_transaction?` is the hook
+# rspec-rails itself uses to decide whether to wrap the example in a transaction.
+# Records created during the example are removed afterwards by truncating the tables.
+module NonTransactional
+  def run_in_transaction?
+    return false if RSpec.current_example&.metadata&.[](:non_transactional)
+
+    super
+  end
+end
+
+RSpec.configure do |config|
+  config.prepend NonTransactional
+
+  config.append_after(:each, :non_transactional) do
+    connection = ActiveRecord::Base.connection
+    tables = connection.tables - %w[ar_internal_metadata schema_migrations]
+    table_list = tables.map { connection.quote_table_name(it) }.join(', ')
+    connection.execute("TRUNCATE #{table_list} RESTART IDENTITY CASCADE")
+  end
+end

--- a/spec/system/live_notifications_spec.rb
+++ b/spec/system/live_notifications_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe 'Live notifications', :non_transactional do
+  let(:user) { create(:user) }
+
+  before do
+    sign_in(user)
+  end
+
+  context 'when on the notifications page' do
+    it 'shows a new notification without a page refresh' do
+      visit notifications_path
+      expect(page).to have_content('No notifications yet')
+      wait_for_cable_subscription
+
+      deliver_notification
+
+      within('#notifications') do
+        expect(page).to have_content('has a broken link in your submission')
+      end
+    end
+  end
+
+  context 'when on another page' do
+    it 'lights up the notification bell without a page refresh' do
+      visit root_path
+      wait_for_cable_subscription
+      expect(page).to have_no_css("[data-test-id='unread-notifications']")
+
+      deliver_notification
+
+      expect(page).to have_css("[data-test-id='unread-notifications']")
+    end
+  end
+
+  def wait_for_cable_subscription
+    expect(page).to have_css('turbo-cable-stream-source[connected]', visible: :all)
+  end
+
+  def deliver_notification
+    flag = create(:flag, project_submission: create(:project_submission, user:))
+    Notifications::DeadLinkNotification.new(flag).deliver
+  end
+end


### PR DESCRIPTION
## Because
- Users only saw new notifications after refreshing the page. Closes #3529 by pushing notifications in real time for a better experience.

## This PR
- Adds ActionCable scaffolding (ApplicationCable::Connection/Channel) and a per-user `turbo_stream_from` subscription in the layout.
- Broadcasts on notification create via an `after_create_commit` callback: prepends the new row to the notifications list and replaces the navbar bell so its unread indicator updates live.
- Extracts the bell into `shared/_notification_bell` and the row into `notifications/_notification` so live and server-rendered markup match.
- Orders the notifications index newest-first, matching the live prepend.
- Switches the test ActionCable adapter to `async` and adds a `:non_transactional` spec helper so `after_commit` fires, with an end-to-end system test of the live updates.