### PR TITLE
Fix: section not opening while sidebar is open

### DIFF
--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -12,7 +12,6 @@
     <%= turbo_frame_tag(
           'lesson-sidebar-frame',
           src: lesson_course_contents_path(@lesson),
-          loading: :lazy,
           target: '_top',
           data: { turbo_permanent: true },
           class: 'block xl:w-80 xl:shrink-0 border-gray-200 dark:border-gray-800 xl:border-r group-[.sidebar-collapsed]/sidebar-layout:xl:hidden'

--- a/spec/requests/lessons_spec.rb
+++ b/spec/requests/lessons_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe 'Lessons' do
+  describe 'GET #show' do
+    let(:course) { create(:course, path: create(:path, default_path: true)) }
+    let(:section) { create(:section, course:) }
+    let(:lesson) { create(:lesson, section:) }
+
+    it 'loads the course-contents sidebar frame eagerly instead of deferring it until it is opened' do
+      get lesson_path(lesson)
+
+      expect(response).to have_http_status(:success)
+
+      frame_tag = response.body[/<turbo-frame[^>]*id="lesson-sidebar-frame"[^>]*>/]
+      expect(frame_tag).not_to be_nil
+      expect(frame_tag).not_to include('loading="lazy"')
+    end
+  end
+end


### PR DESCRIPTION
## Because

The mobile course-contents drawer's `turbo-frame` (`app/views/lessons/show.html.erb`) used `loading: :lazy`. Since the drawer starts off-screen/hidden on mobile, the frame's content only ever became "visible" to the lazy-loading `IntersectionObserver` the first time a user tapped the toggle button to open it. That fetch replaced the frame's DOM (including the `visibility` Stimulus controller that tracks the drawer's open/closed state) in the middle of the user's open interaction, silently resetting it and leaving taps on a section link landing on stale/shifted elements instead of the intended one.

## This PR

- Removes `loading: :lazy` from the `lesson-sidebar-frame` turbo-frame so its content loads eagerly on page load instead of being deferred until the drawer is first opened, eliminating the DOM-replacement race.
- Adds a request spec (`spec/requests/lessons_spec.rb`) asserting the sidebar frame is rendered without `loading="lazy"`.

## Issue

Closes #5430

## Additional Information

Verified locally at mobile viewport: before the fix, opening the course-contents drawer for the first time triggered a `GET .../course_contents` request exactly on toggle, and the drawer's Stimulus `visibleValue` was reset back to `false` right after being set to `true`. After the fix, that request fires immediately on page load and toggling the drawer no longer triggers any additional fetch.

## Pull Request Requirements

- [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
- [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
- [x] The `Because` section summarizes the reason for this PR
- [x] The `This PR` section has a bullet point list describing the changes in this PR
- [x] I have verified all tests and linters pass after making these changes.
- [x] If this PR addresses an open issue, it is linked in the `Issue` section
- [x] If applicable, this PR includes new or updated automated tests