### PR TITLE
fix: Add "Skip to main content" link

### DIFF
--- a/app/assets/stylesheets/custom_styles/layout.css
+++ b/app/assets/stylesheets/custom_styles/layout.css
@@ -39,3 +39,14 @@ html:has([data-controller~="lessons--sidebar-toggle"]) {
     background-color: var(--color-gray-700);
   }
 }
+
+.skip-link {
+  position: absolute;
+  top: -100px;
+  left: 0;
+  z-index: 9999;
+}
+
+.skip-link:focus {
+  top: 0;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,13 +29,24 @@
 
   <body data-controller="dialog-router" class="h-full bg-gray-50 text-gray-600 dark:bg-gray-900 dark:text-gray-300">
     <%= render AnnouncementComponent.new(announcement: Announcement.showable_messages(disabled_announcement_ids).first) %>
-    <%= render 'shared/navbar' %>
+    
+    <header>
+      <a href="#main-content" class="skip-link">
+        Skip to main content
+      </a>
+
+      <%= render 'shared/navbar' %>
+    </header>
+
     <div id="flash-messages">
       <%= render 'shared/flash', flash: flash if flash.any? %>
     </div>
 
     <%= turbo_frame_tag 'modal' %>
-    <%= yield %>
+
+    <main id="main-content">
+      <%= yield %>
+    </main>
 
     <%= render 'shared/footer' %>
   </body>


### PR DESCRIPTION

## 5199

## Changes

- Added a "Skip to main content" link.
- Wrapped the navigation in a header landmark.
- Wrapped the page content in a main landmark with id="main-content".
- Added styling to show the skip link when focused.

##Purpose
This improves keyboard accessibility by allowing keyboard and screen reader users to skip the navigation and move directly to the main page content.