### PR TITLE
Chore: Dedupe prismjs (resolve to 1.30.0)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -5731,14 +5731,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prismjs@npm:^1.29.0":
-  version: 1.29.0
-  resolution: "prismjs@npm:1.29.0"
-  checksum: 10c0/d906c4c4d01b446db549b4f57f72d5d7e6ccaca04ecc670fb85cea4d4b1acc1283e945a9cbc3d81819084a699b382f970e02f9d1378e14af9808d366d9ed7ec6
-  languageName: node
-  linkType: hard
-
-"prismjs@npm:^1.30.0":
+"prismjs@npm:^1.29.0, prismjs@npm:^1.30.0":
   version: 1.30.0
   resolution: "prismjs@npm:1.30.0"
   checksum: 10c0/f56205bfd58ef71ccfcbcb691fd0eb84adc96c6ff21b0b69fc6fdcf02be42d6ef972ba4aed60466310de3d67733f6a746f89f2fb79c00bf217406d465b3e8f23


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->

Fixes https://github.com/TheOdinProject/theodinproject/security/dependabot/167
We were already using prismjs@1.30.0 but for some reason, `esbuild-plugin-prismjs` was stubbornly clinging to `1.29.0` despite resolving `^1.29.0`. Because of that, #5461 failed CI due to making a `yarn.lock` change that'd trigger Yarn's immutable+hardened mode.

Fix is to run `yarn dedupe prismjs` to remove 1.29.0 and make `esbuild-plugin-prismjs` use 1.30.0.
Local CI passes (only addition in 1.30.0 is a check that's part of the linked CVE).

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Dedupes prismjs to only use v1.30.0

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
N/A
