### PR TITLE
Fix: Unify margin between list items and paragraphs in lessons

### DIFF
--- a/app/assets/stylesheets/custom_styles/lesson-content.css
+++ b/app/assets/stylesheets/custom_styles/lesson-content.css
@@ -52,6 +52,10 @@
   & :is(h3, h4)[id] {
     scroll-margin-top: 40px;
   }
+
+  & li > p {
+    @apply my-2;
+  }
 }
 
 @utility toc-item-active {


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Currently, some markdown for lists results in Kramdown adding `p` tags inside the `li`s, such as the following:

```md
1. no blank line after, no p tag, just li
1. will have a p tag inside the li

   will have a new p tag, also inside the li
```
or
```md
1. blank line after, has p tag inside li

1. also has p tag inside own li

1. also has p tag inside own li
```

The `p` tag makes sense but has more block margin than `li`s alone, so you end up with inconsistent spacing between list items sometimes, such as in the [Working With APIs assignment](https://www.theodinproject.com/lessons/node-path-javascript-working-with-apis#assignment). Note the smaller spacing between items 1 and 2, compared to the larger spacing between items 2 and 3, and between item 3's paragraphs.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->

- Reduces block margin for paragraphs within list items in lessons to match plain list items

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
N/A

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
