### PR TITLE
Fix: Give note boxes independent list hierarchies

### DIFF
--- a/app/assets/stylesheets/custom_styles/lesson-content.css
+++ b/app/assets/stylesheets/custom_styles/lesson-content.css
@@ -59,15 +59,22 @@
 
   /* For automatic subnumbering e.g. 1.1, 2.1.2 */
   & ol {
-    counter-reset: item;
+    --counter: item;
+
+    counter-reset: var(--counter);
+  }
+
+  /* Note boxes should have their own list hierarchies */
+  & .lesson-note ol {
+    --counter: item-in-note-box;
   }
 
   & ol > li {
-    counter-increment: item;
+    counter-increment: var(--counter);
   }
 
   & ol > li::marker {
-    content: counters(item, ".") ".";
+    content: counters(var(--counter), ".") ".";
   }
 }
 


### PR DESCRIPTION

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
#5427 gave us automatic subnumbering for nested ordered list markers. However, it missed that a list item may contain a note box, and that note box may contain its own ordered list. And example is in the [JS Testing Basics lesson](
https://www.theodinproject.com/lessons/node-path-javascript-testing-basics#using-es6-import-statements-with-jest
).

Such lists would not be associated with the "parent list" and so should not be subnumbered as it they were. They should have independent hierarchies. So the linked example should have markers `1.` and `2.` for the note box list, as opposed to `3.1.` and `3.2.`.


## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Gives note boxes their own counter to override the base one

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
N/A


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `keyword: brief description of change` format, using one of the following keywords:
    - `Feature` - adds new or amends existing user-facing behavior
    - `Chore` - changes that have no user-facing value, refactors, dependency bumps, etc
    - `Fix` - bug fixes
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] I have verified all tests and linters pass after making these changes.
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, this PR includes new or updated automated tests
