### PR TITLE
Chore: Remove unused postcss dependency and dead config

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "lint": "standard",
     "stylelint": "stylelint 'app/assets/stylesheets'",
     "build": "node esbuild.config.mjs",
-    "build:css": "npx @tailwindcss/cli -i ./app/assets/stylesheets/application.tailwind.css -o ./app/assets/builds/application.css --postcss"
+    "build:css": "npx @tailwindcss/cli -i ./app/assets/stylesheets/application.tailwind.css -o ./app/assets/builds/application.css"
   },
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2",
@@ -27,7 +27,6 @@
     "esbuild-rails": "^1.0.7",
     "flatpickr": "^4.6.13",
     "mermaid": "^11.15.0",
-    "postcss": "^8.5.15",
     "prismjs": "^1.30.0",
     "sortablejs": "^1.15.7",
     "stimulus-use": "^0.52.3",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,0 @@
-module.exports = {
-  plugins: [
-    require('tailwindcss/nesting'),
-    require('@tailwindcss/postcss')
-  ]
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5969,7 +5969,6 @@ __metadata:
     esbuild-rails: "npm:^1.0.7"
     flatpickr: "npm:^4.6.13"
     mermaid: "npm:^11.15.0"
-    postcss: "npm:^8.5.15"
     prismjs: "npm:^1.30.0"
     sortablejs: "npm:^1.15.7"
     standard: "npm:^17.1.2"


### PR DESCRIPTION
The postcss.config.js file referenced @tailwindcss/postcss, which isn't even installed, and the Tailwind v4 CLI never actually loaded it — the CSS build produces identical output without it. This removes the dead config file, drops the now-unused --postcss flag from the build:css script, and removes the direct postcss dependency (it stays available transitively through stylelint and tailwindcss).
