### PR TITLE
Fix: Change Lesson Buttons Grid Breakpoint

### DIFF
--- a/app/views/lessons/_lesson_buttons.html.erb
+++ b/app/views/lessons/_lesson_buttons.html.erb
@@ -1,9 +1,9 @@
-<div class="flex flex-col gap-y-6 max-w-sm mx-auto 2xl:grid 2xl:grid-cols-3 2xl:gap-x-7 2xl:gap-y-0 2xl:max-w-full items-center">
+<div class="flex flex-col gap-y-6 max-w-sm mx-auto md:grid md:grid-cols-[1fr_auto_1fr] md:gap-x-7 md:gap-y-0 md:max-w-full md:items-center">
   <% if course.previous_lesson(lesson).present? %>
     <div class="contents md:block md:justify-self-start">
-      <%= link_to lesson_path(course.previous_lesson(lesson)), class: 'button button--secondary px-4 py-2 min-w-45 font-medium', data: { test_id: 'previous-lesson-btn' } do %>
+      <%= link_to lesson_path(course.previous_lesson(lesson)), class: 'button button--secondary px-4 py-2 font-medium', data: { test_id: 'previous-lesson-btn' } do %>
         <%= inline_svg_tag 'icons/arrow-left-circle.svg', class: 'h-8 w-8 pr-2', aria: true, title: 'Previous lesson', desc: 'Go to previous lesson' %>
-        Previous Lesson
+        Previous
       <% end %>
     </div>
   <% else %>
@@ -25,8 +25,8 @@
 
   <% if course.next_lesson(lesson).present? %>
     <div class="contents md:block md:justify-self-end">
-      <%= link_to lesson_path(course.next_lesson(lesson)), class: 'button button--secondary px-4 py-2 min-w-45 font-medium', data: { test_id: 'next-lesson-btn' } do %>
-        Next Lesson
+      <%= link_to lesson_path(course.next_lesson(lesson)), class: 'button button--secondary px-4 py-2 font-medium', data: { test_id: 'next-lesson-btn' } do %>
+        Next
         <%= inline_svg_tag 'icons/arrow-right-circle.svg', class: 'h-8 w-8 pl-2', aria: true, title: 'Next lesson', desc: 'Go to next lesson' %>
       <% end %>
     </div>

--- a/app/views/lessons/_lesson_buttons.html.erb
+++ b/app/views/lessons/_lesson_buttons.html.erb
@@ -1,4 +1,4 @@
-<div class="flex flex-col gap-y-6 max-w-sm mx-auto md:grid md:grid-cols-3 md:gap-x-7 md:gap-y-0 md:max-w-full md:items-center">
+<div class="flex flex-col gap-y-6 max-w-sm mx-auto 2xl:grid 2xl:grid-cols-3 2xl:gap-x-7 2xl:gap-y-0 2xl:max-w-full items-center">
   <% if course.previous_lesson(lesson).present? %>
     <div class="contents md:block md:justify-self-start">
       <%= link_to lesson_path(course.previous_lesson(lesson)), class: 'button button--secondary px-4 py-2 min-w-45 font-medium', data: { test_id: 'previous-lesson-btn' } do %>


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
-  Buttons at the end of lesson are overlapping on each other at around 1280px-1380px. This was actually due to breakpoints for the button's `<div>` being set too small which causes some overlap. The most straight-forward fix here would be to use tailwind's default breakpoint `2xl` to maintain the button's flex at higher screen widths

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
-  Changes the button's <div> breakpoint from md (48rem = 768px) to 2xl (96rem = 1536px)

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #5384 

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [ ] If applicable, this PR includes new or updated automated tests
