### PR TITLE
Fix: even out horizontal spacing around Mark Complete button

### DIFF
--- a/app/components/complete/button_component.html.erb
+++ b/app/components/complete/button_component.html.erb
@@ -1,7 +1,7 @@
 
 <div id="complete-button" class="flex items-center justify-center">
   <% if lesson.completed? %>
-    <%= button_to lesson_completion_path(lesson.id), form_class: 'w-full h-full group', method: :delete, data: { test_id: 'complete-button' }, class: 'button button--primary relative h-[54px] sm:h-full w-full md:w-60' do %>
+    <%= button_to lesson_completion_path(lesson.id), form_class: 'w-full h-full group', method: :delete, data: { test_id: 'complete-button' }, class: 'button button--primary relative h-[54px] sm:h-full w-full' do %>
       <span class="flex items-center group-aria-busy:opacity-0 transition-opacity delay-100">
         <%= inline_svg_tag 'icons/checkmark-circle-solid.svg', class: "h-6 pr-2 #{'pulse-once' if animate}", aria: true, title: 'check', desc: 'checkmark icon' %>
         <span>Lesson Completed</span>
@@ -12,7 +12,7 @@
       </div>
     <% end %>
   <% else %>
-    <%= button_to lesson_completion_path(lesson.id), form_class: 'w-full h-full group', data: { test_id: 'complete-button'}, class: 'button button--primary relative h-[54px] sm:h-full w-full md:w-60' do %>
+    <%= button_to lesson_completion_path(lesson.id), form_class: 'w-full h-full group', data: { test_id: 'complete-button'}, class: 'button button--primary relative h-[54px] sm:h-full w-full' do %>
       <span class="group-aria-busy:opacity-0 transition-opacity delay-100"> Mark Complete </span>
 
       <div class="group-aria-busy:opacity-100 opacity-0 absolute inset-0 flex items-center justify-center transition-opacity delay-100">


### PR DESCRIPTION
Fixes #5411 

## Because
The horizontal spacing around the "Mark Complete" button was uneven. 
The gap between the "Next" button and "Mark Complete" appeared larger 
than the gap between "Mark Complete" and "Previous". This is because 
the Mark Complete button had a fixed width of `md:w-60` (240px) while 
sitting in a 3-column grid `[1fr_auto_1fr]`, causing it to appear 
visually off-center.


## This PR
- Removes `md:w-60` from both states of the Mark Complete button 
  (completed and not-completed) in `button_component.html.erb`, 
  allowing it to size naturally like the Previous and Next buttons.


## Issue
Closes #5411

## Additional Information
I was unable to test this locally as I don't have a Ruby on Rails 
environment set up. I'd appreciate if a maintainer could verify 
the visual fix. Happy to make any adjustments based on feedback!


## Pull Request Requirements
- [x] I have thoroughly read and understand The Odin Project Contributing Guide
- [x] The title of this PR follows the `keyword: brief description of change` format
- [x] The `Because` section summarizes the reason for this PR
- [x] The `This PR` section has a bullet point list describing the changes in this PR
- [ ] I have verified all tests and linters pass after making these changes.
- [x] If this PR addresses an open issue, it is linked in the `Issue` section
- [ ] If applicable, this PR includes new or updated automated tests