### PR TITLE
Feature: Use subnumbering for nested ordered list markers

### DIFF
--- a/app/assets/stylesheets/custom_styles/lesson-content.css
+++ b/app/assets/stylesheets/custom_styles/lesson-content.css
@@ -56,6 +56,19 @@
   & li > p {
     @apply my-2;
   }
+
+  /* For automatic subnumbering e.g. 1.1, 2.1.2 */
+  & ol {
+    counter-reset: item;
+  }
+
+  & ol > li {
+    counter-increment: item;
+  }
+
+  & ol > li::marker {
+    content: counters(item, ".") ".";
+  }
 }
 
 @utility toc-item-active {


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
Was a great idea brought up by someone on Discord. Currently, we just have nested ordered lists have the usual numbers, which is mostly fine, but it helps to recognise when a numbered step is a subitem like step 4.5 rather than just step 5, especially when sharing cropped screenshots.
A recent example was someone sharing this:
<img width="595" height="537" alt="image" src="https://github.com/user-attachments/assets/1f69d401-fc29-4182-8999-9fa0fc2b86f8" />

Which at a glance looks like that's the full context, but it's actually a substep (4.4, 4.5, 4.6) which provides additional context. It's not immediately clear though, and a screenshot would have to be huge to be able to provide the parent step. If the substep was marked as 4.5, it'll be immediately clear that there may be missing context in the parent step 4.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Adds subnumber counters for ordered list items

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
N/A


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
