### PR TITLE
Complete button: Reduce duplication in template

### DIFF
--- a/app/components/complete/button_component.html.erb
+++ b/app/components/complete/button_component.html.erb
@@ -1,23 +1,22 @@
-
 <div id="complete-button" class="flex items-center justify-center">
-  <% if lesson.completed? %>
-    <%= button_to lesson_completion_path(lesson.id), form_class: 'w-full h-full group', method: :delete, data: { test_id: 'complete-button' }, class: 'button button--primary relative h-[54px] sm:h-full w-full md:w-60' do %>
+  <%= button_to(
+        lesson_completion_path(lesson.id),
+        form_class: 'w-full h-full group',
+        method: (:delete if lesson.completed?),
+        data: { test_id: 'complete-button' },
+        class: 'button button--primary relative h-[54px] sm:h-full w-full md:w-60',
+      ) do %>
+    <% if lesson.completed? %>
       <span class="flex items-center group-aria-busy:opacity-0 transition-opacity delay-100">
         <%= inline_svg_tag 'icons/checkmark-circle-solid.svg', class: "h-6 pr-2 #{'pulse-once' if animate}", aria: true, title: 'check', desc: 'checkmark icon' %>
         <span>Lesson Completed</span>
       </span>
-
-      <div class="group-aria-busy:opacity-100 opacity-0 absolute inset-0 flex items-center justify-center transition-opacity delay-100">
-         <%= inline_svg_tag 'icons/spinner.svg', class: 'h-6 w-6 animate-spin text-white', aria: true %>
-      </div>
+    <% else %>
+      <span class="group-aria-busy:opacity-0 transition-opacity delay-100">Mark Complete</span>
     <% end %>
-  <% else %>
-    <%= button_to lesson_completion_path(lesson.id), form_class: 'w-full h-full group', data: { test_id: 'complete-button'}, class: 'button button--primary relative h-[54px] sm:h-full w-full md:w-60' do %>
-      <span class="group-aria-busy:opacity-0 transition-opacity delay-100"> Mark Complete </span>
 
-      <div class="group-aria-busy:opacity-100 opacity-0 absolute inset-0 flex items-center justify-center transition-opacity delay-100">
-         <%= inline_svg_tag 'icons/spinner.svg', class: 'h-6 w-6 animate-spin text-white', aria: true %>
-      </div>
-    <% end %>
+    <div class="group-aria-busy:opacity-100 opacity-0 absolute inset-0 flex items-center justify-center transition-opacity delay-100">
+       <%= inline_svg_tag 'icons/spinner.svg', class: 'h-6 w-6 animate-spin text-white', aria: true %>
+    </div>
   <% end %>
 </div>


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
The only conditional bits were the form method and SVG span. No need to duplicate so much markup, especially with Tailwind

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Reduces duplication in complete button component template

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
N/A

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
