### PR TITLE
Chore: use dry-initializer for component parameters

### DIFF
--- a/app/components/application_component.rb
+++ b/app/components/application_component.rb
@@ -1,4 +1,6 @@
 class ApplicationComponent < ViewComponent::Base
+  extend Dry::Initializer
+
   include Turbo::FramesHelper
 
   delegate :inline_svg_tag, :inline_svg, to: :helpers

--- a/app/components/new_tab_text_link_component.rb
+++ b/app/components/new_tab_text_link_component.rb
@@ -1,13 +1,7 @@
 class NewTabTextLinkComponent < ApplicationComponent
-  def initialize(text:, href:, classes:, data: nil, noreferrer: true)
-    @text = text
-    @href = href
-    @classes = classes
-    @data = data
-    @noreferrer = noreferrer
-  end
-
-  private
-
-  attr_reader :text, :href, :classes, :data, :noreferrer
+  option :text, reader: :private
+  option :href, reader: :private
+  option :classes, reader: :private
+  option :data, default: -> {}, reader: :private
+  option :noreferrer, default: -> { true }, reader: :private
 end

--- a/app/components/overlays/drawer_component.rb
+++ b/app/components/overlays/drawer_component.rb
@@ -1,20 +1,18 @@
 class Overlays::DrawerComponent < ApplicationComponent
   BREAKPOINT_CLASSES = { lg: 'lg:hidden', xl: 'xl:hidden' }.freeze
 
-  def initialize(hook_class:, aria_label:, breakpoint: :lg, close_label: 'Close sidebar')
-    unless BREAKPOINT_CLASSES.key?(breakpoint)
-      raise ArgumentError, "Unsupported breakpoint: #{breakpoint.inspect}. Must be one of #{BREAKPOINT_CLASSES.keys}"
+  option :hook_class, reader: :private
+  option :aria_label, reader: :private
+  option :close_label, default: -> { 'Close sidebar' }, reader: :private
+  option :breakpoint, reader: :private, default: -> { :lg }, type: lambda { |value|
+    unless BREAKPOINT_CLASSES.key?(value)
+      raise ArgumentError, "Unsupported breakpoint: #{value.inspect}. Must be one of #{BREAKPOINT_CLASSES.keys}"
     end
 
-    @hook_class = hook_class
-    @breakpoint = breakpoint
-    @close_label = close_label
-    @aria_label = aria_label
-  end
+    value
+  }
 
   private
-
-  attr_reader :hook_class, :breakpoint, :close_label, :aria_label
 
   def breakpoint_class
     BREAKPOINT_CLASSES.fetch(breakpoint)

--- a/spec/components/overlays/drawer_component_spec.rb
+++ b/spec/components/overlays/drawer_component_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Overlays::DrawerComponent, type: :component do
 
   it 'requires aria_label' do
     expect { described_class.new(hook_class: 'off-canvas-menu') }
-      .to raise_error(ArgumentError, /aria_label/)
+      .to raise_error(KeyError, /aria_label/)
   end
 
   it 'defaults to lg breakpoint' do


### PR DESCRIPTION
Because:
Each component repeats every parameter three times: once in the keyword arguments, once in the instance variable assignments, and once in the attr_reader list. As a component gains parameters the initializer grows into a long block of boilerplate that is easy to get out of sync and hard to read at a glance.

dry-initializer lets us declare each parameter once, in a declarative list of `option` calls that states the name, default, and any type coercion in a single place. This keeps the focus on what each parameter is rather than the mechanics of assigning it, and stops initializers from collecting too many parameters and growing unwieldy. It also gives us a single pattern to follow as we convert the rest of the components.

This PR:
- Adds `extend Dry::Initializer` to ApplicationComponent so every component inherits the `option` DSL
- Converts NewTabTextLinkComponent to declarative options as a simple reference example
- Converts Overlays::DrawerComponent and moves its breakpoint validation into a `type:` coercer
- Updates the drawer spec to expect KeyError, which is what dry-initializer raises for a missing required option, instead of ArgumentError
