### PR TITLE
Feature: Drawer component closes on outside clicks

### DIFF
--- a/app/components/overlays/drawer_component.html.erb
+++ b/app/components/overlays/drawer_component.html.erb
@@ -20,7 +20,9 @@
     data-transition-leave-end="opacity-0">
   </div>
 
-  <div class="fixed inset-0 flex">
+  <div 
+    class="fixed inset-0 flex"
+    data-action="click->visibility#backdropClick">
     <div
       class="relative mr-16 flex w-full max-w-xs flex-1 hidden"
       data-visibility-target="content"

--- a/app/components/overlays/drawer_component.html.erb
+++ b/app/components/overlays/drawer_component.html.erb
@@ -20,9 +20,10 @@
     data-transition-leave-end="opacity-0">
   </div>
 
-  <div 
+  <div
     class="fixed inset-0 flex"
     data-action="click->visibility#backdropClick">
+
     <div
       class="relative mr-16 flex w-full max-w-xs flex-1 hidden"
       data-visibility-target="content"

--- a/app/components/overlays/drawer_component.html.erb
+++ b/app/components/overlays/drawer_component.html.erb
@@ -20,12 +20,9 @@
     data-transition-leave-end="opacity-0">
   </div>
 
-  <div
-    class="fixed inset-0 flex"
-    data-action="click->visibility#backdropClick">
-
+  <div class="fixed inset-0 flex pointer-events-none">
     <div
-      class="relative mr-16 flex w-full max-w-xs flex-1 hidden"
+      class="relative mr-16 flex w-full max-w-xs flex-1 hidden pointer-events-auto"
       data-visibility-target="content"
       data-transition-enter="transition ease-in-out duration-200 transform"
       data-transition-enter-start="-translate-x-full"

--- a/app/javascript/controllers/visibility_controller.js
+++ b/app/javascript/controllers/visibility_controller.js
@@ -15,12 +15,6 @@ export default class VisibilityController extends Controller {
     useClickOutside(this)
   }
 
-  backdropClick (event) {
-    if (event.target === event.currentTarget) {
-      this.off()
-    }
-  }
-
   disconnect () {
     this.contentTargets.forEach((element) => element.classList.toggle('hidden', true))
     this.off()

--- a/app/javascript/controllers/visibility_controller.js
+++ b/app/javascript/controllers/visibility_controller.js
@@ -15,9 +15,9 @@ export default class VisibilityController extends Controller {
     useClickOutside(this)
   }
 
-  backdropClick(event) {
+  backdropClick (event) {
     if (event.target === event.currentTarget) {
-        this.off()
+      this.off()
     }
   }
 

--- a/app/javascript/controllers/visibility_controller.js
+++ b/app/javascript/controllers/visibility_controller.js
@@ -15,6 +15,12 @@ export default class VisibilityController extends Controller {
     useClickOutside(this)
   }
 
+  backdropClick(event) {
+    if (event.target === event.currentTarget) {
+        this.off()
+    }
+  }
+
   disconnect () {
     this.contentTargets.forEach((element) => element.classList.toggle('hidden', true))
     this.off()


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Course contents sidebar now closes on outside clicks on smaller screens.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Set pointer events to none on line 23 `class="fixed inset-0 flex pointer-events-none"`
- Set pointer events to auto on line 28 `class="relative mr-16 flex w-full max-w-xs flex-1 hidden pointer-events-auto"`

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #5370 

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
